### PR TITLE
Fix a11y iframe landmark

### DIFF
--- a/server/components/buttons/middleware.js
+++ b/server/components/buttons/middleware.js
@@ -167,7 +167,7 @@ export function getButtonMiddleware({
                 <body data-nonce="${ cspNonce }" data-client-version="${ client.version }" data-render-version="${ render.version }">
                     <style nonce="${ cspNonce }">${ buttonStyle }</style>
                     
-                    <div id="buttons-container" class="buttons-container">${ buttonHTML }</div>
+                    <div id="buttons-container" class="buttons-container" role="main">${ buttonHTML }</div>
 
                     ${ meta.getSDKLoader({ nonce: cspNonce }) }
                     <script nonce="${ cspNonce }">${ client.script }</script>

--- a/server/components/buttons/middleware.js
+++ b/server/components/buttons/middleware.js
@@ -167,7 +167,7 @@ export function getButtonMiddleware({
                 <body data-nonce="${ cspNonce }" data-client-version="${ client.version }" data-render-version="${ render.version }">
                     <style nonce="${ cspNonce }">${ buttonStyle }</style>
                     
-                    <div id="buttons-container" class="buttons-container" role="main">${ buttonHTML }</div>
+                    <div id="buttons-container" class="buttons-container" role="main" aria-label="PayPal">${ buttonHTML }</div>
 
                     ${ meta.getSDKLoader({ nonce: cspNonce }) }
                     <script nonce="${ cspNonce }">${ client.script }</script>


### PR DESCRIPTION
This PR adds `role="main` to the buttons container `<div>` to resolve an axe-core error being thrown for html landmarks. It also adds an `aria-label` so that the landmarks distinguishable from the parent.

![Screen Shot 2021-04-19 at 2 41 38 PM](https://user-images.githubusercontent.com/40329316/115293793-5f4df480-a11d-11eb-9a94-133241d5d3bd.png)
