### PR TITLE
fix(iOS): initPopupAppSwitch promise not resolving.

### DIFF
--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -271,6 +271,8 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
             });
 
             clean.register(nativePopup.cancel);
+
+            resolve();
         });
     };
 


### PR DESCRIPTION
Problem: on iOS any funding button clicked will remain inactive with a spinner.  This happens on all scenarios. 

We are seeing a scenario where the promise `resolve` is not being called on iOS only.  Android uses a different mechanism (`setTimeout`, close after a second and call `detectAppSwitch`) where as iOS used the `onPostMessage` to trigger `onDetectAppSwitch`.

Could not determine the exact reason why for iOS this did not work.  As a solution, `resolve` the promise at the bottom of `initPopupAppSwitch`.