### PR TITLE
Introducing upgradeLSAT calls on onAuth callback

### DIFF
--- a/src/button/props.js
+++ b/src/button/props.js
@@ -11,7 +11,7 @@ import type { CreateOrder, XCreateOrder, CreateBillingAgreement, XCreateBillingA
     OnApprove, XOnApprove, OnCancel, XOnCancel, OnClick, XOnClick, OnShippingChange, XOnShippingChange, XOnError, OnError,
     XGetPopupBridge, GetPopupBridge, XCreateSubscription, RememberFunding, GetPageURL, OnAuth } from '../props';
 import { type FirebaseConfig } from '../api';
-import { getNonce } from '../lib';
+import { getNonce, createExperiment } from '../lib';
 import { getOnInit } from '../props/onInit';
 import { getCreateOrder } from '../props/createOrder';
 import { getOnApprove } from '../props/onApprove';

--- a/src/button/props.js
+++ b/src/button/props.js
@@ -220,7 +220,7 @@ export function getProps({ facilitatorAccessToken } : {| facilitatorAccessToken 
     const onApprove = getOnApprove({ onApprove: xprops.onApprove, intent, onError, partnerAttributionID, upgradeLSAT, clientAccessToken, vault, isLSATExperiment: upgradeLSATExperiment.isEnabled() }, { facilitatorAccessToken, createOrder });
     const onCancel = getOnCancel({ onCancel: xprops.onCancel, onError }, { createOrder });
     const onShippingChange = getOnShippingChange({ onShippingChange: xprops.onShippingChange, partnerAttributionID }, { facilitatorAccessToken, createOrder });
-    const onAuth = getOnAuth({ facilitatorAccessToken, createOrder, isLSATExperiment: upgradeLSATExperiment.isEnabled() });
+    const onAuth = getOnAuth({ facilitatorAccessToken, createOrder, isLSATExperiment: upgradeLSATExperiment.isEnabled(), upgradeLSAT });
 
     return {
         env,

--- a/src/button/props.js
+++ b/src/button/props.js
@@ -220,7 +220,7 @@ export function getProps({ facilitatorAccessToken } : {| facilitatorAccessToken 
     const onApprove = getOnApprove({ onApprove: xprops.onApprove, intent, onError, partnerAttributionID, upgradeLSAT, clientAccessToken, vault, isLSATExperiment: upgradeLSATExperiment.isEnabled() }, { facilitatorAccessToken, createOrder });
     const onCancel = getOnCancel({ onCancel: xprops.onCancel, onError }, { createOrder });
     const onShippingChange = getOnShippingChange({ onShippingChange: xprops.onShippingChange, partnerAttributionID }, { facilitatorAccessToken, createOrder });
-    const onAuth = getOnAuth({ facilitatorAccessToken, createOrder });
+    const onAuth = getOnAuth({ facilitatorAccessToken, createOrder, isLSATExperiment: upgradeLSATExperiment.isEnabled() });
 
     return {
         env,

--- a/src/button/props.js
+++ b/src/button/props.js
@@ -8,7 +8,7 @@ import type { ContentType, LocaleType, ProxyWindow, Wallet, CheckoutFlowType, Ca
     ThreeDomainSecureFlowType, PersonalizationType, MenuFlowType, ConnectOptions } from '../types';
 import type { CreateOrder, XCreateOrder, CreateBillingAgreement, XCreateBillingAgreement, OnInit, XOnInit,
     OnApprove, XOnApprove, OnCancel, XOnCancel, OnClick, XOnClick, OnShippingChange, XOnShippingChange, XOnError, OnError,
-    XGetPopupBridge, GetPopupBridge, XCreateSubscription, RememberFunding, GetPageURL } from '../props';
+    XGetPopupBridge, GetPopupBridge, XCreateSubscription, RememberFunding, GetPageURL, OnAuth } from '../props';
 import { type FirebaseConfig } from '../api';
 import { getNonce } from '../lib';
 import { getOnInit } from '../props/onInit';
@@ -19,6 +19,7 @@ import { getOnShippingChange } from '../props/onShippingChange';
 import { getOnClick } from '../props/onClick';
 import { getCreateBillingAgreement } from '../props/createBillingAgreement';
 import { getCreateSubscription } from '../props/createSubscription';
+import { getOnAuth } from '../props/onAuth';
 
 // export something to force webpack to see this as an ES module
 export const TYPES = true;
@@ -81,7 +82,7 @@ export type ButtonXProps = {|
     apiStageHost : ?string,
     upgradeLSAT? : boolean,
     connect? : ConnectOptions,
-    
+
     onInit : XOnInit,
     onApprove : ?XOnApprove,
     onCancel : XOnCancel,
@@ -136,7 +137,9 @@ export type ButtonProps = {|
     onApprove : OnApprove,
 
     onCancel : OnCancel,
-    onShippingChange : ?OnShippingChange
+    onShippingChange : ?OnShippingChange,
+
+    onAuth: OnAuth,
 |};
 
 export function getProps({ facilitatorAccessToken } : {| facilitatorAccessToken : string |}) : ButtonProps {
@@ -209,12 +212,13 @@ export function getProps({ facilitatorAccessToken } : {| facilitatorAccessToken 
 
     const createBillingAgreement = getCreateBillingAgreement({ createBillingAgreement: xprops.createBillingAgreement });
     const createSubscription = getCreateSubscription({ createSubscription: xprops.createSubscription, partnerAttributionID, merchantID, clientID }, { facilitatorAccessToken });
-    
+
     const createOrder = getCreateOrder({ createOrder: xprops.createOrder, currency, intent, merchantID, partnerAttributionID }, { facilitatorAccessToken, createBillingAgreement, createSubscription });
 
     const onApprove = getOnApprove({ onApprove: xprops.onApprove, intent, onError, partnerAttributionID, upgradeLSAT, clientAccessToken, vault }, { facilitatorAccessToken, createOrder });
     const onCancel = getOnCancel({ onCancel: xprops.onCancel, onError }, { createOrder });
     const onShippingChange = getOnShippingChange({ onShippingChange: xprops.onShippingChange, partnerAttributionID }, { facilitatorAccessToken, createOrder });
+    const onAuth = getOnAuth({ facilitatorAccessToken, createOrder });
 
     return {
         env,
@@ -260,7 +264,9 @@ export function getProps({ facilitatorAccessToken } : {| facilitatorAccessToken 
         createSubscription,
         onApprove,
         onCancel,
-        onShippingChange
+        onShippingChange,
+
+        onAuth
     };
 }
 
@@ -285,7 +291,7 @@ export type Config = {|
 export function getConfig({ serverCSPNonce, firebaseConfig } : {| serverCSPNonce : ?string, firebaseConfig : ?FirebaseConfig |}) : Config {
     const cspNonce = serverCSPNonce || getNonce();
     const { version } = paypal;
-    
+
     return {
         version,
         cspNonce,

--- a/src/button/props.js
+++ b/src/button/props.js
@@ -4,14 +4,14 @@ import type { CrossDomainWindowType } from 'cross-domain-utils/src';
 import { ENV, INTENT, COUNTRY, FUNDING, CARD, PLATFORM, CURRENCY, type FundingEligibilityType } from '@paypal/sdk-constants/src';
 import type { ZalgoPromise } from 'zalgo-promise/src';
 
-import { FPTI_STATE, FPTI_TRANSITION, UPGRADE_LSAT_RAMP } from '../constants';
+import {  UPGRADE_LSAT_RAMP } from '../constants';
 import type { ContentType, LocaleType, ProxyWindow, Wallet, CheckoutFlowType, CardFieldsFlowType,
     ThreeDomainSecureFlowType, PersonalizationType, MenuFlowType, ConnectOptions } from '../types';
 import type { CreateOrder, XCreateOrder, CreateBillingAgreement, XCreateBillingAgreement, OnInit, XOnInit,
     OnApprove, XOnApprove, OnCancel, XOnCancel, OnClick, XOnClick, OnShippingChange, XOnShippingChange, XOnError, OnError,
     XGetPopupBridge, GetPopupBridge, XCreateSubscription, RememberFunding, GetPageURL, OnAuth } from '../props';
 import { type FirebaseConfig } from '../api';
-import { getLogger, getNonce } from '../lib';
+import { getNonce } from '../lib';
 import { getOnInit } from '../props/onInit';
 import { getCreateOrder } from '../props/createOrder';
 import { getOnApprove } from '../props/onApprove';
@@ -142,29 +142,6 @@ export type ButtonProps = {|
     onAuth : OnAuth
 |};
 
-function createUpgradeLSATExperiment(name : string, sample : number) : Experiment {
-    const logger = getLogger();
-
-    return experiment({
-        name,
-        sample,
-        logTreatment({ treatment, payload }) {
-            logger.track({
-                [FPTI_KEY.STATE]:           FPTI_STATE.PXP,
-                [FPTI_KEY.TRANSITION]:      FPTI_TRANSITION.PXP,
-                [FPTI_KEY.EXPERIMENT_NAME]: name,
-                [FPTI_KEY.TREATMENT_NAME]:  treatment,
-                ...payload
-            });
-            logger.flush();
-        },
-        logCheckpoint({ treatment, checkpoint, payload }) {
-            logger.info(`${ name }_${ treatment }_${ checkpoint }`, payload);
-            logger.flush();
-        }
-    });
-}
-
 export function getProps({ facilitatorAccessToken } : {| facilitatorAccessToken : string |}) : ButtonProps {
 
     const xprops : ButtonXProps = window.xprops;
@@ -204,7 +181,7 @@ export function getProps({ facilitatorAccessToken } : {| facilitatorAccessToken 
         upgradeLSAT = false
     } = xprops;
 
-    const upgradeLSATExperiment = createUpgradeLSATExperiment(UPGRADE_LSAT_RAMP.EXP_NAME, UPGRADE_LSAT_RAMP.RAMP);
+    const upgradeLSATExperiment = createExperiment(UPGRADE_LSAT_RAMP.EXP_NAME, UPGRADE_LSAT_RAMP.RAMP);
 
     const onInit = getOnInit({ onInit: xprops.onInit });
     const merchantDomain = (typeof getParentDomain === 'function') ? getParentDomain() : 'unknown';

--- a/src/constants.js
+++ b/src/constants.js
@@ -146,5 +146,5 @@ export const USER_ACTION = {
 
 export const UPGRADE_LSAT_RAMP = {
     EXP_NAME: 'UPGRADE_LSAT_EXPERIMENT',
-    RAMP: 1
+    RAMP:      1
 };

--- a/src/constants.js
+++ b/src/constants.js
@@ -76,12 +76,14 @@ export const FPTI_CONTEXT_TYPE = {
 
 export const FPTI_STATE = {
     BUTTON:   ('smart_button' : 'smart_button'),
-    WALLET:   ('smart_wallet' : 'smart_wallet')
+    WALLET:   ('smart_wallet' : 'smart_wallet'),
+    PXP:      ('PXP_CHECK' : 'PXP_CHECK')
 };
 
 export const FPTI_TRANSITION = {
     BUTTON_LOAD:              ('process_button_load' : 'process_button_load'),
     BUTTON_CLICK:             ('process_button_click' : 'process_button_click'),
+    PXP:                      ('process_pxp_check' : 'process_pxp_check'),
 
     WALLET_LOAD:              ('process_wallet_load' : 'process_wallet_load'),
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -143,3 +143,8 @@ export const USER_ACTION = {
     COMMIT:   'commit',
     CONTINUE: 'continue'
 };
+
+export const UPGRADE_LSAT_RAMP = {
+    EXP_NAME: 'UPGRADE_LSAT_EXPERIMENT',
+    RAMP: 1
+};

--- a/src/payment-flows/card-fields.js
+++ b/src/payment-flows/card-fields.js
@@ -103,7 +103,7 @@ const slideDownButtons = () => {
 
 function initCardFields({ props, components, payment, serviceData, config } : InitOptions) : PaymentFlowInstance {
     const { createOrder, onApprove, onCancel,
-        locale, commit, onError, sessionID, buttonSessionID } = props;
+        locale, commit, onError, sessionID, buttonSessionID, onAuth } = props;
     const { CardFields } = components;
     const { fundingSource, card } = payment;
     const { cspNonce } = config;
@@ -145,7 +145,11 @@ function initCardFields({ props, components, payment, serviceData, config } : In
         },
 
         onAuth: ({ accessToken }) => {
-            buyerAccessToken = accessToken;
+            const access_token = accessToken ? accessToken : buyerAccessToken;
+
+            return onAuth({ accessToken: access_token }).then(token => {
+                buyerAccessToken = token;
+            });
         },
 
         onCancel,

--- a/src/payment-flows/checkout.js
+++ b/src/payment-flows/checkout.js
@@ -7,7 +7,7 @@ import { getParent, getTop, type CrossDomainWindowType } from 'cross-domain-util
 
 import type { ProxyWindow, ConnectOptions } from '../types';
 import { type CreateBillingAgreement, type CreateSubscription } from '../props';
-import { enableVault, exchangeAccessTokenForAuthCode, getConnectURL, upgradeFacilitatorAccessToken } from '../api';
+import { enableVault, exchangeAccessTokenForAuthCode, getConnectURL } from '../api';
 import { CONTEXT, TARGET_ELEMENT, BUYER_INTENT, FPTI_TRANSITION, FPTI_CONTEXT_TYPE } from '../constants';
 import { unresolvedPromise, getLogger } from '../lib';
 import { openPopup } from '../ui';
@@ -252,9 +252,9 @@ function initCheckout({ props, components, serviceData, payment, config } : Init
 
             onAuth: ({ accessToken }) => {
 
-                const AT = accessToken ? accessToken : buyerAccessToken;
+                const access_token = accessToken ? accessToken : buyerAccessToken;
 
-                return onAuth({ accessToken }).then(token => {
+                return onAuth({ accessToken: access_token }).then(token => {
                     buyerAccessToken = token;
                 });
             },

--- a/src/payment-flows/checkout.js
+++ b/src/payment-flows/checkout.js
@@ -7,7 +7,7 @@ import { getParent, getTop, type CrossDomainWindowType } from 'cross-domain-util
 
 import type { ProxyWindow, ConnectOptions } from '../types';
 import { type CreateBillingAgreement, type CreateSubscription } from '../props';
-import { enableVault, exchangeAccessTokenForAuthCode, getConnectURL } from '../api';
+import { enableVault, exchangeAccessTokenForAuthCode, getConnectURL, upgradeFacilitatorAccessToken } from '../api';
 import { CONTEXT, TARGET_ELEMENT, BUYER_INTENT, FPTI_TRANSITION, FPTI_CONTEXT_TYPE } from '../constants';
 import { unresolvedPromise, getLogger } from '../lib';
 import { openPopup } from '../ui';
@@ -134,7 +134,7 @@ function enableVaultSetup({ orderID, vault, clientAccessToken, createBillingAgre
         if (!clientAccessToken) {
             return;
         }
-        
+
         if (isVaultAutoSetupEligible({ vault, clientAccessToken, createBillingAgreement, createSubscription, fundingSource, fundingEligibility })) {
             return enableVault({ orderID, clientAccessToken }).catch(err => {
                 if (vault) {
@@ -166,7 +166,7 @@ function initCheckout({ props, components, serviceData, payment, config } : Init
     const { sessionID, buttonSessionID, createOrder, onApprove, onCancel,
         onShippingChange, locale, commit, onError, vault, clientAccessToken,
         createBillingAgreement, createSubscription, onClick,
-        clientID, connect, clientMetadataID: cmid } = props;
+        clientID, connect, clientMetadataID: cmid, onAuth } = props;
     let { button, win, fundingSource, card, isClick, buyerAccessToken = serviceData.buyerAccessToken,
         venmoPayloadID, buyerIntent } = payment;
     const { fundingEligibility, buyerCountry, sdkMeta } = serviceData;
@@ -177,7 +177,7 @@ function initCheckout({ props, components, serviceData, payment, config } : Init
 
     let approved = false;
     let forceClosed = false;
-    
+
     const init = () => {
         return Checkout({
             window: win,
@@ -223,7 +223,7 @@ function initCheckout({ props, components, serviceData, payment, config } : Init
                     });
                 });
             } : null,
-    
+
             createOrder: () => {
                 return createOrder().then(orderID => {
                     return ZalgoPromise.try(() => {
@@ -235,40 +235,42 @@ function initCheckout({ props, components, serviceData, payment, config } : Init
                     });
                 });
             },
-    
+
             onApprove: ({ payerID, paymentID, billingToken, subscriptionID, authCode }) => {
                 approved = true;
                 getLogger().info(`spb_onapprove_access_token_${ buyerAccessToken ? 'present' : 'not_present' }`).flush();
-    
+
                 // eslint-disable-next-line no-use-before-define
                 return close().then(() => {
                     const restart = memoize(() : ZalgoPromise<void> =>
                         initCheckout({ props, components, serviceData, config, payment: { button, fundingSource, card, buyerIntent, isClick: false } })
                             .start().finally(unresolvedPromise));
-                            
+
                     return onApprove({ payerID, paymentID, billingToken, subscriptionID, buyerAccessToken, authCode }, { restart }).catch(noop);
                 });
             },
-    
+
             onAuth: ({ accessToken }) => {
-                getLogger().info(`spb_onauth_access_token_${ (accessToken || buyerAccessToken)  ? 'present' : 'not_present' }`);
-                if (accessToken) {
-                    buyerAccessToken = accessToken;
-                }
+
+                const AT = accessToken ? accessToken : buyerAccessToken;
+
+                return onAuth({ accessToken }).then(token => {
+                    buyerAccessToken = token;
+                });
             },
-    
+
             onCancel: () => {
                 // eslint-disable-next-line no-use-before-define
                 return close().then(() => {
                     return onCancel();
                 });
             },
-    
+
             onShippingChange: onShippingChange
                 ? (data, actions) => {
                     return onShippingChange({ buyerAccessToken, ...data }, actions);
                 } : null,
-    
+
             onClose: () => {
                 checkoutOpen = false;
                 if (!forceClosed && !approved) {
@@ -277,7 +279,7 @@ function initCheckout({ props, components, serviceData, payment, config } : Init
             },
 
             onError,
-    
+
             fundingSource,
             card,
             buyerCountry,
@@ -335,7 +337,7 @@ function updateCheckoutClientConfig({ orderID, payment }) : ZalgoPromise<void> {
     return ZalgoPromise.try(() => {
         const { buyerIntent, fundingSource } = payment;
         const updateClientConfigPromise = updateButtonClientConfig({ fundingSource, orderID, inline: false });
-    
+
         // Block
         if (buyerIntent === BUYER_INTENT.PAY_WITH_DIFFERENT_FUNDING_SHIPPING) {
             return updateClientConfigPromise;

--- a/src/props/index.js
+++ b/src/props/index.js
@@ -12,3 +12,4 @@ export * from './onError';
 export * from './getPopupBridge';
 export * from './rememberFunding';
 export * from './getPageUrl';
+export * from './onAuth';

--- a/src/props/onApprove.js
+++ b/src/props/onApprove.js
@@ -240,7 +240,7 @@ type OnApproveXProps = {|
     upgradeLSAT : boolean,
     clientAccessToken : ?string,
     vault : boolean,
-    isLSATExperiment: boolean
+    isLSATExperiment : boolean
 |};
 
 export function getOnApprove({ intent, onApprove = getDefaultOnApprove(intent), partnerAttributionID, onError, clientAccessToken, vault, upgradeLSAT = false, isLSATExperiment = false } : OnApproveXProps, { facilitatorAccessToken, createOrder } : {| facilitatorAccessToken : string, createOrder : CreateOrder |}) : OnApprove {

--- a/src/props/onApprove.js
+++ b/src/props/onApprove.js
@@ -61,7 +61,7 @@ type ActionOptions = {|
 |};
 
 function buildOrderActions({ intent, orderID, restart, facilitatorAccessToken, buyerAccessToken, partnerAttributionID, forceRestAPI } : ActionOptions) : OrderActions {
-    
+
     const handleProcessorError = (err : mixed) : ZalgoPromise<OrderResponse> => {
         // $FlowFixMe
         const isProcessorDecline = err && err.data && err.data.details && err.data.details.some(detail => {
@@ -74,7 +74,7 @@ function buildOrderActions({ intent, orderID, restart, facilitatorAccessToken, b
 
         throw new Error('Order could not be captured');
     };
-    
+
     const get = memoize(() => {
         return getOrder(orderID, { facilitatorAccessToken, buyerAccessToken, partnerAttributionID, forceRestAPI });
     });
@@ -173,7 +173,7 @@ function buildXApproveActions({ intent, orderID, paymentID, payerID, restart, su
         if (!subscriptionID) {
             throw new Error(`No subscription ID present`);
         }
-        
+
         return activateSubscription(subscriptionID, { buyerAccessToken });
     });
 
@@ -239,15 +239,16 @@ type OnApproveXProps = {|
     onError : XOnError,
     upgradeLSAT : boolean,
     clientAccessToken : ?string,
-    vault : boolean
+    vault : boolean,
+    isLSATExperiment: boolean
 |};
 
-export function getOnApprove({ intent, onApprove = getDefaultOnApprove(intent), partnerAttributionID, onError, clientAccessToken, vault, upgradeLSAT = false } : OnApproveXProps, { facilitatorAccessToken, createOrder } : {| facilitatorAccessToken : string, createOrder : CreateOrder |}) : OnApprove {
+export function getOnApprove({ intent, onApprove = getDefaultOnApprove(intent), partnerAttributionID, onError, clientAccessToken, vault, upgradeLSAT = false, isLSATExperiment = false } : OnApproveXProps, { facilitatorAccessToken, createOrder } : {| facilitatorAccessToken : string, createOrder : CreateOrder |}) : OnApprove {
     if (!onApprove) {
         throw new Error(`Expected onApprove`);
     }
 
-    return memoize(({ payerID, paymentID, billingToken, subscriptionID, buyerAccessToken, authCode, forceRestAPI = upgradeLSAT } : OnApproveData, { restart } : OnApproveActions) => {
+    return memoize(({ payerID, paymentID, billingToken, subscriptionID, buyerAccessToken, authCode, forceRestAPI = (upgradeLSAT || isLSATExperiment) } : OnApproveData, { restart } : OnApproveActions) => {
         return ZalgoPromise.try(() => {
             if (upgradeLSAT && buyerAccessToken) {
                 return createOrder().then(orderID => upgradeFacilitatorAccessToken(facilitatorAccessToken, { buyerAccessToken, orderID }));
@@ -274,7 +275,7 @@ export function getOnApprove({ intent, onApprove = getDefaultOnApprove(intent), 
             return getSupplementalOrderInfo(orderID).then(supplementalData => {
                 intent = intent || (supplementalData && supplementalData.checkoutSession && supplementalData.checkoutSession.cart && supplementalData.checkoutSession.cart.intent);
                 billingToken = billingToken || (supplementalData && supplementalData.checkoutSession && supplementalData.checkoutSession.cart && supplementalData.checkoutSession.cart.billingToken);
-                
+
                 const data = { orderID, payerID, paymentID, billingToken, subscriptionID, facilitatorAccessToken, authCode };
                 const actions = buildXApproveActions({ orderID, paymentID, payerID, intent, restart, subscriptionID, facilitatorAccessToken, buyerAccessToken, partnerAttributionID, forceRestAPI });
 

--- a/src/props/onApprove.js
+++ b/src/props/onApprove.js
@@ -5,7 +5,7 @@ import { ZalgoPromise } from 'zalgo-promise/src';
 import { memoize, redirect as redir, noop } from 'belter/src';
 import { INTENT, SDK_QUERY_KEYS, FPTI_KEY } from '@paypal/sdk-constants/src';
 
-import { type OrderResponse, type PaymentResponse, getOrder, captureOrder, authorizeOrder, patchOrder, getSubscription, activateSubscription, type SubscriptionResponse, getPayment, executePayment, patchPayment, upgradeFacilitatorAccessToken, getSupplementalOrderInfo } from '../api';
+import { type OrderResponse, type PaymentResponse, getOrder, captureOrder, authorizeOrder, patchOrder, getSubscription, activateSubscription, type SubscriptionResponse, getPayment, executePayment, patchPayment, getSupplementalOrderInfo } from '../api';
 import { ORDER_API_ERROR, FPTI_TRANSITION, FPTI_CONTEXT_TYPE } from '../constants';
 import { unresolvedPromise, getLogger } from '../lib';
 import { ENABLE_PAYMENT_API } from '../config';
@@ -250,10 +250,6 @@ export function getOnApprove({ intent, onApprove = getDefaultOnApprove(intent), 
 
     return memoize(({ payerID, paymentID, billingToken, subscriptionID, buyerAccessToken, authCode, forceRestAPI = (upgradeLSAT || isLSATExperiment) } : OnApproveData, { restart } : OnApproveActions) => {
         return ZalgoPromise.try(() => {
-            if (upgradeLSAT && buyerAccessToken) {
-                return createOrder().then(orderID => upgradeFacilitatorAccessToken(facilitatorAccessToken, { buyerAccessToken, orderID }));
-            }
-        }).then(() => {
             return createOrder();
         }).then(orderID => {
             getLogger()

--- a/src/props/onAuth.js
+++ b/src/props/onAuth.js
@@ -1,20 +1,21 @@
 /* @flow */
 
 import { ZalgoPromise } from 'zalgo-promise/src';
-import { memoize } from 'belter/src';
-import type { CreateOrder } from './createOrder';
-import { getLogger } from '../lib';
+
 import { upgradeFacilitatorAccessToken } from '../api';
+import { getLogger } from '../lib';
+
+import type { CreateOrder } from './createOrder';
 
 export type XOnAuthDataType = {|
-    accessToken: string
+    accessToken : string
 |};
 
 export type OnAuth = () => ZalgoPromise<void>;
 
-export function getOnAuth({ facilitatorAccessToken, createOrder, isLSATExperiment } : {| facilitatorAccessToken : string, createOrder: CreateOrder, isLSATExperiment: boolean |}) : OnAuth | void {
+export function getOnAuth({ facilitatorAccessToken, createOrder, isLSATExperiment } : {| facilitatorAccessToken : string, createOrder : CreateOrder, isLSATExperiment : boolean |}) : OnAuth | void {
 
-    return ({ accessToken }) => {
+    return ({ accessToken } : XOnAuthDataType) => {
         getLogger().info(`spb_onauth_access_token_${ accessToken ? 'present' : 'not_present' }`);
 
         return ZalgoPromise.try(() => {
@@ -31,7 +32,7 @@ export function getOnAuth({ facilitatorAccessToken, createOrder, isLSATExperimen
                             getLogger().warn('upgrade_lsat_failure', { error: err });
                         });
                 }
-                return accessToken
+                return accessToken;
             }
         });
     };

--- a/src/props/onAuth.js
+++ b/src/props/onAuth.js
@@ -1,0 +1,32 @@
+/* @flow */
+
+import { ZalgoPromise } from 'zalgo-promise/src';
+import { memoize } from 'belter/src';
+import type {CreateOrder} from './createOrder';
+import { getLogger } from '../lib';
+import { upgradeFacilitatorAccessToken } from '../api';
+
+export type XOnAuthDataType = {|
+    accessToken: string
+|};
+
+export type OnAuth = () => ZalgoPromise<void>;
+
+export function getOnAuth({ facilitatorAccessToken, createOrder } : {| facilitatorAccessToken : string, createOrder: CreateOrder |}) : OnAuth | void {
+
+    return ({ accessToken }) => {
+        getLogger().info(`spb_onauth_access_token_${ (accessToken || buyerAccessToken)  ? 'present' : 'not_present' }`);
+
+        if (accessToken) {
+            return ZalgoPromise.try(() => {
+               // if (experiment) {
+               //     do the thing
+               // }
+
+               return createOrder().then(orderID => upgradeFacilitatorAccessToken(facilitatorAccessToken, {buyerAccessToken: accessToken, orderID}));
+            }).then(() => {
+                return accessToken;
+            });
+        }
+    };
+}

--- a/src/props/onAuth.js
+++ b/src/props/onAuth.js
@@ -14,14 +14,14 @@ export type XOnAuthDataType = {|
 
 export type OnAuth = (params : XOnAuthDataType) => ZalgoPromise<string | void>;
 
-export function getOnAuth({ facilitatorAccessToken, createOrder, isLSATExperiment } : {| facilitatorAccessToken : string, createOrder : CreateOrder, isLSATExperiment : boolean |}) : OnAuth {
+export function getOnAuth({ facilitatorAccessToken, createOrder, isLSATExperiment, upgradeLSAT } : {| facilitatorAccessToken : string, createOrder : CreateOrder, isLSATExperiment : boolean, upgradeLSAT : boolean |}) : OnAuth {
 
     return ({ accessToken } : XOnAuthDataType) => {
         getLogger().info(`spb_onauth_access_token_${ accessToken ? 'present' : 'not_present' }`);
 
         return ZalgoPromise.try(() => {
             if (accessToken) {
-                if (isLSATExperiment) {
+                if (isLSATExperiment || upgradeLSAT) {
                     return createOrder()
                         .then(orderID => upgradeFacilitatorAccessToken(facilitatorAccessToken, { buyerAccessToken: accessToken, orderID }))
                         .then(() => {

--- a/src/props/onAuth.js
+++ b/src/props/onAuth.js
@@ -1,6 +1,7 @@
 /* @flow */
 
 import { ZalgoPromise } from 'zalgo-promise/src';
+import { stringifyError } from 'belter/src';
 
 import { upgradeFacilitatorAccessToken } from '../api';
 import { getLogger } from '../lib';
@@ -8,12 +9,12 @@ import { getLogger } from '../lib';
 import type { CreateOrder } from './createOrder';
 
 export type XOnAuthDataType = {|
-    accessToken : string
+    accessToken : ?string
 |};
 
-export type OnAuth = () => ZalgoPromise<void>;
+export type OnAuth = (params : XOnAuthDataType) => ZalgoPromise<string | void>;
 
-export function getOnAuth({ facilitatorAccessToken, createOrder, isLSATExperiment } : {| facilitatorAccessToken : string, createOrder : CreateOrder, isLSATExperiment : boolean |}) : OnAuth | void {
+export function getOnAuth({ facilitatorAccessToken, createOrder, isLSATExperiment } : {| facilitatorAccessToken : string, createOrder : CreateOrder, isLSATExperiment : boolean |}) : OnAuth {
 
     return ({ accessToken } : XOnAuthDataType) => {
         getLogger().info(`spb_onauth_access_token_${ accessToken ? 'present' : 'not_present' }`);
@@ -29,7 +30,9 @@ export function getOnAuth({ facilitatorAccessToken, createOrder, isLSATExperimen
                             return accessToken;
                         })
                         .catch(err => {
-                            getLogger().warn('upgrade_lsat_failure', { error: err });
+                            getLogger().warn('upgrade_lsat_failure', { error: stringifyError(err) });
+
+                            return accessToken;
                         });
                 }
                 return accessToken;

--- a/src/wallet/props.js
+++ b/src/wallet/props.js
@@ -17,7 +17,7 @@ import type {
 export type WalletSetup = ({||}, {| submit : () => ZalgoPromise<void> |}) => ZalgoPromise<void>;
 
 export type WalletStyle = {|
-    
+
 |};
 
 export type WalletXProps = {|
@@ -53,7 +53,7 @@ export type WalletXProps = {|
 
     stageHost : ?string,
     apiStageHost : ?string,
-    
+
     onApprove : ?XOnApprove,
     onCancel : XOnCancel,
     onError : XOnError
@@ -141,10 +141,10 @@ export function getProps({ facilitatorAccessToken } : {| facilitatorAccessToken 
     } = xprops;
 
     const merchantDomain = (typeof getParentDomain === 'function') ? getParentDomain() : 'unknown';
-    
+
     const createOrder = getCreateOrder({ createOrder: xprops.createOrder, currency, intent, merchantID, partnerAttributionID }, { facilitatorAccessToken });
 
-    const onApprove = getOnApprove({ onApprove: xprops.onApprove, intent, onError, partnerAttributionID, clientAccessToken, vault, upgradeLSAT: false }, { facilitatorAccessToken, createOrder });
+    const onApprove = getOnApprove({ onApprove: xprops.onApprove, intent, onError, partnerAttributionID, clientAccessToken, vault, upgradeLSAT: false, isLSATExperiment: false }, { facilitatorAccessToken, createOrder });
     const onCancel = getOnCancel({ onCancel: xprops.onCancel, onError }, { createOrder });
 
     return {
@@ -198,7 +198,7 @@ export type Config = {|
 export function getConfig({ serverCSPNonce } : {| serverCSPNonce : ?string |}) : Config {
     const cspNonce = serverCSPNonce || getNonce();
     const { version } = paypal;
-    
+
     return {
         version,
         cspNonce

--- a/test/client/auth.js
+++ b/test/client/auth.js
@@ -4,7 +4,9 @@
 import { wrapPromise } from 'belter/src';
 import { FUNDING } from '@paypal/sdk-constants/src';
 
-import { mockSetupButton, mockAsyncProp, createButtonHTML, getGetOrderApiMock, getCaptureOrderApiMock, DEFAULT_FUNDING_ELIGIBILITY, mockFunction, clickButton, MOCK_BUYER_ACCESS_TOKEN } from './mocks';
+import { mockSetupButton, mockAsyncProp, createButtonHTML, getGetOrderApiMock, getCaptureOrderApiMock,
+    DEFAULT_FUNDING_ELIGIBILITY, mockFunction, clickButton, MOCK_BUYER_ACCESS_TOKEN, getRestfulCapturedOrderApiMock,
+    getRestfulGetOrderApiMock, getGraphQLApiMock } from './mocks';
 
 describe('auth cases', () => {
 
@@ -56,6 +58,113 @@ describe('auth cases', () => {
             await mockSetupButton({ merchantID: [ 'XYZ12345' ], fundingEligibility: DEFAULT_FUNDING_ELIGIBILITY });
 
             await clickButton(FUNDING.PAYPAL);
+        });
+    });
+
+    it('should render a button, call onAuth, call upgradeLSAT if flag is set, call restful auth/capture endpoints in onApprove cb', async () => {
+        return await wrapPromise(async ({ expect }) => {
+            const accessToken = MOCK_BUYER_ACCESS_TOKEN;
+            let isUpgradeLSATCalled = false;
+            window.xprops.upgradeLSAT = true;
+
+            const upgradeLSATMock = getGraphQLApiMock({
+                extraHandler: expect('upgradeLSATGQLCall', ({ data }) => {
+
+                    if (data.query.includes('query GetCheckoutDetails')) {
+                        return {
+                            data: {
+                                checkoutSession: {
+                                    cart: {
+                                        intent:  'capture',
+                                        amounts: {
+                                            total: {
+                                                currencyCode: 'USD'
+                                            }
+                                        }
+                                    },
+                                    payees: [
+                                        {
+                                            merchantId: 'XYZ12345',
+                                            email:       {
+                                                stringValue: 'xyz-us-b1@paypal.com'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        };
+                    }
+
+                    if (data.query.includes('mutation UpgradeFacilitatorAccessToken')) {
+                        isUpgradeLSATCalled = true;
+                        if (!data.variables.facilitatorAccessToken) {
+                            throw new Error(`We haven't received the facilitatorAccessToken`);
+                        }
+
+                        if (!data.variables.buyerAccessToken) {
+                            throw new Error(`We haven't received the buyer's access token`);
+                        }
+
+                        if (!data.variables.orderID) {
+                            throw new Error(`We haven't received the orderID`);
+                        }
+
+                        return {
+                            data: {
+                                upgradeLowScopeAccessToken: true
+                            }
+                        };
+                    }
+
+                    return {};
+
+
+                })
+            }).expectCalls();
+
+            window.xprops.onApprove = mockAsyncProp(expect('onApprove', async (data, actions) => {
+                const getOrderMock = getRestfulGetOrderApiMock( {
+                   handler: expect('getOrder', ({ headers }) => {
+                       return {
+                           ack: 'success',
+                           data: {}
+                       };
+                   })
+                });
+                getOrderMock.expectCalls();
+                await actions.order.get();
+                getOrderMock.done();
+
+                const captureOrderApiMock = getRestfulCapturedOrderApiMock({
+                   handler: expect('captureOrder', ({ headers }) => {
+                       return {
+                           ack:  'success',
+                           data: {}
+                       };
+                   })
+                });
+                captureOrderApiMock.expectCalls();
+                await actions.order.capture();
+                captureOrderApiMock.done();
+            }));
+
+
+
+            mockFunction(window.paypal, 'Checkout', expect('Checkout', ({ original: CheckoutOriginal, args: [ props ] }) => {
+                props.onAuth({ accessToken });
+                return CheckoutOriginal(props);
+            }));
+
+            createButtonHTML();
+
+            await mockSetupButton({ merchantID: [ 'XYZ12345' ], fundingEligibility: DEFAULT_FUNDING_ELIGIBILITY });
+
+            await clickButton(FUNDING.PAYPAL);
+
+            if (!isUpgradeLSATCalled) throw new Error('Failed Low Scope Access Token Upgrade');
+
+            upgradeLSATMock.done();
+
         });
     });
 });

--- a/test/client/auth.js
+++ b/test/client/auth.js
@@ -123,31 +123,30 @@ describe('auth cases', () => {
             }).expectCalls();
 
             window.xprops.onApprove = mockAsyncProp(expect('onApprove', async (data, actions) => {
-                const getOrderMock = getRestfulGetOrderApiMock( {
-                   handler: expect('getOrder', ({ headers }) => {
-                       return {
-                           ack: 'success',
-                           data: {}
-                       };
-                   })
+                const getOrderMock = getRestfulGetOrderApiMock({
+                    handler: expect('getOrder', () => {
+                        return {
+                            ack:  'success',
+                            data: {}
+                        };
+                    })
                 });
                 getOrderMock.expectCalls();
                 await actions.order.get();
                 getOrderMock.done();
 
                 const captureOrderApiMock = getRestfulCapturedOrderApiMock({
-                   handler: expect('captureOrder', ({ headers }) => {
-                       return {
-                           ack:  'success',
-                           data: {}
-                       };
-                   })
+                    handler: expect('captureOrder', () => {
+                        return {
+                            ack:  'success',
+                            data: {}
+                        };
+                    })
                 });
                 captureOrderApiMock.expectCalls();
                 await actions.order.capture();
                 captureOrderApiMock.done();
             }));
-
 
 
             mockFunction(window.paypal, 'Checkout', expect('Checkout', ({ original: CheckoutOriginal, args: [ props ] }) => {
@@ -161,7 +160,9 @@ describe('auth cases', () => {
 
             await clickButton(FUNDING.PAYPAL);
 
-            if (!isUpgradeLSATCalled) throw new Error('Failed Low Scope Access Token Upgrade');
+            if (!isUpgradeLSATCalled) {
+                throw new Error('Failed Low Scope Access Token Upgrade');
+            }
 
             upgradeLSATMock.done();
 

--- a/test/client/mocks.js
+++ b/test/client/mocks.js
@@ -335,7 +335,7 @@ export function getRestfulGetOrderApiMock(options : Object = {}) : MockEndpoint 
         method: 'GET',
         uri:    new RegExp('/v2/checkout/orders/[^/]+'),
         data:   {
-            ack: 'success',
+            ack:  'success',
             data: {
 
             }
@@ -363,7 +363,7 @@ export function getRestfulCapturedOrderApiMock(options : Object = {}) : MockEndp
         method: 'POST',
         uri:    new RegExp('/v2/checkout/orders/[^/]+/capture'),
         data:   {
-            ack: 'success',
+            ack:  'success',
             data: {
 
             }

--- a/test/client/mocks.js
+++ b/test/client/mocks.js
@@ -208,7 +208,7 @@ export async function clickMenu(fundingSource? : string = FUNDING.PAYPAL) : Zalg
     if (!menubutton) {
         throw new Error(`Can not find ${ fundingSource } menu button`);
     }
-    
+
     menubutton.click();
     await menubutton.menuPromise;
 }
@@ -237,7 +237,7 @@ export const DEFAULT_FUNDING_ELIGIBILITY = {
 
 export function createButtonHTML({ fundingEligibility = DEFAULT_FUNDING_ELIGIBILITY, wallet } : {| fundingEligibility? : Object, wallet? : Object |} = {}) {
     const buttons = [];
-    
+
     for (const fundingSource of values(FUNDING)) {
         const fundingConfig = fundingEligibility[fundingSource];
 
@@ -252,7 +252,7 @@ export function createButtonHTML({ fundingEligibility = DEFAULT_FUNDING_ELIGIBIL
                 if (!cardConfig || !cardConfig.eligible) {
                     continue;
                 }
-                
+
                 if (cardConfig.vaultedInstruments && cardConfig.vaultedInstruments.length) {
                     const vaultedInstrument = cardConfig.vaultedInstruments[0];
                     buttons.push(`<button data-funding-source="${ fundingSource }" data-payment-method-id="${ vaultedInstrument.id }"><div data-menu></div></div>`);
@@ -330,12 +330,40 @@ export function getGetOrderApiMock(options : Object = {}) : MockEndpoint {
     });
 }
 
+export function getRestfulGetOrderApiMock(options : Object = {}) : MockEndpoint {
+    return $mockEndpoint.register({
+        method: 'GET',
+        uri:    new RegExp('/v2/checkout/orders/[^/]+'),
+        data:   {
+            ack: 'success',
+            data: {
+
+            }
+        },
+        ...options
+    });
+}
+
 export function getCaptureOrderApiMock(options : Object = {}) : MockEndpoint {
     return $mockEndpoint.register({
         method: 'POST',
         uri:    new RegExp('/smart/api/order/[^/]+/capture'),
         data:   {
             ack:  'success',
+            data: {
+
+            }
+        },
+        ...options
+    });
+}
+
+export function getRestfulCapturedOrderApiMock(options : Object = {}) : MockEndpoint {
+    return $mockEndpoint.register({
+        method: 'POST',
+        uri:    new RegExp('/v2/checkout/orders/[^/]+/capture'),
+        data:   {
+            ack: 'success',
             data: {
 
             }
@@ -513,12 +541,32 @@ export function getGraphQLApiMock(options : Object = {}) : MockEndpoint {
                 if (!data.variables.buyerAccessToken) {
                     throw new Error(`Expected buyer access token to be passed`);
                 }
-                
+
                 return {
                     data: {
                         auth: {
                             authCode: uniqueID()
                         }
+                    }
+                };
+            }
+
+            if (data.query.includes('mutation UpgradeFacilitatorAccessToken')) {
+                if (!data.variables.facilitatorAccessToken) {
+                    throw new Error(`We haven't received the facilitatorAccessToken`);
+                }
+
+                if (!data.variables.buyerAccessToken) {
+                    throw new Error(`We haven't received the buyer's access token`);
+                }
+
+                if (!data.variables.orderID) {
+                    throw new Error(`We haven't received the orderID`);
+                }
+
+                return {
+                    data: {
+                        upgradeLowScopeAccessToken: true
                     }
                 };
             }
@@ -755,7 +803,7 @@ export function mockScript({ src, expect = true, block = true } : {| src : strin
             return promise;
         },
         done: () => {
-            
+
             if (expect && (!mockScripts[src] || !mockScripts[src].created)) {
                 throw new Error(`Expected script with src ${ src } to have been created`);
             }
@@ -1039,7 +1087,7 @@ export function getNativeFirebaseMock({ getSessionUID, extraHandler } : {| getSe
                         message_data:       {}
                     }));
                 }
-    
+
                 if (messageType === 'response' && messageStatus === 'error') {
                     if (messageName === 'onError') {
                         throw new Error(messageData.message);
@@ -1059,26 +1107,26 @@ export function getNativeFirebaseMock({ getSessionUID, extraHandler } : {| getSe
                         }
                     }));
                 }
-    
+
                 if (messageType === 'response' && messageName === 'getProps') {
                     if (requestUID !== getPropsRequestID) {
                         throw new Error(`Request uid doest not match for getProps response`);
                     }
                     props = messageData;
                 }
-    
+
                 if (messageType === 'response' && messageName === 'onApprove') {
                     if (requestUID !== onApproveRequestID) {
                         throw new Error(`Request uid doest not match for onApprove response`);
                     }
                 }
-    
+
                 if (messageType === 'response' && messageName === 'onCancel') {
                     if (requestUID !== onCancelRequestID) {
                         throw new Error(`Request uid doest not match for onCancel response`);
                     }
                 }
-    
+
                 if (messageType === 'response' && messageName === 'onError') {
                     if (requestUID !== onErrorRequestID) {
                         throw new Error(`Request uid doest not match for onError response`);
@@ -1278,7 +1326,7 @@ type PostRobotMock = {|
     |}) => ZalgoPromise<T>,  // eslint-disable-line no-undef
         done : () => void
     |};
-    
+
 export function getPostRobotMock() : PostRobotMock {
     let active = true;
 
@@ -1382,7 +1430,7 @@ const getDefaultMockWindowOptions = () : MockWindowOptions => {
     // $FlowFixMe
     return {};
 };
-        
+
 export function getMockWindowOpen({ expectedUrl, times = 1, appSwitch = false, expectClose = false, onOpen = noop, expectedQuery = [], expectImmediateUrl = true } : MockWindowOptions = getDefaultMockWindowOptions()) : MockWindow {
 
     let windowOpenedTimes = 0;
@@ -1394,9 +1442,9 @@ export function getMockWindowOpen({ expectedUrl, times = 1, appSwitch = false, e
         if (expectImmediateUrl && !url) {
             throw new Error(`Expected url to be immediately passed to window.open`);
         }
-    
+
         windowOpenedTimes += 1;
-            
+
         if (windowOpenedTimes === times) {
             window.open = windowOpen;
         }
@@ -1492,7 +1540,7 @@ export function getMockWindowOpen({ expectedUrl, times = 1, appSwitch = false, e
             if (appSwitch) {
                 newWin.closed = true;
             }
-                            
+
             if (url) {
                 newWin.location = url;
             }
@@ -1543,19 +1591,19 @@ export function generateOrderID() : string {
 }
 
 const ensureWindowOpenOnClick = () => {
-    
+
     let isClick = false;
     let clickTimeout;
-    
+
     function doClick() {
         isClick = true;
-    
+
         clearTimeout(clickTimeout);
         clickTimeout = setTimeout(() => {
             isClick = false;
         }, 1);
     }
-    
+
     const HTMLElementClick = window.HTMLElement.prototype.click;
     window.HTMLElement.prototype.click = function overrideHTMLElementClick() : void {
         doClick();
@@ -1570,25 +1618,25 @@ const ensureWindowOpenOnClick = () => {
         }
         return HTMLElementDispatchEvent.apply(this, arguments);
     };
-    
+
     if (!document.body) {
         throw new Error(`Expected to find document body`);
     }
-    
+
     document.body.addEventListener('keydown', (event : Event) => {
         // $FlowFixMe
         if (event.key === 13 || event.key === 32) {
             doClick();
         }
     });
-    
+
     const windowOpen = window.open;
     window.open = function patchedWindowOpen() : CrossDomainWindowType {
-    
+
         if (!isClick) {
             throw new Error(`Attempted to open window not in click event`);
         }
-    
+
         return windowOpen.apply(this, arguments);
     };
 };


### PR DESCRIPTION
This feature is meant to deprecate clientside API calls to smartcomponentnodeweb with the intention of fulfilling the transaction.

This feature was reverted due to the wrongful use of @paypal/sdk-client. Now we're creating a copy of createExperiment inside the Button script. 