### PR TITLE
Move 'Powered by PayPal' below card fields container

### DIFF
--- a/server/components/buttons/middleware.js
+++ b/server/components/buttons/middleware.js
@@ -146,7 +146,6 @@ export function getButtonMiddleware({
                     <style nonce="${ cspNonce }">${ buttonStyle }</style>
                     
                     <div id="buttons-container" class="buttons-container">${ buttonHTML }</div>
-                    <div id="card-fields-container" class="card-fields-container"></div>
 
                     ${ meta.getSDKLoader({ nonce: cspNonce }) }
                     <script nonce="${ cspNonce }">${ client.script }</script>


### PR DESCRIPTION
repositioned "Powered by PayPal" as requested

before:
<img width="767" alt="Screen Shot 2020-09-21 at 4 45 42 PM" src="https://user-images.githubusercontent.com/25190326/93832321-35d1f680-fc2a-11ea-8d7f-fc9283d1f474.png">

after:
<img width="767" alt="Screen Shot 2020-09-21 at 4 45 59 PM" src="https://user-images.githubusercontent.com/25190326/93832328-3bc7d780-fc2a-11ea-83d6-248c32805fe5.png">
