### PR TITLE
Native opt-out fallback

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -157,6 +157,7 @@ export const FPTI_TRANSITION = {
     NATIVE_POPUP_PAGEHIDE:                  ('native_popup_pagehide' : 'native_popup_pagehide'),
     NATIVE_POPUP_OPENER_DETECT_CLOSE:       ('native_popup_opener_detect_close', 'native_popup_opener_detect_close'),
     NATIVE_OPT_OUT:                         ('native_opt_out', 'native_opt_out'),
+    NATIVE_FALLBACK:                        ('native_fallback', 'native_fallback'),
     
     HONEY_IDENTIFY:                         ('honey_identify')
 };
@@ -178,7 +179,8 @@ export const FPTI_CUSTOM_KEY = {
     INTEGRATION_ISSUE:     ('integration_issue' : 'integration_issue'),
     INTEGRATION_WHITELIST: ('whitelist' : 'whitelist'),
     INFO_MSG:              ('info_msg' : 'info_msg'),
-    PMT_TOKEN:             ('pmt_token' : 'pmt_token')
+    PMT_TOKEN:             ('pmt_token' : 'pmt_token'),
+    TRANSITION_TYPE:       ('transition_type' : 'transition_type')
 };
 
 export const FPTI_BUTTON_KEY = {

--- a/src/constants.js
+++ b/src/constants.js
@@ -156,6 +156,7 @@ export const FPTI_TRANSITION = {
     NATIVE_POPUP_BEFORE_UNLOAD:             ('native_popup_beforeunload' : 'native_popup_beforeunload'),
     NATIVE_POPUP_PAGEHIDE:                  ('native_popup_pagehide' : 'native_popup_pagehide'),
     NATIVE_POPUP_OPENER_DETECT_CLOSE:       ('native_popup_opener_detect_close', 'native_popup_opener_detect_close'),
+    NATIVE_OPT_OUT:                         ('native_opt_out', 'native_opt_out'),
     
     HONEY_IDENTIFY:                         ('honey_identify')
 };

--- a/src/native/popup/popup.js
+++ b/src/native/popup/popup.js
@@ -247,7 +247,8 @@ export function setupNativePopup({ parentDomain, env, sessionID, buttonSessionID
             break;
         }
         case HASH.ON_FALLBACK: {
-            sendToParent(MESSAGE.ON_FALLBACK);
+            const { type } = parseQuery(queryString);
+            sendToParent(MESSAGE.ON_FALLBACK, { type });
             break;
         }
         case HASH.ON_ERROR: {

--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -24,6 +24,20 @@ function setupNative({ props, serviceData } : SetupOptions) : ZalgoPromise<void>
     return prefetchNativeEligibility({ props, serviceData }).then(noop);
 }
 
+function setNativeOptOut(data? : {| type? : string,  win? : CrossDomainWindowType |}) : boolean {
+    let optOut = false;
+    if (data && data.type === FPTI_TRANSITION.NATIVE_OPT_OUT) {
+        // Opt-out 1 week from native experience
+        const OPT_OUT_TIME = 7 * 24 * 60 * 60 * 1000;
+        const now = Date.now();
+        getStorageState(state => {
+            state.nativeOptOutLifetime = now + OPT_OUT_TIME;
+        });
+        optOut = true;
+    }
+    return optOut;
+}
+
 function initNative({ props, components, config, payment, serviceData } : InitOptions) : PaymentFlowInstance {
     const { onApprove, onCancel, onError,
         buttonSessionID, onShippingChange } = props;
@@ -158,20 +172,12 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
     const onFallbackCallback = ({ data } : {| data? : {| type? : string,  win? : CrossDomainWindowType |} |}) => {
         
         return ZalgoPromise.try(() => {
-            let optOut = false;
-            if (data && data.type === FPTI_TRANSITION.NATIVE_OPT_OUT) {
-                // Opt-out 1 week from native experience
-                const OPT_OUT_TIME = 7 * 24 * 60 * 60 * 1000;
-                const now = Date.now();
-                getStorageState(state => {
-                    state.nativeOptOutLifetime = now + OPT_OUT_TIME;
-                });
-                optOut = true;
-            }
+            const optOut = setNativeOptOut(data);
 
             getLogger().info(`native_message_onfallback`)
                 .track({
-                    [FPTI_KEY.TRANSITION]:  !optOut ? FPTI_TRANSITION.NATIVE_ON_FALLBACK : FPTI_TRANSITION.NATIVE_OPT_OUT
+                    [FPTI_KEY.TRANSITION]:             FPTI_TRANSITION.NATIVE_ON_FALLBACK,
+                    [FPTI_CUSTOM_KEY.TRANSITION_TYPE]:  optOut ? FPTI_TRANSITION.NATIVE_OPT_OUT :  FPTI_TRANSITION.NATIVE_FALLBACK
                 }).flush();
 
 

--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -160,6 +160,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
         return ZalgoPromise.try(() => {
             let optOut = false;
             if (data && data.type === FPTI_TRANSITION.NATIVE_OPT_OUT) {
+                // Opt-out 1 week from native experience
                 const OPT_OUT_TIME = 7 * 24 * 60 * 60 * 1000;
                 const now = Date.now();
                 getStorageState(state => {

--- a/src/payment-flows/native/popup.js
+++ b/src/payment-flows/native/popup.js
@@ -311,12 +311,13 @@ export function openNativePopup({ props, serviceData, config, fundingSource, ses
         closePopup('onCancel');
     });
 
-    const onFallbackListener = onPostMessage(nativePopupWin, nativePopupDomain, POST_MESSAGE.ON_FALLBACK, () => {
+    const onFallbackListener = onPostMessage(nativePopupWin, nativePopupDomain, POST_MESSAGE.ON_FALLBACK, (data) => {
         getLogger().info(`native_message_onfallback`)
             .track({
                 [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_ON_FALLBACK
             }).flush();
-        onFallback({ data: { win: nativePopupWin } });
+        const { type } = data;
+        onFallback({ data: { win: nativePopupWin, type } });
     });
 
     const onCompleteListener = onPostMessage(nativePopupWin, nativePopupDomain, POST_MESSAGE.ON_COMPLETE, () => {

--- a/src/payment-flows/native/popup.js
+++ b/src/payment-flows/native/popup.js
@@ -130,7 +130,10 @@ type NativePopupOptions = {|
             buttonSessionID : string
         |}>,
         onFallback : ({|
-            win : CrossDomainWindowType
+            data? : {|
+                type? : string,
+                win? : CrossDomainWindowType
+            |}
         |}) => ZalgoPromise<{|
             buttonSessionID : string
         |}>,
@@ -313,7 +316,7 @@ export function openNativePopup({ props, serviceData, config, fundingSource, ses
             .track({
                 [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_ON_FALLBACK
             }).flush();
-        onFallback({ win: nativePopupWin });
+        onFallback({ data: { win: nativePopupWin } });
     });
 
     const onCompleteListener = onPostMessage(nativePopupWin, nativePopupDomain, POST_MESSAGE.ON_COMPLETE, () => {

--- a/src/payment-flows/native/socket.js
+++ b/src/payment-flows/native/socket.js
@@ -3,6 +3,7 @@
 import { getUserAgent, memoize, stringifyError, noop } from 'belter/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
 import { ENV, FPTI_KEY, FUNDING } from '@paypal/sdk-constants/src';
+import { type CrossDomainWindowType } from 'cross-domain-utils/src';
 
 import type { ButtonProps, ServiceData, Config } from '../../button/props';
 import { firebaseSocket, type MessageSocket, type FirebaseConfig } from '../../api';
@@ -143,7 +144,12 @@ type ConnectNativeOptions = {|
         |}) => ZalgoPromise<{|
             buttonSessionID : string
         |}>,
-        onFallback : () => ZalgoPromise<{|
+        onFallback : ({|
+            data? : {|
+                win? : CrossDomainWindowType,
+                type? : string
+            |}
+        |}) => ZalgoPromise<{|
             buttonSessionID : string
         |}>
     |}

--- a/test/client/mocks.js
+++ b/test/client/mocks.js
@@ -687,7 +687,8 @@ type NativeMockWebSocket = {|
     onError : () => void,
     onShippingChange : () => void,
     onFallback : () => void,
-    fallback : ({| buyerAccessToken : string |}) => void
+    fallback : ({| buyerAccessToken : string |}) => void,
+    onFallbackOptOut : () => void
 |};
 
 export function getNativeWebSocketMock({ getSessionUID } : {| getSessionUID : () => ?string |}) : NativeMockWebSocket {
@@ -883,7 +884,7 @@ export function getNativeWebSocketMock({ getSessionUID } : {| getSessionUID : ()
     };
 
     return {
-        expect, onInit, onApprove, onCancel, onError, onShippingChange, onFallback, fallback: noop
+        expect, onInit, onApprove, onCancel, onError, onShippingChange, onFallback, fallback: noop, onFallbackOptOut: noop
     };
 }
 
@@ -1410,6 +1411,26 @@ export function getNativeFirebaseMock({ getSessionUID, extraHandler } : {| getSe
         waitingForResponse.push(onApproveRequestID);
     };
 
+    const onFallbackOptOut = () => {
+        fallbackRequestID = `${ uniqueID()  }_onApprove`;
+
+        send(`users/${ getSessionUID() }/messages/${ uniqueID() }`, JSON.stringify({
+            session_uid:        getSessionUID(),
+            source_app:         'paypal_native_checkout_sdk',
+            source_app_version: '1.2.3',
+            target_app:         'paypal_smart_payment_buttons',
+            request_uid:        fallbackRequestID,
+            message_uid:        uniqueID(),
+            message_type:       'request',
+            message_name:       'onFallback',
+            message_data:       {
+                type: 'native_opt_out'
+            }
+        }));
+
+        waitingForResponse.push(fallbackRequestID);
+    };
+
     const expect = () => {
         const { done: firebaseDone } = expectFirebase();
 
@@ -1429,7 +1450,7 @@ export function getNativeFirebaseMock({ getSessionUID, extraHandler } : {| getSe
     };
 
     return {
-        expect, onInit, onApprove, onCancel, onError, onShippingChange, fallback, onFallback
+        expect, onInit, onApprove, onCancel, onError, onShippingChange, fallback, onFallback, onFallbackOptOut
     };
 }
 

--- a/test/client/mocks.js
+++ b/test/client/mocks.js
@@ -1412,7 +1412,7 @@ export function getNativeFirebaseMock({ getSessionUID, extraHandler } : {| getSe
     };
 
     const onFallbackOptOut = () => {
-        fallbackRequestID = `${ uniqueID()  }_onApprove`;
+        fallbackRequestID = `${ uniqueID()  }_fallback`;
 
         send(`users/${ getSessionUID() }/messages/${ uniqueID() }`, JSON.stringify({
             session_uid:        getSessionUID(),

--- a/test/client/native.js
+++ b/test/client/native.js
@@ -4393,7 +4393,7 @@ describe('native chrome cases', () => {
                         domain: 'https://history.paypal.com',
                         data:   {
                             redirect: true,
-                            pageUrl:  `${ window.location.href }#close`
+                            pageUrl:  `${ window.location.href }#fallback`
                         }
                     }).then(expect('awaitRedirectResponse', res => {
                         if (res.redirect !== true) {


### PR DESCRIPTION
**Reasoning**
As part of a better onboarding native payment flow will be implementing an opt-out feature that gives the user a choice to use web payment flow instead native. Once a user indicates they do not wish to try native they should fall back to the web flow. In this process, JS SDK will store an opt-out lifetime indicator in localStorage on the device so that SPB no longer app switches to native until the date has expired.

**Implementation**
Now the JS SDK will look for a data type `native_opt_out` on the onFallBack event coming from firebase*. If this type exists and if it is the opt-out type the JS SDK will store the property `nativeOptOutLifetime` on the current `__smart_payment_buttons_storage__` object on the localStorage setting the lifetime to 1 week*.

There is a new method called `isNativeOptedIn` that will be used to validate whether the native flow was opt-out or not on the eligibility logic for the native payment flow.

**Considerations**
- As it stands this implementation only handle the Android flow using firebase and listening to the `onFallBack` event.
- The one week opt-out time it is just tentative time span.

