### PR TITLE
Revert "Providing alternative lookup for intent (#105)"

### DIFF
--- a/src/api/order.js
+++ b/src/api/order.js
@@ -449,9 +449,6 @@ type SupplementalOrderInfo = {|
                     currencyValue : string,
                     currencyCode : string
                 |}
-            |},
-            supplementary? : {|
-                initiationIntent? : string
             |}
         |},
         buyer? : {|
@@ -490,9 +487,6 @@ export const getSupplementalOrderInfo : GetSupplementalOrderInfo = memoize(order
                                 currencyValue
                             }
                         }
-                    }
-                    supplementary {
-                        initiationIntent
                     }
                     flags {
                         isChangeShippingAddressAllowed

--- a/src/button/validation.js
+++ b/src/button/validation.js
@@ -155,18 +155,16 @@ const VALIDATE_INTENTS = [
 
 export function validateOrder(orderID : string, { env, clientID, merchantID, currency, intent, vault } : OrderValidateOptions) : ZalgoPromise<void> {
     const logger = getLogger();
-
+    
     // eslint-disable-next-line complexity
     return getSupplementalOrderInfo(orderID).then(order => {
         const cart = order.checkoutSession.cart;
         const cartIntent = (cart.intent.toLowerCase() === 'sale') ? INTENT.CAPTURE : cart.intent.toLowerCase();
-        const initiationIntent = cart.supplementary && cart.supplementary.initiationIntent;
         const cartCurrency = cart.amounts && cart.amounts.total.currencyCode;
         const cartAmount = cart.amounts && cart.amounts.total.currencyValue;
         const cartBillingType = cart.billingType;
-        const intentMatch = (cartIntent === intent) || (initiationIntent === intent);
 
-        if (!intentMatch && VALIDATE_INTENTS.indexOf(intent) !== -1) {
+        if (cartIntent !== intent && VALIDATE_INTENTS.indexOf(intent) !== -1) {
             triggerIntegrationError({
                 error:         'smart_button_validation_error_incorrect_intent',
                 message:       `Expected intent from order api call to be ${ intent }, got ${ cartIntent }. Please ensure you are passing ${ SDK_QUERY_KEYS.INTENT }=${ cartIntent } to the sdk url. https://developer.paypal.com/docs/checkout/reference/customize-sdk/`,
@@ -289,7 +287,7 @@ export function validateOrder(orderID : string, { env, clientID, merchantID, cur
         const xpropMerchantID = window.xprops.merchantID;
 
         if (xpropMerchantID && xpropMerchantID.length) {
-
+            
             // Validate merchant-id value(s) passed explicitly to SDK
             if (!isValidMerchantIDs(xpropMerchantID, uniquePayees)) {
                 if (uniquePayees.length === 1) {


### PR DESCRIPTION
PR #105 was recently merged which depends on some back-end changes. There seems to be an issue with those changes so let's revert this to unblock. 

Here's a screenshot of the error folks have been reporting in local development:

![image](https://user-images.githubusercontent.com/534034/112531907-2ae15580-8d76-11eb-9424-5ee84921fd6b.png)
