### PR TITLE
Native instrumentation

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -101,6 +101,9 @@ export const FPTI_TRANSITION = {
     NATIVE_DETECT_WEB_SWITCH: ('native_detect_web_switch' : 'native_detect_web_switch'),
     NATIVE_APP_SWITCH_ACK:    ('native_app_switch_ack' : 'native_app_switch_ack'),
     NATIVE_ERROR:             ('native_app_switch_ack' : 'native_app_switch_ack'),
+    NATIVE_SET_PROPS_ATTEMPT: ('process_set_props_attempt' : 'process_set_props_attempt'),
+    NATIVE_ATTEMPT_APP_SWITCH:('app_switch_attempted' : 'app_switch_attempted'),
+    NATIVE_POPUP_CLOSED:      ('process_popup_closed' : 'process_popup_closed'),
 
     HONEY_IDENTIFY:           ('honey_identify')
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -97,13 +97,13 @@ export const FPTI_TRANSITION = {
 
     CONNECT_REDIRECT:         ('process_connect_redirect' : 'process_connect_redirect'),
 
-    NATIVE_DETECT_APP_SWITCH: ('native_detect_app_switch' : 'native_detect_app_switch'),
-    NATIVE_DETECT_WEB_SWITCH: ('native_detect_web_switch' : 'native_detect_web_switch'),
-    NATIVE_APP_SWITCH_ACK:    ('native_app_switch_ack' : 'native_app_switch_ack'),
-    NATIVE_ERROR:             ('native_app_switch_ack' : 'native_app_switch_ack'),
-    NATIVE_SET_PROPS_ATTEMPT: ('process_set_props_attempt' : 'process_set_props_attempt'),
-    NATIVE_ATTEMPT_APP_SWITCH:('app_switch_attempted' : 'app_switch_attempted'),
-    NATIVE_POPUP_CLOSED:      ('process_popup_closed' : 'process_popup_closed'),
+    NATIVE_DETECT_APP_SWITCH:  ('native_detect_app_switch' : 'native_detect_app_switch'),
+    NATIVE_DETECT_WEB_SWITCH:  ('native_detect_web_switch' : 'native_detect_web_switch'),
+    NATIVE_APP_SWITCH_ACK:     ('native_app_switch_ack' : 'native_app_switch_ack'),
+    NATIVE_ERROR:              ('native_app_switch_ack' : 'native_app_switch_ack'),
+    NATIVE_SET_PROPS_ATTEMPT:  ('process_set_props_attempt' : 'process_set_props_attempt'),
+    NATIVE_ATTEMPT_APP_SWITCH: ('app_switch_attempted' : 'app_switch_attempted'),
+    NATIVE_POPUP_CLOSED:       ('process_popup_closed' : 'process_popup_closed'),
 
     HONEY_IDENTIFY:           ('honey_identify')
 };

--- a/src/payment-flows/native.js
+++ b/src/payment-flows/native.js
@@ -107,7 +107,7 @@ function isNativeOptedIn({ props } : {| props : ButtonProps |}) : boolean {
 let initialPageUrl;
 
 function isNativeEligible({ props, config, serviceData } : IsEligibleOptions) : boolean {
-    
+
     const { platform, onShippingChange, createBillingAgreement, createSubscription, env } = props;
     const { firebase: firebaseConfig } = config;
     const { eligibility } = serviceData;
@@ -197,6 +197,21 @@ type NativeSDKProps = {|
     apiStageHost : ?string,
     forceEligible : boolean
 |};
+
+function instrumentNativeSDKProps(props : NativeSDKProps) {
+    if (props) {
+        const sanitizedProps = {
+            ...props,
+            facilitatorAccessToken : props && props.facilitatorAccessToken ? '********************' : ''
+        };
+
+        getLogger().info('native_setprops_request', sanitizedProps).track({
+            [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_SET_PROPS_ATTEMPT
+        });
+    } else {
+        getLogger().info('native_setprops_request_has_enpty_props');
+    }
+}
 
 function initNative({ props, components, config, payment, serviceData } : InitOptions) : PaymentFlowInstance {
     const { createOrder, onApprove, onCancel, onError, commit,
@@ -296,6 +311,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
         const setNativeProps = memoize(() => {
             return getSDKProps().then(sdkProps => {
                 getLogger().info(`native_message_setprops`).flush();
+                instrumentNativeSDKProps(sdkProps);
                 return socket.send(SOCKET_MESSAGE.SET_PROPS, sdkProps);
             }).then(() => {
                 getLogger().info(`native_response_setprops`).track({
@@ -343,7 +359,12 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
 
         const onApproveListener = socket.on(SOCKET_MESSAGE.ON_APPROVE, ({ data: { payerID, paymentID, billingToken } }) => {
             approved = true;
-            getLogger().info(`native_message_onapprove`).flush();
+            getLogger().info(`native_message_onapprove`)
+                .track({
+                    [FPTI_KEY.TRANSITION] : FPTI_TRANSITION.NATIVE_POPUP_CLOSED
+                })
+                .flush();
+
             const data = { payerID, paymentID, billingToken, forceRestAPI: true };
             const actions = { restart: () => fallbackToWebCheckout() };
             return ZalgoPromise.all([
@@ -376,7 +397,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
         clean.register(onErrorListener.cancel);
 
         socket.reconnect();
-        
+
         return {
             setProps: setNativeProps,
             close:    closeNative
@@ -417,7 +438,14 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
     });
 
     const initDirectAppSwitch = ({ sessionUID } : {| sessionUID : string |}) => {
-        const nativeWin = popup(getNativeUrl({ sessionUID }));
+        const nativeUrl = getNativeUrl({ sessionUID });
+
+        getLogger().info(`native_attempt_appswitch_url_direct`, { url : nativeUrl })
+            .track({
+                [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_ATTEMPT_APP_SWITCH
+            }).flush();
+
+        const nativeWin = popup(nativeUrl);
         const validatePromise = validate();
         const delayPromise = ZalgoPromise.delay(500);
 
@@ -485,7 +513,14 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
                 }
 
                 return createOrder().then(() => {
-                    return { redirectUrl: getNativeUrl({ sessionUID, pageUrl }) };
+                    const nativeUrl = getNativeUrl({ sessionUID, pageUrl });
+
+                    getLogger().info(`native_attempt_appswitch_url_popup`, { url : nativeUrl })
+                        .track({
+                            [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_ATTEMPT_APP_SWITCH
+                        }).flush();
+
+                    return { redirectUrl: nativeUrl };
                 });
             });
         });

--- a/src/payment-flows/native.js
+++ b/src/payment-flows/native.js
@@ -202,7 +202,7 @@ function instrumentNativeSDKProps(props : NativeSDKProps) {
     if (props) {
         const sanitizedProps = {
             ...props,
-            facilitatorAccessToken : props && props.facilitatorAccessToken ? '********************' : ''
+            facilitatorAccessToken: props && props.facilitatorAccessToken ? '********************' : ''
         };
 
         getLogger().info('native_setprops_request', sanitizedProps).track({
@@ -361,7 +361,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
             approved = true;
             getLogger().info(`native_message_onapprove`)
                 .track({
-                    [FPTI_KEY.TRANSITION] : FPTI_TRANSITION.NATIVE_POPUP_CLOSED
+                    [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_POPUP_CLOSED
                 })
                 .flush();
 
@@ -440,7 +440,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
     const initDirectAppSwitch = ({ sessionUID } : {| sessionUID : string |}) => {
         const nativeUrl = getNativeUrl({ sessionUID });
 
-        getLogger().info(`native_attempt_appswitch_url_direct`, { url : nativeUrl })
+        getLogger().info(`native_attempt_appswitch_url_direct`, { url: nativeUrl })
             .track({
                 [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_ATTEMPT_APP_SWITCH
             }).flush();
@@ -515,7 +515,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
                 return createOrder().then(() => {
                     const nativeUrl = getNativeUrl({ sessionUID, pageUrl });
 
-                    getLogger().info(`native_attempt_appswitch_url_popup`, { url : nativeUrl })
+                    getLogger().info(`native_attempt_appswitch_url_popup`, { url: nativeUrl })
                         .track({
                             [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_ATTEMPT_APP_SWITCH
                         }).flush();

--- a/src/payment-flows/native.js
+++ b/src/payment-flows/native.js
@@ -199,18 +199,14 @@ type NativeSDKProps = {|
 |};
 
 function instrumentNativeSDKProps(props : NativeSDKProps) {
-    if (props) {
-        const sanitizedProps = {
-            ...props,
-            facilitatorAccessToken: props && props.facilitatorAccessToken ? '********************' : ''
-        };
+    const sanitizedProps = {
+        ...props,
+        facilitatorAccessToken: props.facilitatorAccessToken ? '********************' : ''
+    };
 
-        getLogger().info('native_setprops_request', sanitizedProps).track({
-            [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_SET_PROPS_ATTEMPT
-        });
-    } else {
-        getLogger().info('native_setprops_request_has_enpty_props');
-    }
+    getLogger().info('native_setprops_request', sanitizedProps).track({
+        [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_SET_PROPS_ATTEMPT
+    });
 }
 
 function initNative({ props, components, config, payment, serviceData } : InitOptions) : PaymentFlowInstance {


### PR DESCRIPTION
Instrumentation for the following usecases:
 - When setting the props, (we need to know if all of them will be making it to firebase `process_set_props_attempt`)
 - When attempting the app-switch, (we need to know what will be making it in the url to native `app_switch_attempted`)
 - When coming back from native, (we need a log that confirms that the popup was closed `process_popup_closed`)