### PR TITLE
Remove Node 10 from GitHub workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [10.13, 12, 14]
+        node: [12, 14]
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v2


### PR DESCRIPTION
### Purpose

This PR removes Node 10 from GitHub workflows, since Node 10 is no longer supported.