### PR TITLE
Fix memoize functionality for onApprove callback

### DIFF
--- a/src/payment-flows/checkout.js
+++ b/src/payment-flows/checkout.js
@@ -325,10 +325,7 @@ function initCheckout({ props, components, serviceData, payment, config } : Init
 
                 // eslint-disable-next-line no-use-before-define
                 return close().then(() => {
-                    const restart = memoize(() : ZalgoPromise<void> =>
-                        initCheckout({ props, components, serviceData, config, payment: { button, fundingSource, card, buyerIntent, isClick: false } })
-                            .start().finally(unresolvedPromise));
-
+                    // eslint-disable-next-line no-use-before-define
                     return onApprove({ payerID, paymentID, billingToken, subscriptionID, buyerAccessToken, authCode }, { restart }).catch(noop);
                 });
             },
@@ -394,6 +391,11 @@ function initCheckout({ props, components, serviceData, payment, config } : Init
                 throw err;
             }
         });
+    });
+
+    const restart = memoize(() : ZalgoPromise<void> => {
+        return initCheckout({ props, components, serviceData, config, payment: { button, fundingSource, card, buyerIntent, isClick: false } })
+            .start().finally(unresolvedPromise);
     });
 
     const click = () => {


### PR DESCRIPTION
This PR passes in a reference to the `restart` function to fix memoizing the `onApprove` callback.


### Additional Info

We have been troubleshooting why memoize isn't working with the `onApprove` callback. We are thinking it's related to the `restart` function getting declared on every `onApprove` call which makes it's the arguments unique and breaks the memoization. 

We haven't been able to test this locally yet which is why I made it a draft PR.