### PR TITLE
Add support for testing the sdk cdn in stage

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "grabthar": "^4",
     "jsx-pragmatic": "^2",
     "module-alias": "^2.2.2",
+    "node-fetch": "^2.6.1",
     "preact": "^10",
     "preact-render-to-string": "^5.1.4",
     "strict-merge": "^1.0.1",

--- a/server/components/buttons/middleware.js
+++ b/server/components/buttons/middleware.js
@@ -70,7 +70,9 @@ export function getButtonMiddleware({
 
             const { env, clientID, buttonSessionID, cspNonce, debug, buyerCountry, disableFunding, disableCard, userIDToken, amount,
                 merchantID: sdkMerchantID, currency, intent, commit, vault, clientAccessToken, basicFundingEligibility, locale,
-                clientMetadataID, pageSessionID, correlationID, cookies, enableFunding, style, paymentMethodNonce, branded, fundingSource } = getButtonParams(params, req, res);
+                clientMetadataID, pageSessionID, correlationID, cookies, enableFunding, style, paymentMethodNonce, branded, fundingSource,
+                cdnRegistry, activeTag
+            } = await getButtonParams(params, req, res);
 
             const { label, period, tagline } = style;
             logger.info(req, `button_params`, { params: JSON.stringify(params) });
@@ -86,7 +88,7 @@ export function getButtonMiddleware({
             const facilitatorAccessTokenPromise = getAccessToken(req, clientID);
             const merchantIDPromise = facilitatorAccessTokenPromise.then(facilitatorAccessToken => resolveMerchantID(req, { merchantID: sdkMerchantID, getMerchantID, facilitatorAccessToken }));
             const clientPromise = getSmartPaymentButtonsClientScript({ debug, logBuffer, cache, useLocal });
-            const renderPromise = getPayPalSmartPaymentButtonsRenderScript({ logBuffer, cache, useLocal });
+            const renderPromise = getPayPalSmartPaymentButtonsRenderScript({ logBuffer, cache, useLocal, cdnRegistry, activeTag });
 
             const isCardFieldsExperimentEnabledPromise = promiseTimeout(
                 merchantIDPromise.then(merchantID =>
@@ -191,7 +193,7 @@ export function getButtonMiddleware({
         script: async ({ req, res, params, logBuffer }) => {
             logger.info(req, 'smart_buttons_script_render');
 
-            const { debug } = getButtonParams(params, req, res);
+            const { debug } = await getButtonParams(params, req, res);
             const { script } = await getSmartPaymentButtonsClientScript({ debug, logBuffer, cache, useLocal });
 
             return javascriptResponse(res, script);

--- a/server/components/buttons/script.js
+++ b/server/components/buttons/script.js
@@ -47,10 +47,12 @@ export async function getLocalSmartPaymentButtonRenderScript() : Promise<?SmartP
 type GetPayPalSmartPaymentButtonsRenderScriptOptions = {|
     logBuffer : ?LoggerBufferType,
     cache : ?CacheType,
-    useLocal? : boolean
+    useLocal? : boolean,
+    cdnRegistry : ?string,
+    activeTag : ?string
 |};
 
-export async function getPayPalSmartPaymentButtonsRenderScript({ logBuffer, cache, useLocal = isLocalOrTest() } : GetPayPalSmartPaymentButtonsRenderScriptOptions) : Promise<SmartPaymentButtonsRenderScript> {
+export async function getPayPalSmartPaymentButtonsRenderScript({ logBuffer, cache, useLocal = isLocalOrTest(), cdnRegistry, activeTag } : GetPayPalSmartPaymentButtonsRenderScriptOptions) : Promise<SmartPaymentButtonsRenderScript> {
     if (useLocal) {
         const script = await getLocalSmartPaymentButtonRenderScript();
         if (script) {
@@ -58,7 +60,7 @@ export async function getPayPalSmartPaymentButtonsRenderScript({ logBuffer, cach
         }
     }
 
-    const { getTag, getDeployTag, importDependency } = getPayPalSDKWatcher({ logBuffer, cache });
+    const { getTag, getDeployTag, importDependency } = getPayPalSDKWatcher({ logBuffer, cache, cdnRegistry, activeTag });
     const { version } = await getTag();
     const button = await importDependency(CHECKOUT_COMPONENTS_MODULE, BUTTON_RENDER_JS, ACTIVE_TAG);
 

--- a/server/config/config.js
+++ b/server/config/config.js
@@ -41,7 +41,9 @@ export const NATIVE_FALLBACK_CLIENT_MIN_JS = 'dist/smart-native-fallback.min.js'
 
 export const BROWSER_CACHE_TIME = 6 * 60 * 60;
 
-export const SDK_CDN_NAMESPACE = 'https://www.paypalobjects.com/js-sdk-release';
+export const SDK_CDN_REGISTRY_NAMESPACE = 'js-sdk-release';
+export const SDK_PRODUCTION_CDN_REGISTRY = `https://www.paypalobjects.com/${ SDK_CDN_REGISTRY_NAMESPACE }`;
+
 export const SMART_BUTTONS_CDN_NAMESPACE = 'https://www.paypalobjects.com/smart-payment-buttons';
 
 export const FUNDING_ELIGIBILITY_TIMEOUT = 200;

--- a/server/watchers.js
+++ b/server/watchers.js
@@ -4,7 +4,7 @@ import { poll } from 'grabthar';
 
 import type { CacheType } from './types';
 import type { LoggerBufferType } from './lib';
-import { SDK_RELEASE_MODULE, SMART_BUTTONS_MODULE, MODULE_POLL_INTERVAL, SDK_CDN_NAMESPACE, SMART_BUTTONS_CDN_NAMESPACE,
+import { SDK_RELEASE_MODULE, SMART_BUTTONS_MODULE, MODULE_POLL_INTERVAL, SDK_PRODUCTION_CDN_REGISTRY, SMART_BUTTONS_CDN_NAMESPACE,
     CHECKOUT_COMPONENTS_MODULE, LATEST_TAG, ACTIVE_TAG } from './config';
 
 let paypalSDKWatcher;
@@ -46,15 +46,27 @@ function logInfo(logBuffer : LoggerBufferType, name : string, moduleDetails : Mo
     logBuffer.info(`${ name }_version_${ version.replace(/[^0-9]+/g, '_') }`, {});
 }
 
-export function getPayPalSDKWatcher({ logBuffer, cache } : {| logBuffer : ?LoggerBufferType, cache : ?CacheType |}) : Watcher {
+type GetSDKWatcherParams = {|
+    logBuffer : ?LoggerBufferType,
+    cache : ?CacheType,
+    cdnRegistry? : ?string,
+    activeTag? : ?string
+|};
+
+export function getPayPalSDKWatcher({
+    cdnRegistry = SDK_PRODUCTION_CDN_REGISTRY,
+    activeTag = ACTIVE_TAG,
+    logBuffer,
+    cache
+} : GetSDKWatcherParams) : Watcher {
     if (!cache || !logBuffer) {
         throw new Error(`Cache and logBuffer required`);
     }
 
     paypalSDKWatcher = paypalSDKWatcher || poll({
-        cdnRegistry:  SDK_CDN_NAMESPACE,
+        cdnRegistry,
         name:         SDK_RELEASE_MODULE,
-        tags:         [ LATEST_TAG, ACTIVE_TAG ],
+        tags:         [ LATEST_TAG, activeTag ],
         period:       MODULE_POLL_INTERVAL,
         childModules: [ CHECKOUT_COMPONENTS_MODULE ],
         flat:         true,


### PR DESCRIPTION
The JS SDK supports the `cdn-registry` and `version` query params in lower environments (https://github.com/paypal/paypal-sdk-constants/pull/54). This PR updates SPB to respect these params for the second render so it uses the same JS SDK bundle when rendering server-side.