### PR TITLE
fix(LSAT): Moving logStart() to capture test and control

### DIFF
--- a/src/props/onAuth.js
+++ b/src/props/onAuth.js
@@ -23,8 +23,9 @@ export function getOnAuth({ facilitatorAccessToken, createOrder, upgradeLSAT } :
 
         return ZalgoPromise.try(() => {
             if (accessToken) {
+                upgradeLSATExperiment.logStart();
+
                 if (upgradeLSAT) {
-                    upgradeLSATExperiment.logStart();
                     return createOrder()
                         .then(orderID => upgradeFacilitatorAccessToken(facilitatorAccessToken, { buyerAccessToken: accessToken, orderID }))
                         .then(() => {


### PR DESCRIPTION
Related to https://github.com/paypal/paypal-smart-payment-buttons/pull/115

Problem: Right now, we're not seeing test _**and**_ control logs for the LSAT experiment, only test.

@abarco recommended that we move .logStart() outside of this condition to capture control events too.