### PR TITLE
Add 'web: false' to webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,6 +19,7 @@ type SmartWebpackConfig = {|
 
 function getSmartWebpackConfig({ entry, env, filename, minify = true, debug = false, libraryTarget = 'window', modulename } : SmartWebpackConfig) : Object {
     return getWebpackConfig({
+        web:           false,
         env,
         entry:         `${ __dirname }/${ entry }`,
         modulename,


### PR DESCRIPTION
### Purpose

This PR fixes the failing CI tests by adding 'web: false' to the webpack config.