### PR TITLE
Use merchantID instead of sdkMerchantID for personalization

### DIFF
--- a/server/components/buttons/middleware.js
+++ b/server/components/buttons/middleware.js
@@ -105,9 +105,15 @@ export function getButtonMiddleware({
             }).catch(noop);
 
             const personalizationEnabled = getPersonalizationEnabled(req);
-            const personalizationPromise = resolvePersonalization(req, gqlBatch, {
-                logger, clientID, merchantID: sdkMerchantID, buyerCountry, locale, buttonSessionID,
-                currency, intent, commit, vault, label, period, tagline, personalizationEnabled
+            const personalizationPromise = promiseTimeout(
+                merchantIDPromise.then(merchantID =>
+                    resolvePersonalization(req, gqlBatch, {
+                        logger, clientID, merchantID, buyerCountry, locale, buttonSessionID,
+                        currency, intent, commit, vault, label, period, tagline, personalizationEnabled
+                    })),
+                EXPERIMENT_TIMEOUT
+            ).catch(() => {
+                return {};
             });
 
             gqlBatch.flush();

--- a/test/server/render.button.test.js
+++ b/test/server/render.button.test.js
@@ -216,3 +216,34 @@ test('should render empty personalization when config is disabled', async () => 
         throw new Error(`Expected personalization to be empty, got: ${ JSON.stringify(setupButtonParams.personalization) }`);
     }
 });
+
+test('should render filled out tagline when config is enabled', async () => {
+    const buttonMiddleware = getButtonMiddleware({
+        graphQL,
+        getAccessToken,
+        getMerchantID,
+        content:                   mockContent,
+        cache,
+        logger,
+        tracking,
+        getPersonalizationEnabled: () => true,
+        isFundingSourceBranded
+    });
+
+    const req = mockReq({
+        query: {
+            clientID: 'xyz'
+        }
+    });
+    const res = mockRes();
+    
+    // $FlowFixMe
+    await buttonMiddleware(req, res);
+    const html = res.getBody();
+
+    const setupButtonParams = getSetupButtonParams(html);
+    
+    if (!setupButtonParams.personalization.buttonText || !setupButtonParams.personalization.tagline) {
+        throw new Error(`Expected personalization to be rendered, got: ${ JSON.stringify(setupButtonParams.personalization) }`);
+    }
+});


### PR DESCRIPTION
Currently adding logic in personalization that requires the merchantID. There is no special logic in the graphql layer that requires the sdkMerchatID so this change should be fine.

https://engineering.paypalcorp.com/jira/browse/DTNAVYA-1102