### PR TITLE
fix/opener

### DIFF
--- a/src/payment-flows/native.js
+++ b/src/payment-flows/native.js
@@ -496,6 +496,10 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
         const nativeUrl = getNativeUrlForAndroid({ sessionUID });
 
         const nativeWin = popup(nativeUrl);
+        window.addEventListener('unload', () => {
+            nativeWin.close();
+        });
+        
         getLogger()
             .info(`native_attempt_appswitch_popup_shown`, { url: nativeUrl })
             .info(`native_attempt_appswitch_url_popup`, { url: nativeUrl })
@@ -546,6 +550,10 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
 
     const initPopupAppSwitch = ({ sessionUID } : {| sessionUID : string |}) => {
         const popupWin = popup(getNativePopupUrl({ sessionUID }));
+        window.addEventListener('unload', () => {
+            popupWin.close();
+        });
+
         getLogger().info(`native_attempt_appswitch_popup_shown`)
             .track({
                 [FPTI_KEY.STATE]:      FPTI_STATE.BUTTON,


### PR DESCRIPTION
### Why is this change required?
- native popup doesn't close if merchant redirects after completing PayPal Checkout

### Steps to Replicate
1. Opt-in to Native Checkout Testing
2. Visit bedbathandbeyond.com
3. Add item to cart
4. Go to cart page
5. Tap PayPal Button
6. App switch to PayPal App
7. See Native Pay Sheet
8. Tap Continue
9. Return to bedbathandbeyond.com
10. Tap Bed Bath & Beyond logo, returning you to cart page
11. Tap Cart Button
12. Tap PayPal Button a 2nd time
13. Merchant reuses previous approval and takes user directly to confirmation change even as SPB attempts to app switch.
14. On iOS, history.paypal.com hangs endlessly, on Android the Consumer App opens and shows an endless spinner. Both should should close automatically like popups do for control users.

More discussion here: https://github.paypal.com/Checkout-R/smartcomponentnodeweb/pull/154