### PR TITLE
Export intent

### DIFF
--- a/src/button/exports.js
+++ b/src/button/exports.js
@@ -23,8 +23,10 @@ export function setupExports({ props, isEnabled } : ExportsProps)  {
     
     window.exports = {
         name:           'smart-payment-buttons',
-        commit,
-        intent,
+        commit: {
+            commit,
+            intent
+        },
         paymentSession: () => {
             return {
                 getAvailableFundingSources: () => fundingSources,

--- a/src/button/exports.js
+++ b/src/button/exports.js
@@ -24,6 +24,7 @@ export function setupExports({ props, isEnabled } : ExportsProps)  {
     window.exports = {
         name:           'smart-payment-buttons',
         commit,
+        intent,
         paymentSession: () => {
             return {
                 getAvailableFundingSources: () => fundingSources,
@@ -59,8 +60,7 @@ export function setupExports({ props, isEnabled } : ExportsProps)  {
                     return onApprove(data, actions);
                 },
                 onCancel,
-                onError,
-                intent
+                onError
             };
         }
     };

--- a/src/button/exports.js
+++ b/src/button/exports.js
@@ -14,7 +14,7 @@ props : ButtonProps,
 |};
 
 export function setupExports({ props, isEnabled } : ExportsProps)  {
-    const { createOrder, onApprove, onError, onCancel, commit } = props;
+    const { createOrder, onApprove, onError, onCancel, commit, intent } = props;
     const { onClick, fundingSource } = props;
 
     const fundingSources = querySelectorAll(`[${ DATA_ATTRIBUTES.FUNDING_SOURCE }]`).map(el => {
@@ -59,7 +59,8 @@ export function setupExports({ props, isEnabled } : ExportsProps)  {
                     return onApprove(data, actions);
                 },
                 onCancel,
-                onError
+                onError,
+                intent
             };
         }
     };


### PR DESCRIPTION
Adding `intent` to window.props to support pay with nonce flow. It is included as part of `commit` object to meet time constraints