### PR TITLE
Add domain and clientID to native url for app switch

### DIFF
--- a/src/api/eligibility.js
+++ b/src/api/eligibility.js
@@ -85,7 +85,8 @@ type NativeEligibilityOptions = {|
     cookies : string,
     orderID? : ?string,
     enableFunding : ?$ReadOnlyArray<$Values<typeof FUNDING>>,
-    stickinessID : string
+    stickinessID : string,
+    domain : string
 |};
 
 export type NativeEligibility = {|
@@ -95,9 +96,9 @@ export type NativeEligibility = {|
     |}
 |};
 
-export function getNativeEligibility({ vault, shippingCallbackEnabled, merchantID, clientID, buyerCountry, currency, buttonSessionID, cookies, orderID, enableFunding, stickinessID } : NativeEligibilityOptions) : ZalgoPromise<NativeEligibility> {
+export function getNativeEligibility({ vault, shippingCallbackEnabled, merchantID, clientID, buyerCountry, currency, buttonSessionID, cookies, orderID, enableFunding, stickinessID, domain } : NativeEligibilityOptions) : ZalgoPromise<NativeEligibility> {
     const userAgent = getUserAgent();
-    
+
     return callGraphQL({
         name:  'GetNativeEligibility',
         query: `
@@ -113,7 +114,8 @@ export function getNativeEligibility({ vault, shippingCallbackEnabled, merchantI
                 $cookies : String,
                 $orderID : String,
                 $enableFunding : [String],
-                $stickinessID : String
+                $stickinessID : String,
+                $domain : String
             ) {
                 mobileSDKEligibility(
                     vault: $vault,
@@ -127,7 +129,8 @@ export function getNativeEligibility({ vault, shippingCallbackEnabled, merchantI
                     cookies: $cookies,
                     token: $orderID,
                     enableFunding: $enableFunding,
-                    stickinessID: $stickinessID
+                    stickinessID: $stickinessID,
+                    domain: $domain
                 ) {
                     paypal {
                         eligibility
@@ -143,7 +146,7 @@ export function getNativeEligibility({ vault, shippingCallbackEnabled, merchantI
         variables: {
             vault, shippingCallbackEnabled, merchantID, clientID,
             buyerCountry, currency, userAgent, buttonSessionID,
-            cookies, orderID, enableFunding, stickinessID
+            cookies, orderID, enableFunding, stickinessID, domain
         }
     }).then((gqlResult) => {
         if (!gqlResult || !gqlResult.mobileSDKEligibility) {

--- a/src/payment-flows/native.js
+++ b/src/payment-flows/native.js
@@ -390,7 +390,7 @@ export function extendUrlWithPartialEncoding(url : string, options : {| query? :
 function initNative({ props, components, config, payment, serviceData } : InitOptions) : PaymentFlowInstance {
     const { createOrder, onApprove, onCancel, onError, commit, clientID, sessionID, sdkCorrelationID,
         buttonSessionID, env, stageHost, apiStageHost, onClick, onShippingChange, vault, platform,
-        currency, stickinessID, enableFunding } = props;
+        currency, stickinessID, enableFunding, merchantDomain } = props;
     let { facilitatorAccessToken, sdkMeta, buyerCountry, merchantID, cookies } = serviceData;
     const { fundingSource } = payment;
     const { sdkVersion, firebase: firebaseConfig } = config;
@@ -473,9 +473,10 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
     const getDirectNativeUrl = memoize(({ pageUrl = initialPageUrl, sessionUID } = {}) : string => {
         return conditionalExtendUrl(`${ getNativeDomain() }${ NATIVE_CHECKOUT_URI[fundingSource] }`, {
             query: {
-                sdkMeta, fundingSource, sessionUID, buttonSessionID, pageUrl,
+                sdkMeta, fundingSource, sessionUID, buttonSessionID, pageUrl, clientID,
                 stickinessID:  finalStickinessID,
-                enableFunding: enableFunding.join(',')
+                enableFunding: enableFunding.join(','),
+                domain:        merchantDomain
             }
         });
     });

--- a/src/payment-flows/native.js
+++ b/src/payment-flows/native.js
@@ -492,6 +492,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
             orderID,
             facilitatorAccessToken,
             pageUrl,
+            clientID,
             commit:         String(commit),
             webCheckoutUrl: isIOSSafari() ? webCheckoutUrl : '',
             stickinessID:   finalStickinessID,
@@ -502,7 +503,8 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
             apiStageHost:   apiStageHost || '',
             forceEligible,
             fundingSource,
-            enableFunding:  enableFunding.join(',')
+            enableFunding:  enableFunding.join(','),
+            domain:         merchantDomain
         };
     };
 

--- a/src/payment-flows/native.js
+++ b/src/payment-flows/native.js
@@ -252,7 +252,7 @@ function isNativePaymentEligible({ payment, props } : IsPaymentEligibleOptions) 
 function setupNative({ props, serviceData } : SetupOptions) : ZalgoPromise<void> {
     return ZalgoPromise.try(() => {
         const { getPageUrl, clientID, onShippingChange, currency, platform,
-            vault, buttonSessionID, enableFunding, env, stickinessID } = props;
+            vault, buttonSessionID, enableFunding, env, stickinessID, merchantDomain } = props;
         const { merchantID, buyerCountry, cookies } = serviceData;
 
         const finalStickinessID = (env !== ENV.PRODUCTION) ? stickinessID : buttonSessionID;
@@ -260,8 +260,11 @@ function setupNative({ props, serviceData } : SetupOptions) : ZalgoPromise<void>
         const shippingCallbackEnabled = Boolean(onShippingChange);
 
         return ZalgoPromise.all([
-            getNativeEligibility({ vault, platform, shippingCallbackEnabled, merchantID:   merchantID[0],
-                clientID, buyerCountry, currency, buttonSessionID, cookies, enableFunding, stickinessID: finalStickinessID
+            getNativeEligibility({
+                vault, platform, shippingCallbackEnabled, clientID, buyerCountry, currency, buttonSessionID, cookies, enableFunding,
+                merchantID:   merchantID[0],
+                stickinessID: finalStickinessID,
+                domain:       merchantDomain
             }).then(result => {
                 nativeEligibility = result;
             }),
@@ -883,7 +886,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
             closeListener.cancel();
             popupWin.close();
         };
-        
+
         window.addEventListener('pagehide', closePopup);
         window.addEventListener('unload', closePopup);
 
@@ -912,8 +915,11 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
             }
 
             return createOrder().then(orderID => {
-                return getNativeEligibility({ vault, platform, shippingCallbackEnabled, merchantID:   merchantID[0],
-                    clientID, buyerCountry, currency, buttonSessionID, cookies, orderID, enableFunding, stickinessID: finalStickinessID
+                return getNativeEligibility({ vault, platform, shippingCallbackEnabled,
+                    clientID, buyerCountry, currency, buttonSessionID, cookies, orderID, enableFunding,
+                    merchantID:   merchantID[0],
+                    stickinessID: finalStickinessID,
+                    domain:       merchantDomain
                 }).then(eligibility => {
                     if (!eligibility || !eligibility[fundingSource] || !eligibility[fundingSource].eligibility) {
                         getLogger().info(`native_appswitch_ineligible`, { orderID })


### PR DESCRIPTION
This PR adds domain and clientID to the native url. It also adds domain to the nativeEligibility graphql calls.