### PR TITLE
fix/AndroidWebListener

### DIFF
--- a/src/payment-flows/native.js
+++ b/src/payment-flows/native.js
@@ -10,7 +10,7 @@ import { type CrossDomainWindowType, isWindowClosed, onCloseWindow, getDomain } 
 import type { ButtonProps } from '../button/props';
 import { NATIVE_CHECKOUT_URI, WEB_CHECKOUT_URI, NATIVE_CHECKOUT_POPUP_URI } from '../config';
 import { getNativeEligibility, firebaseSocket, type MessageSocket, type FirebaseConfig } from '../api';
-import { getLogger, promiseOne, promiseNoop, unresolvedPromise } from '../lib';
+import { getLogger, promiseOne, promiseNoop } from '../lib';
 import { USER_ACTION, FPTI_STATE, FPTI_TRANSITION, FTPI_CUSTOM_KEY } from '../constants';
 
 import type { PaymentFlow, PaymentFlowInstance, SetupOptions, IsEligibleOptions, IsPaymentEligibleOptions, InitOptions } from './types';
@@ -438,12 +438,10 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
         return connectNative({ sessionUID }).setProps();
     });
 
-    const detectWebSwitch = once(({ sessionUID, fallbackWin } : {| sessionUID : string, fallbackWin : ?CrossDomainWindowType |}) => {
+    const detectWebSwitch = once((fallbackWin : ?CrossDomainWindowType) => {
         getLogger().info(`native_detect_web_switch`).track({
             [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_DETECT_WEB_SWITCH
         }).flush();
-
-        connectNative({ sessionUID }).close();
 
         return fallbackToWebCheckout(fallbackWin);
     });
@@ -484,13 +482,6 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
         const validatePromise = validate();
         const delayPromise = ZalgoPromise.delay(500);
 
-        const detectWebSwitchListener = listen(nativeWin, getNativeDomain(), POST_MESSAGE.DETECT_WEB_SWITCH, () => {
-            getLogger().info(`native_post_message_detect_web_switch`).flush();
-            return detectWebSwitch({ sessionUID, nativeWin }).then(unresolvedPromise);
-        });
-
-        clean.register(detectWebSwitchListener.cancel);
-
         return validatePromise.then(valid => {
             if (!valid) {
                 return delayPromise.then(() => {
@@ -506,7 +497,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
                 if (didAppSwitch(nativeWin)) {
                     return detectAppSwitch({ sessionUID });
                 } else if (nativeWin) {
-                    return detectWebSwitch({ sessionUID, nativeWin });
+                    return detectWebSwitch(nativeWin);
                 } else {
                     throw new Error(`No window found`);
                 }
@@ -595,7 +586,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
 
         const detectWebSwitchListener = listen(popupWin, getNativeDomain(), POST_MESSAGE.DETECT_WEB_SWITCH, () => {
             getLogger().info(`native_post_message_detect_web_switch`).flush();
-            return detectWebSwitch({ sessionUID, popupWin });
+            return detectWebSwitch(popupWin);
         });
 
         clean.register(awaitRedirectListener.cancel);


### PR DESCRIPTION
Android app switching logs are present after web switching and causing the Android to hang waiting for props from Firebase.  This PR proposes that we send a close message to native when web switching to ensure a better user experience by letting the app know it needs to close.