### PR TITLE
Add support for negative testing

### DIFF
--- a/src/api/order.js
+++ b/src/api/order.js
@@ -42,7 +42,6 @@ type OrderAPIOptions = {|
     forceRestAPI? : boolean
 |};
 
-
 export function createOrderID(order : OrderCreateRequest, { facilitatorAccessToken, partnerAttributionID } : OrderAPIOptions) : ZalgoPromise<string> {
     getLogger().info(`rest_api_create_order_id`);
 
@@ -50,9 +49,8 @@ export function createOrderID(order : OrderCreateRequest, { facilitatorAccessTok
 
     if (order.mockErrorCode) {
         headers[HEADERS.PAYPAL_MOCK_RESPONSE] = `{"mock_application_codes": "${ order.mockErrorCode }"}`;
+        delete order.mockErrorCode;
     }
-
-    delete order.mockErrorCode;
 
     return callRestAPI({
         accessToken: facilitatorAccessToken,

--- a/src/constants.js
+++ b/src/constants.js
@@ -22,7 +22,9 @@ export const HEADERS = {
 
     PARTNER_ATTRIBUTION_ID: 'paypal-partner-attribution-id',
     CLIENT_METADATA_ID:     'paypal-client-metadata-id',
-    PAYPAL_DEBUG_ID:        'paypal-debug-id'
+    PAYPAL_DEBUG_ID:        'paypal-debug-id',
+
+    PAYPAL_MOCK_RESPONSE:    'paypal-mock-response'
 };
 
 export const DATA_ATTRIBUTES = {

--- a/src/props/onApprove.js
+++ b/src/props/onApprove.js
@@ -79,12 +79,16 @@ function buildOrderActions({ intent, orderID, restart, facilitatorAccessToken, b
         return getOrder(orderID, { facilitatorAccessToken, buyerAccessToken, partnerAttributionID, forceRestAPI });
     });
 
-    const capture = memoize(() => {
+    const capture = memoize((data) => {
+        const order : Object = { ...data };
+
+        order.orderID = orderID;
+
         if (intent !== INTENT.CAPTURE) {
             throw new Error(`Use ${ SDK_QUERY_KEYS.INTENT }=${ INTENT.CAPTURE } to use client-side capture`);
         }
 
-        return captureOrder(orderID, { facilitatorAccessToken, buyerAccessToken, partnerAttributionID, forceRestAPI })
+        return captureOrder(order, { facilitatorAccessToken, buyerAccessToken, partnerAttributionID, forceRestAPI })
             .finally(get.reset)
             .finally(capture.reset)
             .catch(handleProcessorError);


### PR DESCRIPTION
## What
This PR utilizes the `PayPal-Mock-Response` header (documented [here](https://developer.paypal.com/docs/api-basics/sandbox/request-headers/)) to allow merchants to pass in error codes with actions to invoke negative responses.

```
createOrder: function(data, actions) {
                return actions.order.create({
                   mockErrorCode: "AMOUNT_MISMATCH",
                    purchase_units: [{
                        amount: {
                            value: '1.00'
                        }
                    }]
                });
            }
```
```
onApprove: function(data, actions) {
                return actions.order.capture({
                    mockErrorCode: "INSTRUMENT_DECLINED"
                  }).then(function(details) {
                    alert('Transaction completed by ' + details.payer.name.given_name + '!');
                });
            }
```
## Why
Negative testing on the server with request headers is possible, but is inconvenient is not comprehensive with the current docs. Merchants want to be able to easily test out negative responses on the client.

## Steps to reproduce
1. Full local sdk setup
3. Add a valid `mockErrorCode` in the `actions.order.create()`and click on a button
2. In the network tab look for the `orders` request and confirm the `paypal-mock-response: {"mock_application_codes": "APPROPRIATE_ERROR_CODE"}` header is being passed

## Important notes
- The mocking component is not enabled in stage and is a blocker to test this locally end to end. Instead this has been tested with a combination of confirming the header is being passed correctly locally and by confirming in sandbox with a resend request in FireFox, adding in the header manually, and seeing a negative response (422).
<img width="1469" alt="Screen Shot 2020-11-09 at 3 30 10 PM" src="https://user-images.githubusercontent.com/40329316/99562046-433b0100-298d-11eb-8b9b-0b4f635b08ff.png">

- The current `sync-browser-mocks` library does not support mocking by request header, and therefore is blocking adding tests.