### PR TITLE
Provide alternative lookup for intent v2

### DIFF
--- a/src/api/order.js
+++ b/src/api/order.js
@@ -130,7 +130,7 @@ export function authorizeOrder(orderID : string, { facilitatorAccessToken, buyer
 }
 
 type PatchData = {|
-    
+
 |};
 
 export function patchOrder(orderID : string, data : PatchData, { facilitatorAccessToken, buyerAccessToken, partnerAttributionID, forceRestAPI = false } : OrderAPIOptions) : ZalgoPromise<OrderResponse> {
@@ -449,6 +449,9 @@ type SupplementalOrderInfo = {|
                     currencyValue : string,
                     currencyCode : string
                 |}
+            |},
+            supplementary? : {|
+                initiationIntent? : string
             |}
         |},
         buyer? : {|
@@ -486,6 +489,9 @@ export const getSupplementalOrderInfo : GetSupplementalOrderInfo = memoize(order
                                 currencyFormatSymbolISOCurrency
                                 currencyValue
                             }
+                        }
+                        supplementary {
+                            initiationIntent
                         }
                     }
                     flags {


### PR DESCRIPTION
This PR adds back the alternative lookup for intent and fixes the bug with the graphql query by moving it under cart.

Previous PR: https://github.com/paypal/paypal-smart-payment-buttons/pull/105