### PR TITLE
Feat - Support 3rd party use case for subscriptions

### DIFF
--- a/src/api/auth.js
+++ b/src/api/auth.js
@@ -9,12 +9,23 @@ import { HEADERS } from '../constants';
 
 import { callGraphQL } from './api';
 
-export function createAccessToken (clientID : string) : ZalgoPromise<string> {
+type GenerateAccessTokenOptions = {|
+    targetSubject? : string
+|};
+
+export function createAccessToken(clientID : ?string, { targetSubject } : GenerateAccessTokenOptions = {}) : ZalgoPromise<string> {
     return inlineMemoize(createAccessToken, () => {
 
         getLogger().info(`rest_api_create_access_token`);
 
-        const basicAuth = base64encode(`${ clientID }:`);
+        const basicAuth = base64encode(`${ clientID || '' }:`);
+        const data : Object = {
+            grant_type: `client_credentials`
+        };
+
+        if (targetSubject) {
+            data.target_subject = targetSubject;
+        }
 
         return request({
 
@@ -23,14 +34,12 @@ export function createAccessToken (clientID : string) : ZalgoPromise<string> {
             headers: {
                 Authorization: `Basic ${ basicAuth }`
             },
-            data: {
-                grant_type: `client_credentials`
-            }
+            data
 
         }).then(({ body }) => {
 
             if (body && body.error === 'invalid_client') {
-                throw new Error(`Auth Api invalid client id: ${ clientID }:\n\n${ JSON.stringify(body, null, 4) }`);
+                throw new Error(`Auth Api invalid client id: ${ clientID || '' }:\n\n${ JSON.stringify(body, null, 4) }`);
             }
 
             if (!body || !body.access_token) {
@@ -39,7 +48,7 @@ export function createAccessToken (clientID : string) : ZalgoPromise<string> {
 
             return body.access_token;
         });
-    }, [ clientID ]);
+    }, [ clientID, targetSubject ]);
 }
 
 export function getFirebaseSessionToken(sessionUID : string) : ZalgoPromise<string> {

--- a/src/api/subscription.js
+++ b/src/api/subscription.js
@@ -7,6 +7,7 @@ import { CREATE_SUBSCRIPTIONS_API_URL, SMART_API_URI } from '../config';
 import { getLogger } from '../lib';
 
 import { callSmartAPI } from './api';
+import { createAccessToken } from './auth';
 
 export type SubscriptionCreateRequest = {|
     plan_id : string,
@@ -27,24 +28,18 @@ export type SubscriptionCreateRequest = {|
 
 export type SubscriptionResponse = {||};
 
-type SubsriptionOptions = {|
-    partnerAttributionID : ?string
+type SubscriptionOptions = {|
+    clientID : ?string,
+    merchantID? : $ReadOnlyArray<string>,
+    partnerAttributionID? : string
 |};
 
-export function createSubscription(accessToken : string, subscriptionPayload : SubscriptionCreateRequest, { partnerAttributionID } : SubsriptionOptions) : ZalgoPromise<string> {
-    getLogger().info(`rest_api_create_subscription_id`);
 
-    if (!accessToken) {
-        throw new Error(`Access token not passed`);
-    }
-
-    if (!subscriptionPayload) {
-        throw new Error(`Expected subscription payload to be passed`);
-    }
-
+// Create Subscription Request method
+function createRequest(accessToken : string, subscriptionPayload : SubscriptionCreateRequest, partnerAttributionID? : string) : ZalgoPromise<string> {
     const headers : Object = {
         'Authorization':                 `Bearer ${ accessToken }`,
-        'PayPal-Partner-Attribution-Id': partnerAttributionID
+        'PayPal-Partner-Attribution-Id': partnerAttributionID || ''
     };
 
     return request({
@@ -61,24 +56,31 @@ export function createSubscription(accessToken : string, subscriptionPayload : S
     });
 }
 
-export function reviseSubscription(accessToken : string, subscriptionID : string, subscriptionPayload : ?SubscriptionCreateRequest, { partnerAttributionID } : SubsriptionOptions) : ZalgoPromise<string> {
+export function createSubscription(accessToken : string, subscriptionPayload : SubscriptionCreateRequest, { partnerAttributionID, merchantID, clientID } : SubscriptionOptions) : ZalgoPromise<string> {
     getLogger().info(`rest_api_create_subscription_id`);
-
-    if (!accessToken) {
-        throw new Error(`Access token not passed`);
-    }
-
-    if (!subscriptionID) {
-        throw new Error(`Expected subscription id to be passed as first argument to revise subscription api`);
-    }
 
     if (!subscriptionPayload) {
         throw new Error(`Expected subscription payload to be passed`);
     }
 
+    if (merchantID && merchantID[0]) {
+        getLogger().info(`rest_api_subscriptions_recreate_access_token`);
+        return createAccessToken(clientID, { targetSubject: merchantID[0] }).then((thirdPartyAccessToken) : ZalgoPromise<string> => {
+            return createRequest(thirdPartyAccessToken, subscriptionPayload, partnerAttributionID);
+        });
+    }
+
+    if (!accessToken) {
+        throw new Error(`Access token not passed`);
+    }
+    return createRequest(accessToken, subscriptionPayload, partnerAttributionID);
+}
+
+// Revise Subscription API request
+function reviseRequest(accessToken : string, subscriptionID : string, subscriptionPayload : ?SubscriptionCreateRequest, partnerAttributionID? : string) : ZalgoPromise<string> {
     const headers : Object = {
         'Authorization':                 `Bearer ${ accessToken }`,
-        'PayPal-Partner-Attribution-Id': partnerAttributionID
+        'PayPal-Partner-Attribution-Id': partnerAttributionID || ''
     };
 
     return request({
@@ -94,6 +96,30 @@ export function reviseSubscription(accessToken : string, subscriptionID : string
         // for revision flow the same subscription id is returned
         return subscriptionID;
     });
+}
+
+export function reviseSubscription(accessToken : string, subscriptionID : string, subscriptionPayload : ?SubscriptionCreateRequest, { partnerAttributionID, merchantID, clientID } : SubscriptionOptions) : ZalgoPromise<string> {
+    getLogger().info(`rest_api_create_subscription_id`);
+
+    if (!subscriptionID) {
+        throw new Error(`Expected subscription id to be passed as first argument to revise subscription api`);
+    }
+
+    if (!subscriptionPayload) {
+        throw new Error(`Expected subscription payload to be passed`);
+    }
+
+    if (merchantID && merchantID[0]) {
+        getLogger().info(`rest_api_subscriptions_recreate_access_token`);
+        return createAccessToken(clientID, { targetSubject: merchantID[0] }).then((thirdPartyAccessToken) : ZalgoPromise<string> => {
+            return reviseRequest(thirdPartyAccessToken, subscriptionID, subscriptionPayload, partnerAttributionID);
+        });
+    }
+
+    if (!accessToken) {
+        throw new Error(`Access token not passed`);
+    }
+    return reviseRequest(accessToken, subscriptionID, subscriptionPayload, partnerAttributionID);
 }
 
 type SubscriptionAPICredentials = {|

--- a/src/button/props.js
+++ b/src/button/props.js
@@ -200,7 +200,7 @@ export function getProps({ facilitatorAccessToken } : {| facilitatorAccessToken 
     }
 
     const createBillingAgreement = getCreateBillingAgreement({ createBillingAgreement: xprops.createBillingAgreement });
-    const createSubscription = getCreateSubscription({ createSubscription: xprops.createSubscription, partnerAttributionID }, { facilitatorAccessToken });
+    const createSubscription = getCreateSubscription({ createSubscription: xprops.createSubscription, partnerAttributionID, merchantID, clientID }, { facilitatorAccessToken });
     
     const createOrder = getCreateOrder({ createOrder: xprops.createOrder, currency, intent, merchantID, partnerAttributionID }, { facilitatorAccessToken, createBillingAgreement, createSubscription });
 

--- a/src/props/createSubscription.js
+++ b/src/props/createSubscription.js
@@ -2,7 +2,8 @@
 
 import { type ZalgoPromise } from 'zalgo-promise/src';
 
-import { createSubscription as createSubcriptionID, reviseSubscription } from '../api';
+import { createAccessToken, createSubscription as createSubcriptionID, reviseSubscription } from '../api';
+import { getLogger } from '../lib';
 
 export type XCreateSubscriptionDataType = {||};
 
@@ -20,13 +21,13 @@ export function buildXCreateSubscriptionData() : XCreateSubscriptionDataType {
     return {};
 }
 
-export function buildXCreateSubscriptionActions({ facilitatorAccessToken, partnerAttributionID } : {| facilitatorAccessToken : string, partnerAttributionID : ?string |}) : XCreateSubscriptionActionsType {
+export function buildXCreateSubscriptionActions({ facilitatorAccessToken, partnerAttributionID, merchantID, clientID } : {| facilitatorAccessToken : string, partnerAttributionID? : string, merchantID? : $ReadOnlyArray<string>, clientID : ?string |}) : XCreateSubscriptionActionsType {
     const create = (data) => {
-        return createSubcriptionID(facilitatorAccessToken, data, { partnerAttributionID });
+        return createSubcriptionID(facilitatorAccessToken, data, { partnerAttributionID, merchantID, clientID });
     };
 
     const revise = (subscriptionID : string, data) => {
-        return reviseSubscription(facilitatorAccessToken, subscriptionID, data, { partnerAttributionID });
+        return reviseSubscription(facilitatorAccessToken, subscriptionID, data, { partnerAttributionID, merchantID, clientID });
     };
 
     return {
@@ -38,13 +39,20 @@ export type CreateSubscription = XCreateSubscription;
 
 type CreateSubscriptionXProps = {|
     createSubscription : ?XCreateSubscription,
-    partnerAttributionID : ?string
+    partnerAttributionID? : string,
+    merchantID? : $ReadOnlyArray<string>,
+    clientID : ?string
 |};
 
-export function getCreateSubscription({ createSubscription, partnerAttributionID } : CreateSubscriptionXProps, { facilitatorAccessToken } : {| facilitatorAccessToken : string |}) : ?CreateSubscription {
+export function getCreateSubscription({ createSubscription, partnerAttributionID, merchantID, clientID } : CreateSubscriptionXProps, { facilitatorAccessToken } : {| facilitatorAccessToken : string |}) : ?CreateSubscription {
     if (createSubscription) {
+        // Recreate the accessToken if merchantId is passed.
+        if (merchantID && merchantID[0]) {
+            getLogger().info(`src_props_subscriptions_recreate_access_token_cache`);
+            createAccessToken(clientID, { targetSubject: merchantID[0] });
+        }
         return () => {
-            return createSubscription(buildXCreateSubscriptionData(), buildXCreateSubscriptionActions({ facilitatorAccessToken, partnerAttributionID })).then(subscriptionID => {
+            return createSubscription(buildXCreateSubscriptionData(), buildXCreateSubscriptionActions({ facilitatorAccessToken, partnerAttributionID, merchantID, clientID })).then(subscriptionID => {
                 if (!subscriptionID || typeof subscriptionID !== 'string') {
                     throw new Error(`Expected an subscription id to be passed to createSubscription`);
                 }

--- a/test/client/happy.js
+++ b/test/client/happy.js
@@ -5,8 +5,19 @@ import { wrapPromise } from 'belter/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
 import { FUNDING } from '@paypal/sdk-constants/src';
 
-import { mockSetupButton, generateOrderID, mockAsyncProp, createButtonHTML,
-    DEFAULT_FUNDING_ELIGIBILITY, mockFunction, clickButton, enterButton, getMockWindowOpen } from './mocks';
+import {
+    clickButton,
+    createButtonHTML,
+    DEFAULT_FUNDING_ELIGIBILITY,
+    enterButton,
+    generateOrderID,
+    getCreateSubscriptionIdApiMock,
+    getReviseSubscriptionIdApiMock,
+    getMockWindowOpen,
+    mockAsyncProp,
+    mockFunction,
+    mockSetupButton
+} from './mocks';
 import { triggerKeyPress } from './util';
 
 describe('happy cases', () => {
@@ -246,6 +257,122 @@ describe('happy cases', () => {
             await mockSetupButton({ merchantID: [ 'XYZ12345' ], fundingEligibility: DEFAULT_FUNDING_ELIGIBILITY });
 
             await clickButton(FUNDING.PAYPAL);
+        });
+    });
+
+    it('should render a button with createSubscription with create call, click the button, and render checkout', async () => {
+        return await wrapPromise(async ({ expect, avoid }) => {
+            const cartID = 'CARTIDOFSUBSCRIPTIONS';
+            const subscriptionID = 'I-SUBSCRIPTIONID';
+            const payerID = 'YYYYYYYYYY';
+            const createSubscriptionIdApiMock = getCreateSubscriptionIdApiMock({}, subscriptionID);
+            createSubscriptionIdApiMock.expectCalls();
+
+            window.xprops.vault = true;
+            delete window.xprops.createOrder;
+            window.xprops.createSubscription = mockAsyncProp(expect('createSubscription', async (data, actions) => {
+                return actions.subscription.create({
+                    plan_id: 'P-ASDFGHJKL:'
+                });
+            }));
+
+            window.xprops.onCancel = avoid('onCancel');
+
+            window.xprops.onApprove = mockAsyncProp(expect('onApprove', async (data) => {
+                if (data.subscriptionID !== subscriptionID) {
+                    throw new Error(`Expected billingToken to be ${ subscriptionID }, got ${ data.subscriptionID }`);
+                }
+
+                if (data.payerID !== payerID) {
+                    throw new Error(`Expected payerID to be ${ payerID }, got ${ data.payerID }`);
+                }
+            }));
+
+            mockFunction(window.paypal, 'Checkout', expect('Checkout', ({ original: CheckoutOriginal, args: [ props ] }) => {
+
+                mockFunction(props, 'onApprove', expect('onApprove', ({ original: onApproveOriginal, args: [ data, actions ] }) => {
+                    return onApproveOriginal({ ...data, payerID, subscriptionID }, actions);
+                }));
+
+                const checkoutInstance = CheckoutOriginal(props);
+
+                mockFunction(checkoutInstance, 'renderTo', expect('renderTo', async ({ original: renderToOriginal, args }) => {
+                    return props.createOrder().then(id => {
+                        if (id !== cartID) {
+                            throw new Error(`Expected cartID to be ${ cartID }, got ${ id }`);
+                        }
+
+                        return renderToOriginal(...args);
+                    });
+                }));
+
+                return checkoutInstance;
+            }));
+
+            createButtonHTML();
+
+            await mockSetupButton({ merchantID: [ 'XYZ12345' ], fundingEligibility: DEFAULT_FUNDING_ELIGIBILITY });
+
+            await clickButton(FUNDING.PAYPAL);
+            createSubscriptionIdApiMock.done();
+        });
+    });
+
+    it('should render a button with createSubscription with revise call, click the button, and render checkout', async () => {
+        return await wrapPromise(async ({ expect, avoid }) => {
+            const cartID = 'CARTIDOFSUBSCRIPTIONS';
+            const subscriptionID = 'I-SUBSCRIPTIONID';
+            const payerID = 'YYYYYYYYYY';
+            const reviseSubscriptionIdApiMock = getReviseSubscriptionIdApiMock({}, subscriptionID);
+            reviseSubscriptionIdApiMock.expectCalls();
+
+            window.xprops.vault = true;
+            delete window.xprops.createOrder;
+            window.xprops.createSubscription = mockAsyncProp(expect('createSubscription', async (data, actions) => {
+                return actions.subscription.revise(subscriptionID, {
+                    plan_id: 'P-ASDFGHJKL:'
+                });
+            }));
+
+            window.xprops.onCancel = avoid('onCancel');
+
+            window.xprops.onApprove = mockAsyncProp(expect('onApprove', async (data) => {
+                if (data.subscriptionID !== subscriptionID) {
+                    throw new Error(`Expected billingToken to be ${ subscriptionID }, got ${ data.subscriptionID }`);
+                }
+
+                if (data.payerID !== payerID) {
+                    throw new Error(`Expected payerID to be ${ payerID }, got ${ data.payerID }`);
+                }
+            }));
+
+            mockFunction(window.paypal, 'Checkout', expect('Checkout', ({ original: CheckoutOriginal, args: [ props ] }) => {
+
+                mockFunction(props, 'onApprove', expect('onApprove', ({ original: onApproveOriginal, args: [ data, actions ] }) => {
+                    return onApproveOriginal({ ...data, payerID, subscriptionID }, actions);
+                }));
+
+                const checkoutInstance = CheckoutOriginal(props);
+
+                mockFunction(checkoutInstance, 'renderTo', expect('renderTo', async ({ original: renderToOriginal, args }) => {
+                    return props.createOrder().then(id => {
+                        if (id !== cartID) {
+                            throw new Error(`Expected cartID to be ${ cartID }, got ${ id }`);
+                        }
+
+                        return renderToOriginal(...args);
+                    });
+                }));
+
+                return checkoutInstance;
+            }));
+
+            createButtonHTML();
+
+            await mockSetupButton({ merchantID: [ 'XYZ12345' ], fundingEligibility: DEFAULT_FUNDING_ELIGIBILITY });
+
+            await clickButton(FUNDING.PAYPAL);
+            reviseSubscriptionIdApiMock.done();
         });
     });
 


### PR DESCRIPTION
Support 3rd party token for subscription

Recreate the access token with 3rd party credentials with target as merchantID if merchantID is passed.

Create the token on button render when createSubscription prop is passed to Button so that memoization can store the access token for use while clicking the button.

On Button Click call create Token method and let memoized value to be used if available.