### PR TITLE
fix/shippingCallback

### DIFF
--- a/src/payment-flows/native.js
+++ b/src/payment-flows/native.js
@@ -928,10 +928,13 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
             }
 
             return createOrder().then(orderID => {
-                return getNativeEligibility({ vault, platform, shippingCallbackEnabled,
+                const shippingCallback = shippingCallbackEnabled || window.xprops.onShippingChange;
+
+                return getNativeEligibility({ vault, platform,
                     clientID, buyerCountry, currency, buttonSessionID, cookies, orderID, enableFunding, stickinessID,
-                    merchantID:   merchantID[0],
-                    domain:       merchantDomain
+                    merchantID:              merchantID[0],
+                    domain:                  merchantDomain,
+                    shippingCallbackEnabled: shippingCallback
                 }).then(eligibility => {
                     if (!eligibility || !eligibility[fundingSource] || !eligibility[fundingSource].eligibility) {
                         getLogger().info(`native_appswitch_ineligible`, { orderID })


### PR DESCRIPTION
`onShippingChange` is undefined when SPB is initialized and setup through gap.com.  We find that it is set after full load in `xprops`.  

Is there a reason why it's undefined for this merchant?
Do we want to use this fix as a short term solution until we find the root cause of why it is undefined?