### PR TITLE
Remove flex query from paylater products

### DIFF
--- a/server/service/fundingEligibility.js
+++ b/server/service/fundingEligibility.js
@@ -75,7 +75,6 @@ function buildFundingEligibilityQuery(basicFundingEligibility : FundingEligibili
 
     const getPayLaterProductsQuery = () => {
         return {
-            flex:   getPayLaterProductQuery(),
             payIn4: getPayLaterProductQuery()
         };
     };


### PR DESCRIPTION
This PR removes the query on `flex` for pay later products. We won't be needing this key anymore and won't return it in GraphQL.