### PR TITLE
Fix app switch log

### DIFF
--- a/src/native/popup/popup.js
+++ b/src/native/popup/popup.js
@@ -274,7 +274,7 @@ export function setupNativePopup({ parentDomain, env, sessionID, buttonSessionID
                     if (!didRedirect) {
                         sendToParent(MESSAGE.DETECT_APP_SWITCH);
                     }
-                }, 900);
+                }, 1500);
                 clean.register(() => clearTimeout(timer));
             }
         });

--- a/src/native/popup/popup.js
+++ b/src/native/popup/popup.js
@@ -274,7 +274,7 @@ export function setupNativePopup({ parentDomain, env, sessionID, buttonSessionID
                     if (!didRedirect) {
                         sendToParent(MESSAGE.DETECT_APP_SWITCH);
                     }
-                }, 500);
+                }, 900);
                 clean.register(() => clearTimeout(timer));
             }
         });

--- a/src/payment-flows/native.js
+++ b/src/payment-flows/native.js
@@ -105,7 +105,7 @@ const getNativeSocket = memoize(({ sessionUID, firebaseConfig, version } : Nativ
     });
     nativeSocket.onError(err => {
         const stringifiedError = stringifyError(err);
-        if (stringifiedError.indexOf('permission_denied') === -1) {
+        if (stringifiedError && stringifiedError.toLowerCase().indexOf('permission_denied') === -1) {
             getLogger().error('native_socket_error', { err: stringifiedError })
                 .track({
                     [FPTI_KEY.STATE]:           FPTI_STATE.BUTTON,

--- a/test/client/nativePopup.js
+++ b/test/client/nativePopup.js
@@ -63,7 +63,7 @@ describe('Native popup cases', () => {
                                     throw new Error(`Expected native popup to be available`);
                                 }
 
-                                return ZalgoPromise.delay(500).then(expect('appSwitchDetector', () => {
+                                return ZalgoPromise.delay(1500).then(expect('appSwitchDetector', () => {
                                     if (!detectedAppSwitch) {
                                         throw new Error(`Expected app switch to be detected`);
                                     }
@@ -223,7 +223,7 @@ describe('Native popup cases', () => {
                                     throw new Error(`Expected native popup to be available`);
                                 }
 
-                                return ZalgoPromise.delay(500).then(expect('appSwitchDetector', () => {
+                                return ZalgoPromise.delay(1500).then(expect('appSwitchDetector', () => {
                                     if (!detectedAppSwitch) {
                                         throw new Error(`Expected app switch to be detected`);
                                     }
@@ -335,7 +335,7 @@ describe('Native popup cases', () => {
                                     throw new Error(`Expected native popup to be available`);
                                 }
 
-                                return ZalgoPromise.delay(500).then(expect('appSwitchDetector', () => {
+                                return ZalgoPromise.delay(1500).then(expect('appSwitchDetector', () => {
                                     if (!detectedAppSwitch) {
                                         throw new Error(`Expected app switch to be detected`);
                                     }
@@ -431,7 +431,7 @@ describe('Native popup cases', () => {
                                     throw new Error(`Expected native popup to be available`);
                                 }
 
-                                return ZalgoPromise.delay(500).then(expect('appSwitchDetector', () => {
+                                return ZalgoPromise.delay(1500).then(expect('appSwitchDetector', () => {
                                     if (!detectedAppSwitch) {
                                         throw new Error(`Expected app switch to be detected`);
                                     }
@@ -536,7 +536,7 @@ describe('Native popup cases', () => {
                                     throw new Error(`Expected native popup to be available`);
                                 }
 
-                                return ZalgoPromise.delay(500).then(expect('appSwitchDetector', () => {
+                                return ZalgoPromise.delay(1500).then(expect('appSwitchDetector', () => {
                                     if (!detectedAppSwitch) {
                                         throw new Error(`Expected app switch to be detected`);
                                     }
@@ -632,7 +632,7 @@ describe('Native popup cases', () => {
                                     throw new Error(`Expected native popup to be available`);
                                 }
 
-                                return ZalgoPromise.delay(500).then(expect('appSwitchDetector', () => {
+                                return ZalgoPromise.delay(1500).then(expect('appSwitchDetector', () => {
                                     if (!detectedAppSwitch) {
                                         throw new Error(`Expected app switch to be detected`);
                                     }


### PR DESCRIPTION
Still seeing app and web switch in same session due to 500ms timeout not being long enough.  Increasing to ensure web switch only shows in session for customers not having the app.  It took a little over 1s from `#appSwitch` and `pagehide`, therefore, setting the timeout to 1500ms.  This only initiates the Firebase flow, which we don't use, by sending props so will not affect performance.  This will ensure our dashboard is more accurate with regards to top of funnel dropoff.

[FPTI Log:](https://engineering.paypalcorp.com/searchserv-dashboard/fpti-2/app/kibana#/discover?_g=(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:'2021-02-28T05:00:00.000Z',mode:absolute,to:'2021-03-01T04:59:59.999Z'))&_a=(columns:!(transition_name,info_msg,int_error_desc,ext_error_desc,t),filters:!(('$state':(store:appState),meta:(alias:!n,disabled:!t,index:fb82ffb0-c18c-11ea-83a1-9d42b3bd3651,key:sdk_environment,negate:!f,params:(query:iOS,type:phrase),type:phrase,value:iOS),query:(match:(sdk_environment:(query:iOS,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!t,index:fb82ffb0-c18c-11ea-83a1-9d42b3bd3651,key:web_fragment,negate:!f,params:(query:%23onApprove,type:phrase),type:phrase,value:%23onApprove),query:(match:(web_fragment:(query:%23onApprove,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:fb82ffb0-c18c-11ea-83a1-9d42b3bd3651,key:os,negate:!f,params:(query:iOS,type:phrase),type:phrase,value:iOS),query:(match:(os:(query:iOS,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!t,index:fb82ffb0-c18c-11ea-83a1-9d42b3bd3651,key:ext_error_code,negate:!f,params:(query:smart_buttons_payment_error,type:phrase),type:phrase,value:smart_buttons_payment_error),query:(match:(ext_error_code:(query:smart_buttons_payment_error,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!t,index:fb82ffb0-c18c-11ea-83a1-9d42b3bd3651,key:transition_name,negate:!f,params:(query:native_app_switch_ack,type:phrase),type:phrase,value:native_app_switch_ack),query:(match:(transition_name:(query:native_app_switch_ack,type:phrase)))),('$state':(store:appState),meta:(alias:!n,disabled:!f,index:fb82ffb0-c18c-11ea-83a1-9d42b3bd3651,key:context_id,negate:!f,params:!('50cbdf166f_mtc6nde6mtc',EC-8XA53014JY7270941),type:phrases,value:'50cbdf166f_mtc6nde6mtc,+EC-8XA53014JY7270941'),query:(bool:(minimum_should_match:1,should:!((match_phrase:(context_id:'50cbdf166f_mtc6nde6mtc')),(match_phrase:(context_id:EC-8XA53014JY7270941))))))),index:fb82ffb0-c18c-11ea-83a1-9d42b3bd3651,interval:auto,query:(language:kuery,query:''),sort:!(ts_buffer_in,desc)))