### PR TITLE
[Native] - iOS Back to Browser

### DIFF
--- a/src/native/popup/constants.js
+++ b/src/native/popup/constants.js
@@ -5,6 +5,7 @@ export const MESSAGE = {
     DETECT_APP_SWITCH:  'detectAppSwitch',
     ON_APPROVE:         'onApprove',
     ON_CANCEL:          'onCancel',
+    ON_FALLBACK:        'onFallback',
     ON_COMPLETE:        'onComplete',
     ON_ERROR:           'onError'
 };

--- a/src/native/popup/constants.js
+++ b/src/native/popup/constants.js
@@ -24,6 +24,7 @@ export const HASH = {
     FALLBACK:           'fallback',
     ON_APPROVE:         'onApprove',
     ON_CANCEL:          'onCancel',
+    ON_FALLBACK:        'fallback',
     ON_ERROR:           'onError',
     TEST:               'test'
 };

--- a/src/native/popup/popup.js
+++ b/src/native/popup/popup.js
@@ -245,6 +245,10 @@ export function setupNativePopup({ parentDomain, env, sessionID, buttonSessionID
             sendToParent(MESSAGE.ON_CANCEL).finally(closeWindow);
             break;
         }
+        case HASH.ON_FALLBACK: {
+            sendToParent(MESSAGE.ON_FALLBACK);
+            break;
+        }
         case HASH.ON_ERROR: {
             const { message } = parseQuery(queryString);
             sendToParent(MESSAGE.ON_ERROR, { message }).finally(closeWindow);

--- a/src/payment-flows/native.js
+++ b/src/payment-flows/native.js
@@ -29,6 +29,7 @@ const POST_MESSAGE = {
     DETECT_WEB_SWITCH:  'detectWebSwitch',
     ON_APPROVE:         'onApprove',
     ON_CANCEL:          'onCancel',
+    ON_FALLBACK:        'onFallback',
     ON_COMPLETE:        'onComplete',
     ON_ERROR:           'onError'
 };
@@ -1088,6 +1089,14 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
             closePopup('onCancel');
         });
 
+        const onFallbackListener = listen(popupWin, getNativePopupDomain(), POST_MESSAGE.ON_FALLBACK, () => {
+            getLogger().info(`native_message_onfallback`)
+                .track({
+                    [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_ON_FALLBACK
+                }).flush();
+            fallbackToWebCheckout(popupWin);
+        });
+
         const onCompleteListener = listen(popupWin, getNativePopupDomain(), POST_MESSAGE.ON_COMPLETE, () => {
             getLogger().info(`native_post_message_on_complete`)
                 .track({
@@ -1111,6 +1120,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
         clean.register(detectAppSwitchListener.cancel);
         clean.register(onApproveListener.cancel);
         clean.register(onCancelListener.cancel);
+        clean.register(onFallbackListener.cancel);
         clean.register(onCompleteListener.cancel);
         clean.register(onErrorListener.cancel);
         clean.register(detectWebSwitchListener.cancel);

--- a/test/client/nativePopup.js
+++ b/test/client/nativePopup.js
@@ -430,12 +430,12 @@ describe('Native popup cases', () => {
                                     throw new Error(`Expected native popup to be available`);
                                 }
 
+                                window.location.hash = 'fallback';
+
                                 return ZalgoPromise.delay(1500).then(expect('appSwitchDetector', () => {
                                     if (!detectedAppSwitch) {
                                         throw new Error(`Expected app switch to be detected`);
                                     }
-
-                                    window.location.hash = `fallback`;
 
                                     return ZalgoPromise.delay(50).then(expect('detectOnApprove', () => {
                                         if (!fallbackCalled) {
@@ -465,7 +465,7 @@ describe('Native popup cases', () => {
                             });
                         }
 
-                        if (event === 'fallback') {
+                        if (event === 'onFallback') {
                             fallbackCalled = true;
                             return ZalgoPromise.resolve({
                                 source: window,

--- a/test/client/nativePopup.js
+++ b/test/client/nativePopup.js
@@ -431,13 +431,19 @@ describe('Native popup cases', () => {
                                 }
 
                                 return ZalgoPromise.delay(1500).then(expect('appSwitchDetector', () => {
-                                    if (!fallbackCalled) {
-                                        throw new Error(`Expected fallback to be called`);
+                                    if (!detectedAppSwitch) {
+                                        throw new Error(`Expected app switch to be detected`);
                                     }
 
                                     window.location.hash = `fallback`;
 
-                                    return nativePopup.destroy();
+                                    return ZalgoPromise.delay(50).then(expect('detectOnApprove', () => {
+                                        if (!fallbackCalled) {
+                                            throw new Error(`Expected fallback to be called`);
+                                        }
+
+                                        return nativePopup.destroy();
+                                    }));
                                 }));
                             }));
 

--- a/test/client/nativePopup.js
+++ b/test/client/nativePopup.js
@@ -388,6 +388,101 @@ describe('Native popup cases', () => {
         });
     });
 
+    it('should open the native popup and await a url to redirect to, then redirect and detect an app switch, then return with fallback', () => {
+        return wrapPromise(({ expect }) => {
+            const opener = {};
+            const parentDomain = 'foo.paypal.com';
+            const nativeRedirectUrl = '#test';
+            let detectedAppSwitch = false;
+            let fallbackCalled = false;
+
+            window.opener = opener;
+
+            // eslint-disable-next-line prefer-const
+            let nativePopup;
+
+            window.paypal = {
+                postRobot: {
+                    send: expect('postRobotSend', (win, event, payload, opts) => {
+                        if (win !== opener) {
+                            throw new Error(`Expected message to be sent to parent`);
+                        }
+
+                        if (!opts || opts.domain !== parentDomain) {
+                            throw new Error(`Expected message to be sent to ${ parentDomain }, got ${ opts ? opts.domain : 'undefined' }`);
+                        }
+
+                        if (!event) {
+                            throw new Error(`Expected event to be passed`);
+                        }
+
+                        if (event === 'awaitRedirect') {
+                            if (!payload || !payload.pageUrl || !payload.pageUrl === `${ window.location.href }#close`) {
+                                throw new Error(`Expected payload.pageUrl to be ${ window.location.href }#close, got ${ payload ? payload.pageUrl : 'undefined' }`);
+                            }
+
+                            ZalgoPromise.delay(50).then(expect('postRedirect', () => {
+                                if (window.location.hash !== nativeRedirectUrl) {
+                                    throw new Error(`Expected page to have redirected to ${ nativeRedirectUrl }, got ${ window.location.hash }`);
+                                }
+
+                                if (!nativePopup) {
+                                    throw new Error(`Expected native popup to be available`);
+                                }
+
+                                return ZalgoPromise.delay(1500).then(expect('appSwitchDetector', () => {
+                                    if (!detectedAppSwitch) {
+                                        throw new Error(`Expected app switch to be detected`);
+                                    }
+
+                                    window.location.hash = `fallback`;
+
+                                    return ZalgoPromise.delay(50).then(expect('detectOnApprove', () => {
+                                        if (!fallbackCalled) {
+                                            throw new Error(`Expected fallback to be called`);
+                                        }
+
+                                        return nativePopup.destroy();
+                                    }));
+                                }));
+                            }));
+
+                            return ZalgoPromise.resolve({
+                                source: window,
+                                origin: window.location.origin,
+                                data:   {
+                                    redirectUrl: nativeRedirectUrl
+                                }
+                            });
+                        }
+
+                        if (event === 'detectAppSwitch') {
+                            detectedAppSwitch = true;
+                            return ZalgoPromise.resolve({
+                                source: window,
+                                origin: window.location.origin,
+                                data:   null
+                            });
+                        }
+
+                        if (event === 'fallback') {
+                            fallbackCalled = true;
+                            return ZalgoPromise.resolve({
+                                source: window,
+                                origin: window.location.origin,
+                                data:   null
+                            });
+                        }
+
+                        throw new Error(`Unrecognized event: ${ event }`);
+                    })
+                }
+            };
+
+            nativePopup = setupNativePopup({ parentDomain, env, sessionID, buttonSessionID, sdkCorrelationID, clientID, fundingSource, locale });
+        });
+    });
+
     it('should open the native popup and await a url to redirect to, then redirect and detect an app switch, then return with onError', () => {
         return wrapPromise(({ expect }) => {
             const opener = {};

--- a/test/client/nativePopup.js
+++ b/test/client/nativePopup.js
@@ -431,19 +431,13 @@ describe('Native popup cases', () => {
                                 }
 
                                 return ZalgoPromise.delay(1500).then(expect('appSwitchDetector', () => {
-                                    if (!detectedAppSwitch) {
-                                        throw new Error(`Expected app switch to be detected`);
+                                    if (!fallbackCalled) {
+                                        throw new Error(`Expected fallback to be called`);
                                     }
 
                                     window.location.hash = `fallback`;
 
-                                    return ZalgoPromise.delay(50).then(expect('detectOnApprove', () => {
-                                        if (!fallbackCalled) {
-                                            throw new Error(`Expected fallback to be called`);
-                                        }
-
-                                        return nativePopup.destroy();
-                                    }));
+                                    return nativePopup.destroy();
                                 }));
                             }));
 


### PR DESCRIPTION
## PR Details

This pull request adds handling in the case where we have app switched over to Native for iOS, encountered an issue and fall back to Safari Browser.

## Details

#### Mechanisms

**onFallbackListener**

We needed to define another `#` hash listener which will listen to a url containing the `#fallback` fragment. This will then reuse our existing `popupWindow` and redirect to a checkout experience in Safari browser.

```javascript
const onFallbackListener = listen(popupWin, getNativePopupDomain(), POST_MESSAGE.ON_FALLBACK, () => {
    getLogger().info(`native_message_onfallback`)
        .track({
            [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_ON_FALLBACK
        }).flush();
    fallbackToWebCheckout(popupWin);
});
```

The above is called from `popup.js` where we listen to a redirect.

**popup.js**

```javascript
case HASH.ON_FALLBACK: {
    sendToParent(MESSAGE.ON_FALLBACK);
    break;
}
```

## Testing

Tested locally with an end to end experience.