### PR TITLE
Checkout modal fixes

### DIFF
--- a/src/button/exports.js
+++ b/src/button/exports.js
@@ -14,8 +14,7 @@ props : ButtonProps,
 |};
 
 export function setupExports({ props, isEnabled } : ExportsProps)  {
-    const { createOrder, onApprove, onError, onCancel, commit, intent } = props;
-    const { onClick, fundingSource } = props;
+    const { createOrder, onApprove, onError, onCancel, commit, intent, currency } = props;
 
     const fundingSources = querySelectorAll(`[${ DATA_ATTRIBUTES.FUNDING_SOURCE }]`).map(el => {
         return el.getAttribute(DATA_ATTRIBUTES.FUNDING_SOURCE);
@@ -25,6 +24,7 @@ export function setupExports({ props, isEnabled } : ExportsProps)  {
         name:           'smart-payment-buttons',
         commit: {
             commit,
+            currency,
             intent
         },
         paymentSession: () => {

--- a/src/button/exports.js
+++ b/src/button/exports.js
@@ -14,7 +14,7 @@ props : ButtonProps,
 |};
 
 export function setupExports({ props, isEnabled } : ExportsProps)  {
-    const { createOrder, onApprove, onError, onCancel, commit, intent, currency } = props;
+    const { createOrder, onApprove, onError, onCancel, onClick, fundingSource, commit, intent, currency } = props;
 
     const fundingSources = querySelectorAll(`[${ DATA_ATTRIBUTES.FUNDING_SOURCE }]`).map(el => {
         return el.getAttribute(DATA_ATTRIBUTES.FUNDING_SOURCE);

--- a/src/button/pay.js
+++ b/src/button/pay.js
@@ -101,7 +101,7 @@ export function initiatePaymentFlow({ payment, serviceData, config, components, 
             const updateClientConfigPromise = createOrder()
                 .then(orderID => {
                     if (updateFlowClientConfig) {
-                        return updateFlowClientConfig({ orderID, payment });
+                        return updateFlowClientConfig({ orderID, payment, userExperienceFlow });
                     }
 
                     // Do not block by default

--- a/src/payment-flows/checkout.js
+++ b/src/payment-flows/checkout.js
@@ -443,10 +443,10 @@ function initCheckout({ props, components, serviceData, payment, config } : Init
     return { click, start, close };
 }
 
-function updateCheckoutClientConfig({ orderID, payment }) : ZalgoPromise<void> {
+function updateCheckoutClientConfig({ orderID, payment, userExperienceFlow }) : ZalgoPromise<void> {
     return ZalgoPromise.try(() => {
         const { buyerIntent, fundingSource } = payment;
-        const updateClientConfigPromise = updateButtonClientConfig({ fundingSource, orderID, inline: false });
+        const updateClientConfigPromise = updateButtonClientConfig({ fundingSource, orderID, inline: false, userExperienceFlow });
 
         // Block
         if (buyerIntent === BUYER_INTENT.PAY_WITH_DIFFERENT_FUNDING_SHIPPING) {

--- a/src/payment-flows/types.js
+++ b/src/payment-flows/types.js
@@ -77,7 +77,8 @@ export type MenuOptions = {|
 
 export type UpdateClientConfigOptions = {|
     orderID : string,
-    payment : Payment
+    payment : Payment,
+    userExperienceFlow? : string
 |};
 
 export type PaymentFlow = {|


### PR DESCRIPTION
* Pass `userExperienceFlow` through to `updateClientConfig` to support webhooks for pay-with-nonce
* Include `currency` in `exports` to support non-USD merchants in future