### PR TITLE
Fix restart flow closing previous popup if exists.

### DIFF
--- a/src/payment-flows/checkout.js
+++ b/src/payment-flows/checkout.js
@@ -400,8 +400,11 @@ function initCheckout({ props, components, serviceData, payment, config } : Init
     });
 
     const restart = memoize(() : ZalgoPromise<void> => {
-        return initCheckout({ props, components, serviceData, config, payment: { button, fundingSource, card, buyerIntent, isClick: false } })
-            .start().finally(unresolvedPromise);
+        // Closing any previous checkout instance before restarting
+        return close().finally(() => {
+            return initCheckout({ props, components, serviceData, config, payment: { button, fundingSource, card, buyerIntent, isClick: false } })
+                .start().finally(unresolvedPromise);
+        });
     });
 
     const click = () => {

--- a/src/payment-flows/checkout.js
+++ b/src/payment-flows/checkout.js
@@ -400,7 +400,7 @@ function initCheckout({ props, components, serviceData, payment, config } : Init
     });
 
     const restart = memoize(() : ZalgoPromise<void> => {
-        // Closing any previous checkout instance before restarting
+        // Closing any previous checkout popup before restarting
         return close().finally(() => {
             return initCheckout({ props, components, serviceData, config, payment: { button, fundingSource, card, buyerIntent, isClick: false } })
                 .start().finally(unresolvedPromise);

--- a/test/client/contingency.js
+++ b/test/client/contingency.js
@@ -443,4 +443,88 @@ describe('contingency cases', () => {
             gqlMock.done();
         });
     });
+
+
+    it('should render a button, click the button, and render checkout, then pass onApprove callback to the parent with actions.order.capture and auto restart with INSTRUMENT_DECLINED closing previous popup', async () => {
+        return await wrapPromise(async ({ expect, avoid }) => {
+
+            const orderID = generateOrderID();
+            const payerID = 'YYYYYYYYYY';
+            const accessToken = MOCK_BUYER_ACCESS_TOKEN;
+
+            window.xprops.onClick = mockAsyncProp(expect('onClick'));
+
+            window.xprops.createOrder = mockAsyncProp(expect('createOrder', async () => {
+                return ZalgoPromise.try(() => {
+                    return orderID;
+                });
+            }));
+
+            let onApprove = async (data, actions) => {
+                if (data.orderID !== orderID) {
+                    throw new Error(`Expected orderID to be ${ orderID }, got ${ data.orderID }`);
+                }
+
+                if (data.payerID !== payerID) {
+                    throw new Error(`Expected payerID to be ${ payerID }, got ${ data.payerID }`);
+                }
+
+                onApprove = expect('onApprove2', async (data2) => {
+                    if (data2.orderID !== orderID) {
+                        throw new Error(`Expected orderID to be ${ orderID }, got ${ data.orderID }`);
+                    }
+
+                    if (data2.payerID !== payerID) {
+                        throw new Error(`Expected payerID to be ${ payerID }, got ${ data.payerID }`);
+                    }
+
+                    const captureOrderMock2 = getCaptureOrderApiMock();
+                    captureOrderMock2.expectCalls();
+                    await actions.order.capture();
+                    captureOrderMock2.done();
+                });
+
+                const captureOrderMock = getCaptureOrderApiMock({
+                    data: {
+                        ack:         'contingency',
+                        contingency: 'UNPROCESSABLE_ENTITY',
+                        data:        {
+                            details: [
+                                {
+                                    issue: 'INSTRUMENT_DECLINED'
+                                }
+                            ]
+                        }
+                    }
+                });
+
+                actions.restart().then(avoid('restartThen'));
+                captureOrderMock.done();
+            };
+
+
+            window.xprops.onApprove = mockAsyncProp(expect('onApprove', (data, actions) => onApprove(data, actions)));
+
+            mockFunction(window.paypal, 'Checkout', expect('Checkout', ({ original: CheckoutOriginal, args: [ props ] }) => {
+                window[LSAT_UPGRADE_FAILED] = true;
+                props.onAuth({ accessToken });
+                mockFunction(props, 'onApprove', expect('onApprove', ({ original: onApproveOriginal, args: [ data, actions ] }) => {
+                    return onApproveOriginal({ ...data, payerID }, actions);
+                }));
+
+                const checkoutInstance = CheckoutOriginal(props);
+
+                mockFunction(checkoutInstance, 'close', expect('close'));
+
+                return checkoutInstance;
+            }));
+
+            createButtonHTML();
+
+            await mockSetupButton({ merchantID: [ 'XYZ12345' ], fundingEligibility: DEFAULT_FUNDING_ELIGIBILITY });
+
+            await clickButton(FUNDING.PAYPAL);
+        });
+    });
+
 });


### PR DESCRIPTION
Added new logic to close any previous checkout popup before restarting a new one.
This solves the problem of having two checkouts when there is a rejection and a restart of the checkout flow.

This is now necessary after the modification of the popup closing sequence. (Now the popup only closes after all the promises get resolved on the `onApprove`  method).