### PR TITLE
Add channel to universal link

### DIFF
--- a/src/payment-flows/native/url.js
+++ b/src/payment-flows/native/url.js
@@ -90,6 +90,11 @@ type NativeUrlQuery = {|
     rtdbInstanceID : string
 |};
 
+const CHANNEL = {
+    DESKTOP: 'desktop-web',
+    MOBILE:  'mobile-web'
+};
+
 function getNativeUrlQueryParams({ props, serviceData, fundingSource, sessionUID, firebaseConfig, pageUrl, orderID, stickinessID } : GetNativeUrlOptions) : NativeUrlQuery {
     const { env, clientID, commit, buttonSessionID, stageHost, apiStageHost, enableFunding, merchantDomain } = props;
     const { facilitatorAccessToken, sdkMeta } = serviceData;

--- a/src/payment-flows/native/url.js
+++ b/src/payment-flows/native/url.js
@@ -69,6 +69,7 @@ type GetNativeUrlOptions = {|
 |};
 
 type NativeUrlQuery = {|
+    channel : string,
     sdkMeta : string,
     sessionUID : string,
     orderID : string,
@@ -105,6 +106,7 @@ function getNativeUrlQueryParams({ props, serviceData, fundingSource, sessionUID
     const channel = isDevice() ? CHANNEL.MOBILE : CHANNEL.DESKTOP;
 
     return {
+        channel,
         sdkMeta,
         sessionUID,
         orderID,

--- a/src/payment-flows/native/url.js
+++ b/src/payment-flows/native/url.js
@@ -1,7 +1,7 @@
 /* @flow */
 
 
-import { extendUrl, getUserAgent } from 'belter/src';
+import { extendUrl, getUserAgent, isDevice } from 'belter/src';
 import { ENV, FUNDING } from '@paypal/sdk-constants/src';
 import { getDomain } from 'cross-domain-utils/src';
 
@@ -102,6 +102,7 @@ function getNativeUrlQueryParams({ props, serviceData, fundingSource, sessionUID
     const webCheckoutUrl = getWebCheckoutUrl({ orderID, props, fundingSource, facilitatorAccessToken });
     const userAgent = getUserAgent();
     const forceEligible = isNativeOptedIn({ props });
+    const channel = isDevice() ? CHANNEL.MOBILE : CHANNEL.DESKTOP;
 
     return {
         sdkMeta,

--- a/src/payment-flows/native/url.js
+++ b/src/payment-flows/native/url.js
@@ -96,8 +96,6 @@ const CHANNEL = {
     MOBILE:  'mobile-web'
 };
 
-const channel = isDevice() ? CHANNEL.MOBILE : CHANNEL.DESKTOP;
-
 function getNativeUrlQueryParams({ props, serviceData, fundingSource, sessionUID, firebaseConfig, pageUrl, orderID, stickinessID } : GetNativeUrlOptions) : NativeUrlQuery {
     const { env, clientID, commit, buttonSessionID, stageHost, apiStageHost, enableFunding, merchantDomain } = props;
     const { facilitatorAccessToken, sdkMeta } = serviceData;
@@ -105,6 +103,7 @@ function getNativeUrlQueryParams({ props, serviceData, fundingSource, sessionUID
     const webCheckoutUrl = getWebCheckoutUrl({ orderID, props, fundingSource, facilitatorAccessToken });
     const userAgent = getUserAgent();
     const forceEligible = isNativeOptedIn({ props });
+    const channel = isDevice() ? CHANNEL.MOBILE : CHANNEL.DESKTOP;
 
     return {
         channel,

--- a/src/payment-flows/native/url.js
+++ b/src/payment-flows/native/url.js
@@ -96,6 +96,8 @@ const CHANNEL = {
     MOBILE:  'mobile-web'
 };
 
+const channel = isDevice() ? CHANNEL.MOBILE : CHANNEL.DESKTOP;
+
 function getNativeUrlQueryParams({ props, serviceData, fundingSource, sessionUID, firebaseConfig, pageUrl, orderID, stickinessID } : GetNativeUrlOptions) : NativeUrlQuery {
     const { env, clientID, commit, buttonSessionID, stageHost, apiStageHost, enableFunding, merchantDomain } = props;
     const { facilitatorAccessToken, sdkMeta } = serviceData;
@@ -103,7 +105,6 @@ function getNativeUrlQueryParams({ props, serviceData, fundingSource, sessionUID
     const webCheckoutUrl = getWebCheckoutUrl({ orderID, props, fundingSource, facilitatorAccessToken });
     const userAgent = getUserAgent();
     const forceEligible = isNativeOptedIn({ props });
-    const channel = isDevice() ? CHANNEL.MOBILE : CHANNEL.DESKTOP;
 
     return {
         channel,

--- a/test/client/native.js
+++ b/test/client/native.js
@@ -101,6 +101,10 @@ describe('native ios cases', () => {
                             throw new Error(`Expected env to be passed in url`);
                         }
 
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
+                        }
+
                         sessionUID = redirectQuery.sessionUID;
 
                         postRobotMock.receive({
@@ -279,6 +283,10 @@ describe('native ios cases', () => {
                             throw new Error(`Expected env to be passed in url`);
                         }
 
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
+                        }
+
                         postRobotMock.receive({
                             win,
                             name:   'detectWebSwitch',
@@ -392,6 +400,10 @@ describe('native ios cases', () => {
 
                         if (!redirectQuery.env) {
                             throw new Error(`Expected env to be passed in url`);
+                        }
+
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
                         }
 
                         sessionUID = redirectQuery.sessionUID;
@@ -586,6 +598,10 @@ describe('native ios cases', () => {
                             throw new Error(`Expected env to be passed in url`);
                         }
 
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
+                        }
+
                         postRobotMock.receive({
                             win,
                             name:   'detectWebSwitch',
@@ -716,6 +732,10 @@ describe('native ios cases', () => {
 
                         if (!redirectQuery.env) {
                             throw new Error(`Expected env to be passed in url`);
+                        }
+
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
                         }
 
                         sessionUID = redirectQuery.sessionUID;
@@ -875,6 +895,10 @@ describe('native ios cases', () => {
                             throw new Error(`Expected env to be passed in url`);
                         }
 
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
+                        }
+
                         sessionUID = redirectQuery.sessionUID;
 
                         postRobotMock.receive({
@@ -1016,6 +1040,10 @@ describe('native ios cases', () => {
 
                         if (!redirectQuery.buttonSessionID) {
                             throw new Error(`Expected sdkMeta to be passed in url`);
+                        }
+
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
                         }
 
                         sessionUID = redirectQuery.sessionUID;
@@ -1168,6 +1196,10 @@ describe('native ios cases', () => {
 
                         if (!redirectQuery.env) {
                             throw new Error(`Expected env to be passed in url`);
+                        }
+
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
                         }
 
                         sessionUID = redirectQuery.sessionUID;
@@ -1446,6 +1478,10 @@ describe('native ios cases', () => {
                             throw new Error(`Expected env to be passed in url`);
                         }
 
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
+                        }
+
                         postRobotMock.receive({
                             win,
                             name:   'detectWebSwitch',
@@ -1575,6 +1611,10 @@ describe('native ios cases', () => {
 
                         if (!redirectQuery.env) {
                             throw new Error(`Expected env to be passed in url`);
+                        }
+
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
                         }
 
                         postRobotMock.receive({
@@ -1786,6 +1826,10 @@ describe('native ios cases', () => {
                             throw new Error(`Expected env to be passed in url`);
                         }
 
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
+                        }
+
                         sessionUID = redirectQuery.sessionUID;
 
                         postRobotMock.receive({
@@ -1953,6 +1997,10 @@ describe('native ios cases', () => {
 
                         if (!redirectQuery.env) {
                             throw new Error(`Expected env to be passed in url`);
+                        }
+
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
                         }
 
                         sessionUID = redirectQuery.sessionUID;
@@ -2150,6 +2198,10 @@ describe('native ios cases', () => {
                             throw new Error(`Expected env to be passed in url`);
                         }
 
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
+                        }
+
                         sessionUID = redirectQuery.sessionUID;
 
                         postRobotMock.receive({
@@ -2317,6 +2369,10 @@ describe('native chrome cases', () => {
 
                         if (!redirectQuery.env) {
                             throw new Error(`Expected env to be passed in url`);
+                        }
+
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
                         }
 
                         sessionUID = redirectQuery.sessionUID;
@@ -2487,6 +2543,10 @@ describe('native chrome cases', () => {
                             throw new Error(`Expected env to be passed in url`);
                         }
 
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
+                        }
+
                         postRobotMock.receive({
                             win,
                             name:   'detectWebSwitch',
@@ -2601,6 +2661,10 @@ describe('native chrome cases', () => {
 
                         if (!redirectQuery.env) {
                             throw new Error(`Expected env to be passed in url`);
+                        }
+
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
                         }
 
                         sessionUID = redirectQuery.sessionUID;
@@ -2785,6 +2849,10 @@ describe('native chrome cases', () => {
                             throw new Error(`Expected env to be passed in url`);
                         }
 
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
+                        }
+
                         postRobotMock.receive({
                             win,
                             name:   'detectWebSwitch',
@@ -2916,6 +2984,10 @@ describe('native chrome cases', () => {
 
                         if (!redirectQuery.env) {
                             throw new Error(`Expected env to be passed in url`);
+                        }
+
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
                         }
 
                         sessionUID = redirectQuery.sessionUID;
@@ -3055,6 +3127,10 @@ describe('native chrome cases', () => {
 
                         if (!redirectQuery.buttonSessionID) {
                             throw new Error(`Expected sdkMeta to be passed in url`);
+                        }
+
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
                         }
 
                         sessionUID = redirectQuery.sessionUID;
@@ -3198,6 +3274,10 @@ describe('native chrome cases', () => {
 
                         if (!redirectQuery.env) {
                             throw new Error(`Expected env to be passed in url`);
+                        }
+
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
                         }
 
                         sessionUID = redirectQuery.sessionUID;
@@ -3466,6 +3546,10 @@ describe('native chrome cases', () => {
                             throw new Error(`Expected env to be passed in url`);
                         }
 
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
+                        }
+
                         postRobotMock.receive({
                             win,
                             name:   'detectWebSwitch',
@@ -3595,6 +3679,10 @@ describe('native chrome cases', () => {
 
                         if (!redirectQuery.env) {
                             throw new Error(`Expected env to be passed in url`);
+                        }
+
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
                         }
 
                         postRobotMock.receive({
@@ -3807,6 +3895,10 @@ describe('native chrome cases', () => {
                             throw new Error(`Expected env to be passed in url`);
                         }
 
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
+                        }
+
                         sessionUID = redirectQuery.sessionUID;
 
                         popupWin.close();
@@ -3965,6 +4057,10 @@ describe('native chrome cases', () => {
 
                         if (!redirectQuery.env) {
                             throw new Error(`Expected env to be passed in url`);
+                        }
+
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
                         }
 
                         sessionUID = redirectQuery.sessionUID;
@@ -4150,6 +4246,10 @@ describe('native chrome cases', () => {
 
                         if (!redirectQuery.env) {
                             throw new Error(`Expected env to be passed in url`);
+                        }
+
+                        if (!redirectQuery.channel) {
+                            throw new Error(`Expected channel to be passed in url`);
                         }
 
                         sessionUID = redirectQuery.sessionUID;


### PR DESCRIPTION
### Purpose

This PR adds `channel` to the universal link as a generic param for all FI's.

### Notes

`channel` is being declared and assigned within `getNativeUrlQueryParams`.