### PR TITLE
Native flow opt-out duration

### DIFF
--- a/src/native/popup/popup.js
+++ b/src/native/popup/popup.js
@@ -253,8 +253,8 @@ export function setupNativePopup({ parentDomain, env, sessionID, buttonSessionID
             break;
         }
         case HASH.ON_FALLBACK: {
-            const { type } = parseQuery(queryString);
-            sendToParent(MESSAGE.ON_FALLBACK, { type });
+            const { type, duration } = parseQuery(queryString);
+            sendToParent(MESSAGE.ON_FALLBACK, { type, duration });
             break;
         }
         case HASH.ON_ERROR: {

--- a/src/native/popup/popup.js
+++ b/src/native/popup/popup.js
@@ -253,8 +253,8 @@ export function setupNativePopup({ parentDomain, env, sessionID, buttonSessionID
             break;
         }
         case HASH.ON_FALLBACK: {
-            const { type, duration } = parseQuery(queryString);
-            sendToParent(MESSAGE.ON_FALLBACK, { type, duration });
+            const { type, skip_native_duration } = parseQuery(queryString);
+            sendToParent(MESSAGE.ON_FALLBACK, { type, skip_native_duration });
             break;
         }
         case HASH.ON_ERROR: {

--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -24,15 +24,15 @@ function setupNative({ props, serviceData } : SetupOptions) : ZalgoPromise<void>
     return prefetchNativeEligibility({ props, serviceData }).then(noop);
 }
 
-function setNativeOptOut(data? : {| type? : string, duration? : number,  win? : CrossDomainWindowType |}) : boolean {
+function setNativeOptOut(data? : {| type? : string, skip_native_duration? : number,  win? : CrossDomainWindowType |}) : boolean {
     let optOut = false;
     if (data && data.type === FPTI_TRANSITION.NATIVE_OPT_OUT) {
-        const { duration } = data;
+        const { skip_native_duration } = data;
 
-        // Opt-out 1 week from native experience as default
-        let OPT_OUT_TIME = 7 * 24 * 60 * 60 * 1000;
-        if (duration && typeof duration === 'number') {
-            OPT_OUT_TIME = duration;
+        // Opt-out 6 weeks from native experience as default
+        let OPT_OUT_TIME = 6 * 7 * 24 * 60 * 60 * 1000;
+        if (skip_native_duration && typeof skip_native_duration === 'number') {
+            OPT_OUT_TIME = skip_native_duration;
         }
 
         const now = Date.now();
@@ -175,7 +175,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
         });
     };
 
-    const onFallbackCallback = ({ data } : {| data? : {| type? : string, duration? : number,  win? : CrossDomainWindowType |} |}) => {
+    const onFallbackCallback = ({ data } : {| data? : {| type? : string, skip_native_duration? : number,  win? : CrossDomainWindowType |} |}) => {
         
         return ZalgoPromise.try(() => {
             const optOut = setNativeOptOut(data);

--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -24,11 +24,17 @@ function setupNative({ props, serviceData } : SetupOptions) : ZalgoPromise<void>
     return prefetchNativeEligibility({ props, serviceData }).then(noop);
 }
 
-function setNativeOptOut(data? : {| type? : string,  win? : CrossDomainWindowType |}) : boolean {
+function setNativeOptOut(data? : {| type? : string, duration? : number,  win? : CrossDomainWindowType |}) : boolean {
     let optOut = false;
     if (data && data.type === FPTI_TRANSITION.NATIVE_OPT_OUT) {
-        // Opt-out 1 week from native experience
-        const OPT_OUT_TIME = 7 * 24 * 60 * 60 * 1000;
+        const { duration } = data;
+
+        // Opt-out 1 week from native experience as default
+        let OPT_OUT_TIME = 7 * 24 * 60 * 60 * 1000;
+        if (duration && typeof duration === 'number') {
+            OPT_OUT_TIME = duration;
+        }
+
         const now = Date.now();
         getStorageState(state => {
             state.nativeOptOutLifetime = now + OPT_OUT_TIME;
@@ -169,7 +175,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
         });
     };
 
-    const onFallbackCallback = ({ data } : {| data? : {| type? : string,  win? : CrossDomainWindowType |} |}) => {
+    const onFallbackCallback = ({ data } : {| data? : {| type? : string, duration? : number,  win? : CrossDomainWindowType |} |}) => {
         
         return ZalgoPromise.try(() => {
             const optOut = setNativeOptOut(data);

--- a/src/payment-flows/native/popup.js
+++ b/src/payment-flows/native/popup.js
@@ -132,7 +132,7 @@ type NativePopupOptions = {|
         onFallback : ({|
             data? : {|
                 type? : string,
-                duration? : number,
+                skip_native_duration? : number,
                 win? : CrossDomainWindowType
             |}
         |}) => ZalgoPromise<{|
@@ -317,8 +317,8 @@ export function openNativePopup({ props, serviceData, config, fundingSource, ses
             .track({
                 [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_ON_FALLBACK
             }).flush();
-        const { type, duration } = data;
-        onFallback({ data: { win: nativePopupWin, type, duration } });
+        const { type, skip_native_duration } = data;
+        onFallback({ data: { win: nativePopupWin, type, skip_native_duration } });
     });
 
     const onCompleteListener = onPostMessage(nativePopupWin, nativePopupDomain, POST_MESSAGE.ON_COMPLETE, () => {

--- a/src/payment-flows/native/popup.js
+++ b/src/payment-flows/native/popup.js
@@ -132,6 +132,7 @@ type NativePopupOptions = {|
         onFallback : ({|
             data? : {|
                 type? : string,
+                duration? : number,
                 win? : CrossDomainWindowType
             |}
         |}) => ZalgoPromise<{|
@@ -316,8 +317,8 @@ export function openNativePopup({ props, serviceData, config, fundingSource, ses
             .track({
                 [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_ON_FALLBACK
             }).flush();
-        const { type } = data;
-        onFallback({ data: { win: nativePopupWin, type } });
+        const { type, duration } = data;
+        onFallback({ data: { win: nativePopupWin, type, duration } });
     });
 
     const onCompleteListener = onPostMessage(nativePopupWin, nativePopupDomain, POST_MESSAGE.ON_COMPLETE, () => {

--- a/src/payment-flows/native/socket.js
+++ b/src/payment-flows/native/socket.js
@@ -148,7 +148,7 @@ type ConnectNativeOptions = {|
             data? : {|
                 win? : CrossDomainWindowType,
                 type? : string,
-                duration? : number
+                skip_native_duration? : number
             |}
         |}) => ZalgoPromise<{|
             buttonSessionID : string

--- a/src/payment-flows/native/socket.js
+++ b/src/payment-flows/native/socket.js
@@ -147,7 +147,8 @@ type ConnectNativeOptions = {|
         onFallback : ({|
             data? : {|
                 win? : CrossDomainWindowType,
-                type? : string
+                type? : string,
+                duration? : number
             |}
         |}) => ZalgoPromise<{|
             buttonSessionID : string

--- a/test/client/mocks.js
+++ b/test/client/mocks.js
@@ -1425,7 +1425,8 @@ export function getNativeFirebaseMock({ getSessionUID, extraHandler } : {| getSe
             message_type:       'request',
             message_name:       'onFallback',
             message_data:       {
-                type: 'native_opt_out'
+                type:                 'native_opt_out',
+                skip_native_duration: 604800000
             }
         }));
 


### PR DESCRIPTION
Added logic to receive a prop called `duration` from the native flow opt-out fallback.

- If this prop is passed in and it a valid number representing `milliseconds` it will be used to set the lifetime duration of the native flow opt-out.
- If the duration prop is not passed in, the JS SDK will set a default duration of a `1 week` for the native flow opt-out.