### PR TITLE
QRCode close on  onClose

### DIFF
--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -306,29 +306,21 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
             [FPTI_KEY.TRANSITION]:      FPTI_TRANSITION.QR_SHOWN
         }).flush();
 
-
-        const closeQRCode = (event? : string = 'closeQRCode') => {
+        const logQRClose = (event? : string = 'closeQRCode') => {
             getLogger().info(`VenmoDesktopPay_qrcode_closing_${ event }`).track({
                 [FPTI_KEY.STATE]:       FPTI_STATE.BUTTON,
                 [FPTI_KEY.TRANSITION]:  event ? `${ FPTI_TRANSITION.QR_CLOSING }_${ event }` : FPTI_TRANSITION.QR_CLOSING
             }).flush();
-
-            return ZalgoPromise.delay(2000).then(() => {
-                return ZalgoPromise.try(() => {
-                    qrCodeRenderTarget.close();
-                    return destroy();
-                });
-            }).then(noop);
         };
         
-        return orderIDPromise.then((orderID) => {
+        orderIDPromise.then((orderID) => {
             const url = getNativeUrl({ props, serviceData, config, fundingSource, sessionUID, orderID, stickinessID, pageUrl });
 
             const qrCodeComponentInstance = QRCode({
                 cspNonce:  config.cspNonce,
                 qrPath:    url,
                 state:     QRCODE_STATE.DEFAULT,
-                onClose:   closeQRCode
+                onClose:   logQRClose()
             });
 
             function updateQRCodeComponentState(newState : {|
@@ -338,10 +330,21 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
                 return qrCodeComponentInstance.updateProps({
                     cspNonce: config.cspNonce,
                     qrPath:   url,
-                    onClose:  closeQRCode,
+                    onClose:  logQRClose(),
                     ...newState
                 });
             }
+
+            const closeQRCode = (event? : string) => {
+                logQRClose(event);
+
+                return ZalgoPromise.delay(2000).then(() => {
+                    return ZalgoPromise.try(() => {
+                        qrCodeComponentInstance.close();
+                        return destroy();
+                    });
+                }).then(noop);
+            };
             const onInitializeQR  = () => {
                 return updateQRCodeComponentState({ state: QRCODE_STATE.SCANNED }).then(() => {
                     return onInitCallback();
@@ -385,12 +388,11 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
                 }
             });
             clean.register(connection.cancel);
-            connection.setProps();
 
             return qrCodeComponentInstance.renderTo(qrCodeRenderTarget, TARGET_ELEMENT.BODY);
-            
-            
+
         });
+
     };
 
 

--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -356,7 +356,10 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
                 });
             };
             const onCancelQR = () => {
-                return closeQRCode('onCancel').then(() => {
+                return updateQRCodeComponentState({
+                    state:     QRCODE_STATE.ERROR,
+                    errorText: 'The authorization was canceled'
+                }).then(() => {
                     return onCancelCallback();
                 });
             };

--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -315,6 +315,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
 
             return ZalgoPromise.delay(2000).then(() => {
                 return ZalgoPromise.try(() => {
+                    qrCodeRenderTarget.close();
                     return destroy();
                 });
             }).then(noop);

--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -313,7 +313,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
             }).flush();
         };
         
-        orderIDPromise.then((orderID) => {
+        return orderIDPromise.then((orderID) => {
             const url = getNativeUrl({ props, serviceData, config, fundingSource, sessionUID, orderID, stickinessID, pageUrl });
 
             const qrCodeComponentInstance = QRCode({

--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -312,7 +312,12 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
                 [FPTI_KEY.STATE]:       FPTI_STATE.BUTTON,
                 [FPTI_KEY.TRANSITION]:  event ? `${ FPTI_TRANSITION.QR_CLOSING }_${ event }` : FPTI_TRANSITION.QR_CLOSING
             }).flush();
-            return onCloseCallback();
+
+            return ZalgoPromise.delay(2000).then(() => {            
+                return ZalgoPromise.try(() => {
+                    return destroy();
+                });                
+            }).then(noop);
         };
         
         return orderIDPromise.then((orderID) => {
@@ -344,6 +349,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
             const onApproveQR = (res) => {
                 return updateQRCodeComponentState({ state: QRCODE_STATE.AUTHORIZED }).then(() => {
                     return closeQRCode('onApprove').then(() => {
+
                         return onApproveCallback(res);
                     });
                 });

--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -313,10 +313,10 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
                 [FPTI_KEY.TRANSITION]:  event ? `${ FPTI_TRANSITION.QR_CLOSING }_${ event }` : FPTI_TRANSITION.QR_CLOSING
             }).flush();
 
-            return ZalgoPromise.delay(2000).then(() => {            
+            return ZalgoPromise.delay(2000).then(() => {
                 return ZalgoPromise.try(() => {
                     return destroy();
-                });                
+                });
             }).then(noop);
         };
         


### PR DESCRIPTION
- Actually close the QRCode component on the onClose call per: 
https://engineering.paypalcorp.com/jira/browse/DTCHKINT-925 & https://engineering.paypalcorp.com/jira/browse/DTCHKINT-887

- Wires onCancel callback to use the error UI state per:
 https://engineering.paypalcorp.com/jira/browse/DTCHKINT-893

- Removes `setProps` call that was used early on in QA & testing
https://engineering.paypalcorp.com/jira/browse/DTCHKINT-886
