### PR TITLE
[WIP] fix(spinner): Removing button spinner for Native and ApplePay

### DIFF
--- a/src/payment-flows/applepay/applepay.js
+++ b/src/payment-flows/applepay/applepay.js
@@ -491,5 +491,5 @@ export const applepay : PaymentFlow = {
     isEligible:        isApplePayEligible,
     isPaymentEligible: isApplePayPaymentEligible,
     init:              initApplePay,
-    spinner:           true
+    spinner:           false
 };

--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -315,5 +315,5 @@ export const native : PaymentFlow = {
     isPaymentEligible:      isNativePaymentEligible,
     init:                   initNative,
     updateFlowClientConfig: updateNativeClientConfig,
-    spinner:                true
+    spinner:                false
 };


### PR DESCRIPTION
Fixes an issue when the user returns back from the native (PayPal or Venmo) app and the button still has the spinner applied.  This is problematic when the user cancels the payment (in the native app) but can't proceed because the spinner deactivates the payment button..