### PR TITLE
Make button render errors generate clientErrorResponse

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@paypal/common-components": "^1.0.16",
     "@paypal/installments": "^1.0.0",
     "@paypal/sdk-client": "^4.0.123",
-    "@paypal/sdk-constants": "^1.0.87",
+    "@paypal/sdk-constants": "^1.0.107",
     "@paypal/sdk-logos": "^1.0.26",
     "@paypal/sdk-release": "^5.0.138",
     "beaver-logger": "^4.0.12",

--- a/server/components/buttons/middleware.js
+++ b/server/components/buttons/middleware.js
@@ -65,13 +65,13 @@ export function getButtonMiddleware({
             for (const name of Object.keys(req.cookies || {})) {
                 logger.info(req, `smart_buttons_cookie_${ name || 'unknown' }`);
             }
-            
+
             tracking(req);
 
             const { env, clientID, buttonSessionID, cspNonce, debug, buyerCountry, disableFunding, disableCard, userIDToken, amount,
                 merchantID: sdkMerchantID, currency, intent, commit, vault, clientAccessToken, basicFundingEligibility, locale,
                 clientMetadataID, pageSessionID, correlationID, cookies, enableFunding, style, paymentMethodNonce, branded, fundingSource } = getButtonParams(params, req, res);
-            
+
             const { label, period, tagline } = style;
             logger.info(req, `button_params`, { params: JSON.stringify(params) });
 
@@ -138,7 +138,7 @@ export function getButtonMiddleware({
             const wallet = await walletPromise;
             const personalization = await personalizationPromise;
             const brandedDefault = await isFundingSourceBranded(req, { clientID, fundingSource, wallet });
-            
+
             const eligibility = {
                 cardFields: isCardFieldsExperimentEnabled
             };
@@ -155,10 +155,11 @@ export function getButtonMiddleware({
                 if (render.button.validateButtonProps) {
                     render.button.validateButtonProps(buttonProps);
                 }
+
             } catch (err) {
                 return clientErrorResponse(res, err.stack || err.message);
             }
-            
+
             const buttonHTML = render.button.Buttons(buttonProps).render(html());
 
             const setupParams = {
@@ -172,7 +173,7 @@ export function getButtonMiddleware({
                 <head></head>
                 <body data-nonce="${ cspNonce }" data-client-version="${ client.version }" data-render-version="${ render.version }">
                     <style nonce="${ cspNonce }">${ buttonStyle }</style>
-                    
+
                     <div id="buttons-container" class="buttons-container" role="main" aria-label="PayPal">${ buttonHTML }</div>
 
                     ${ meta.getSDKLoader({ nonce: cspNonce }) }

--- a/server/components/buttons/params.js
+++ b/server/components/buttons/params.js
@@ -3,10 +3,10 @@
 
 import type { FundingEligibilityType } from '@paypal/sdk-constants/src/types';
 import { ENV, COUNTRY, CURRENCY, INTENT, COMMIT, VAULT, CARD, FUNDING, DEFAULT_COUNTRY,
-    COUNTRY_LANGS, PLATFORM, FUNDING_PRODUCTS, SDK_QUERY_KEYS } from '@paypal/sdk-constants';
+    COUNTRY_LANGS, PLATFORM, FUNDING_PRODUCTS, SDK_QUERY_KEYS, ERROR_CODE } from '@paypal/sdk-constants';
 import { values, constHas } from 'belter';
 
-import { HTTP_HEADER, ERROR_CODE } from '../../config';
+import { HTTP_HEADER } from '../../config';
 import type { ExpressRequest, ExpressResponse, LocaleType, RiskData } from '../../types';
 import { makeError, getCSPNonce } from '../../lib';
 
@@ -156,11 +156,11 @@ function getFundingEligibilityParam(req : ExpressRequest) : FundingEligibilityTy
                         if (typeof vendorEligibilityInput.eligible === 'boolean') {
                             vendorEligibility.eligible = vendorEligibilityInput.eligible;
                         }
-        
+
                         if (typeof vendorEligibilityInput.branded === 'boolean') {
                             vendorEligibility.branded = vendorEligibilityInput.branded;
                         }
-        
+
                         if (typeof vendorEligibilityInput.vaultable === 'boolean') {
                             vendorEligibility.vaultable = vendorEligibilityInput.vaultable;
                         }
@@ -378,7 +378,7 @@ export function getButtonPreflightParams(params : ButtonPreflightInputParams) : 
         [ SPB_QUERY_KEYS.USER_ID_TOKEN ]: userIDToken,
         [ SPB_QUERY_KEYS.AMOUNT ]: amount = '0.00'
     } = params;
-    
+
     if (merchantID) {
         merchantID = merchantID.split(',');
     } else {

--- a/server/components/native/params.js
+++ b/server/components/native/params.js
@@ -1,11 +1,11 @@
 /* @flow */
 /* eslint max-depth: off */
 
-import { ENV, DEFAULT_COUNTRY, COUNTRY_LANGS, COUNTRY } from '@paypal/sdk-constants';
+import { ENV, DEFAULT_COUNTRY, COUNTRY_LANGS, COUNTRY, ERROR_CODE } from '@paypal/sdk-constants';
 
 import type { ExpressRequest, ExpressResponse, LocaleType } from '../../types';
 import { getCSPNonce, makeError } from '../../lib';
-import { ERROR_CODE, HTTP_HEADER } from '../../config';
+import { HTTP_HEADER } from '../../config';
 
 export type NativePopupInputParams = {|
     debug? : boolean,

--- a/server/config/constants.js
+++ b/server/config/constants.js
@@ -35,7 +35,3 @@ export const EVENT = {
 export const AUTH_ERROR_CODE = {
     INVALID_CLIENT: 'invalid_client'
 };
-
-export const ERROR_CODE = {
-    VALIDATION_ERROR: 'validation_error'
-};

--- a/server/lib/sdk.js
+++ b/server/lib/sdk.js
@@ -2,10 +2,11 @@
 
 import { unpackSDKMeta } from '@paypal/sdk-client';
 import { undotify } from 'belter';
+import { ERROR_CODE } from '@paypal/sdk-constants';
 
 import type { ExpressRequest, ExpressResponse, LoggerType, CacheType } from '../types';
 import { startWatchers } from '../watchers';
-import { EVENT, ERROR_CODE, BROWSER_CACHE_TIME, HTTP_HEADER } from '../config';
+import { EVENT, BROWSER_CACHE_TIME, HTTP_HEADER } from '../config';
 
 import { clientErrorResponse, serverErrorResponse, defaultLogger, type LoggerBufferType,
     getLogBuffer, safeJSON, isError, emptyResponse } from './util';
@@ -161,7 +162,7 @@ export function sdkMiddleware({ logger = defaultLogger, cache } : SDKMiddlewareO
             console.error(err.stack ? err.stack : err); // eslint-disable-line no-console
             logger.error(req, EVENT.ERROR, { err: err.stack ? err.stack : err.toString() });
             return serverErrorResponse(res, err.stack ? err.stack : err.toString());
-            
+
         } finally {
             logBuffer.flush(req);
         }

--- a/test/server/render.button.test.js
+++ b/test/server/render.button.test.js
@@ -70,16 +70,16 @@ test('should do a basic button render and succeed', async () => {
     if (fundingSources.indexOf(FUNDING.PAYPAL) === -1) {
         throw new Error(`Expected paypal button to be rendered, got: ${ fundingSources.join(', ') }`);
     }
-    
+
     const setupButtonParams = getSetupButtonParams(html);
-    
+
     if (!setupButtonParams.personalization.buttonText || !setupButtonParams.personalization.tagline) {
         throw new Error(`Expected personalization to be rendered, got: ${ JSON.stringify(setupButtonParams.personalization) }`);
     }
 });
 
 test('should do a basic button render and succeed when graphql fundingEligibility errors', async () => {
-    
+
     const req = mockReq({
         query: {
             clientID:           'xyz',
@@ -103,7 +103,7 @@ test('should do a basic button render and succeed when graphql fundingEligibilit
     });
 
     const res = mockRes();
-    
+
     const errButtonMiddleware = getButtonMiddleware({
         graphQL,
         getAccessToken,
@@ -117,27 +117,27 @@ test('should do a basic button render and succeed when graphql fundingEligibilit
     });
     // $FlowFixMe
     await errButtonMiddleware(req, res);
-    
+
     const status = res.getStatus();
     const contentType = res.getHeader('content-type');
     const html = res.getBody();
-    
+
     if (status !== 200) {
         throw new Error(`Expected response status to be 200, got ${ status }`);
     }
-    
+
     if (contentType !== 'text/html') {
         throw new Error(`Expected content type to be text/html, got ${ contentType || 'undefined' }`);
     }
-    
+
     if (!html) {
         throw new Error(`Expected res to have a body`);
     }
-    
+
     if (html.indexOf(`class="paypal-button-container`) === -1) {
         throw new Error(`Expected button template to be rendered`);
     }
-    
+
     const fundingSources = getRenderedFundingSources(html);
     if (fundingSources.indexOf(FUNDING.PAYPAL) === -1) {
         throw new Error(`Expected paypal button to be rendered, got: ${ fundingSources.join(', ') }`);
@@ -164,6 +164,28 @@ test('should give a 400 error with no clientID passed', async () => {
     }
 });
 
+test('should give a 400 error when an error occur while rendering button', async () => {
+    const buttonMiddleware = getButtonMiddleware({ graphQL, getAccessToken, getMerchantID, content: mockContent, cache, logger, tracking, getPersonalizationEnabled, isFundingSourceBranded });
+
+    // These are considered valid (validateButtonProps pass)
+    const req = mockReq({
+        query: {
+            clientID:           'xyz',
+            fundingEligibility: Buffer.from(JSON.stringify({}), 'utf8').toString('base64')
+        }
+    });
+    const res = mockRes();
+
+    // $FlowFixMe
+    await buttonMiddleware(req, res);
+
+    const status = res.getStatus();
+
+    if (status !== 400) {
+        throw new Error(`Expected status code to be 400, got ${ status }`);
+    }
+});
+
 test('should render empty personalization when API errors', async () => {
     const buttonMiddleware = getButtonMiddleware({ graphQL, getAccessToken, getMerchantID, content: mockContent, cache, logger, tracking, getPersonalizationEnabled, isFundingSourceBranded });
 
@@ -174,13 +196,13 @@ test('should render empty personalization when API errors', async () => {
         }
     });
     const res = mockRes();
-    
+
     // $FlowFixMe
     await buttonMiddleware(req, res);
     const html = res.getBody();
 
     const setupButtonParams = getSetupButtonParams(html);
-    
+
     if (Object.keys(setupButtonParams.personalization).length > 0) {
         throw new Error(`Expected personalization to be empty, got: ${ JSON.stringify(setupButtonParams.personalization) }`);
     }
@@ -205,13 +227,13 @@ test('should render empty personalization when config is disabled', async () => 
         }
     });
     const res = mockRes();
-    
+
     // $FlowFixMe
     await buttonMiddleware(req, res);
     const html = res.getBody();
 
     const setupButtonParams = getSetupButtonParams(html);
-    
+
     if (Object.keys(setupButtonParams.personalization).length > 0) {
         throw new Error(`Expected personalization to be empty, got: ${ JSON.stringify(setupButtonParams.personalization) }`);
     }


### PR DESCRIPTION
When the render method for paypal-checkout-components throws an Error, it should be considered an clientErrorResponse and not a serverErrorResponse, thus returning response code 400. 