### PR TITLE
QR Code Logic Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ slipper-cache.json
 flow-typed
 server-coverage
 package-lock.json
+.vscode

--- a/src/native/lib/logger.js
+++ b/src/native/lib/logger.js
@@ -6,7 +6,7 @@ import { FPTI_KEY, ENV, FUNDING, COUNTRY } from '@paypal/sdk-constants/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
 
 import type { LocaleType } from '../../types';
-import { getLogger, setupLogger } from '../../lib';
+import { enableAmplitude, getLogger, setupLogger } from '../../lib';
 import { FPTI_TRANSITION, FPTI_STATE, FPTI_CONTEXT_TYPE, AMPLITUDE_KEY } from '../../constants';
 
 type NativeLoggerOptions = {|
@@ -25,12 +25,7 @@ export function setupNativeLogger({ env, sessionID, buttonSessionID, sdkCorrelat
     const logger = getLogger();
 
     setupLogger({ env, sessionID, clientID, sdkCorrelationID, locale, sdkVersion, buyerCountry });
-
-    logger.addMetaBuilder(() => {
-        return {
-            amplitude: true
-        };
-    });
+    enableAmplitude({ env });
 
     logger.addPayloadBuilder(() => {
         return {

--- a/src/payment-flows/applepay/applepay.js
+++ b/src/payment-flows/applepay/applepay.js
@@ -12,7 +12,7 @@ import type { ApplePayPaymentContact, ApplePayShippingMethod, ApplePayShippingMe
 
 import { createApplePayRequest, isJSON, validateShippingContact } from './utils';
 
-const SUPPORTED_VERSION = 3;
+const SUPPORTED_VERSION = 4;
 
 let clean;
 function setupApplePay() : ZalgoPromise<void> {

--- a/src/payment-flows/applepay/utils.js
+++ b/src/payment-flows/applepay/utils.js
@@ -9,14 +9,16 @@ type ValidNetworks = {|
     discover : ApplePaySupportedNetworks,
     visa : ApplePaySupportedNetworks,
     mastercard : ApplePaySupportedNetworks,
-    amex : ApplePaySupportedNetworks
+    amex : ApplePaySupportedNetworks,
+    cb_nationale : ApplePaySupportedNetworks
 |};
 
 const validNetworks : ValidNetworks = {
     discover:       'discover',
     visa:           'visa',
     mastercard:     'masterCard',
-    amex:           'amex'
+    amex:           'amex',
+    cb_nationale:   'cartesBancaires'
 };
 
 function getSupportedNetworksFromIssuers(issuers : $ReadOnlyArray<string>) : $ReadOnlyArray<ApplePaySupportedNetworks> {

--- a/src/payment-flows/applepay/utils.js
+++ b/src/payment-flows/applepay/utils.js
@@ -10,7 +10,9 @@ type ValidNetworks = {|
     visa : ApplePaySupportedNetworks,
     mastercard : ApplePaySupportedNetworks,
     amex : ApplePaySupportedNetworks,
-    cb_nationale : ApplePaySupportedNetworks
+    cb_nationale : ApplePaySupportedNetworks,
+    maestro : ApplePaySupportedNetworks,
+    jcb : ApplePaySupportedNetworks
 |};
 
 const validNetworks : ValidNetworks = {
@@ -18,7 +20,9 @@ const validNetworks : ValidNetworks = {
     visa:           'visa',
     mastercard:     'masterCard',
     amex:           'amex',
-    cb_nationale:   'cartesBancaires'
+    cb_nationale:   'cartesBancaires',
+    maestro:        'maestro',
+    jcb:            'jcb'
 };
 
 function getSupportedNetworksFromIssuers(issuers : $ReadOnlyArray<string>) : $ReadOnlyArray<ApplePaySupportedNetworks> {

--- a/src/payment-flows/native/qrcode.js
+++ b/src/payment-flows/native/qrcode.js
@@ -45,15 +45,16 @@ function getEligibility({ fundingSource, props, serviceData, validatePromise } :
                 skipElmo:   true
             }).then(eligibility => {
                 // ignore isUserAgentEligible and isBrowserMobileAndroid for Venmo Desktop as they don't apply
-                if (
-                    !eligibility &&
-                    !eligibility[fundingSource] &&
-                    !eligibility[fundingSource].eligibility &&
-                    eligibility[fundingSource].ineligibilityReason &&
-                    eligibility[fundingSource].ineligibilityReason.length &&
-                    eligibility[fundingSource].ineligibilityReason.indexOf('isUserAgentEligible') === -1 &&
-                    eligibility[fundingSource].ineligibilityReason.indexOf('isBrowserMobileAndroid') === -1
+                const eligibleReasons = [ 'isUserAgentEligible', 'isBrowserMobileAndroid' ];
+                const ineligibleReasons = eligibility && eligibility[fundingSource]?.ineligibilityReason?.split(',');
+                const ineligible = ineligibleReasons?.reduce((acc, reason) => {
+                    acc = acc || eligibleReasons.indexOf(reason) === -1;
+                    return acc;
+                }, false);
 
+                if (
+                    ineligibleReasons &&
+                    ineligible
                 ) {
                     getLogger().info(`native_appswitch_ineligible`, { orderID })
                         .track({

--- a/src/payment-flows/native/qrcode.js
+++ b/src/payment-flows/native/qrcode.js
@@ -48,7 +48,9 @@ function getEligibility({ fundingSource, props, serviceData, validatePromise } :
                 const eligibleReasons = [ 'isUserAgentEligible', 'isBrowserMobileAndroid' ];
                 const ineligibleReasons = eligibility && eligibility[fundingSource]?.ineligibilityReason?.split(',');
 
-                const ineligible = ineligibleReasons?.reduce((acc, reason) => {
+                const ineligible = ineligibleReasons?.every(reason => {
+                    return eligibleReasons.indexOf(reason) === -1;
+                });
                     acc = acc || eligibleReasons.indexOf(reason) === -1;
                     return acc;
                 }, false);

--- a/src/payment-flows/native/qrcode.js
+++ b/src/payment-flows/native/qrcode.js
@@ -47,6 +47,7 @@ function getEligibility({ fundingSource, props, serviceData, validatePromise } :
                 // ignore isUserAgentEligible and isBrowserMobileAndroid for Venmo Desktop as they don't apply
                 const eligibleReasons = [ 'isUserAgentEligible', 'isBrowserMobileAndroid' ];
                 const ineligibleReasons = eligibility && eligibility[fundingSource]?.ineligibilityReason?.split(',');
+
                 const ineligible = ineligibleReasons?.reduce((acc, reason) => {
                     acc = acc || eligibleReasons.indexOf(reason) === -1;
                     return acc;

--- a/src/payment-flows/native/qrcode.js
+++ b/src/payment-flows/native/qrcode.js
@@ -48,16 +48,13 @@ function getEligibility({ fundingSource, props, serviceData, validatePromise } :
                 const eligibleReasons = [ 'isUserAgentEligible', 'isBrowserMobileAndroid' ];
                 const ineligibleReasons = eligibility && eligibility[fundingSource]?.ineligibilityReason?.split(',');
 
-                const ineligible = ineligibleReasons?.every(reason => {
-                    return eligibleReasons.indexOf(reason) === -1;
+                const eligible = ineligibleReasons?.every(reason => {
+                    return eligibleReasons?.indexOf(reason) !== -1;
                 });
-                    acc = acc || eligibleReasons.indexOf(reason) === -1;
-                    return acc;
-                }, false);
 
                 if (
                     ineligibleReasons &&
-                    ineligible
+                    !eligible
                 ) {
                     getLogger().info(`native_appswitch_ineligible`, { orderID })
                         .track({

--- a/src/payment-flows/types.js
+++ b/src/payment-flows/types.js
@@ -137,7 +137,7 @@ export type ApplePayMerchantCapabilities =
     'supports3DS' | 'supportsEMV' | 'supportsCredit' | 'supportsDebit';
 
 export type ApplePaySupportedNetworks =
-    'discover' | 'visa' | 'masterCard' | 'amex' | 'jcb' | 'chinaUnionPay';
+    'discover' | 'visa' | 'masterCard' | 'amex' | 'jcb' | 'chinaUnionPay' | 'cartesBancaires';
 
 export type ApplePayLineItemType = 'final' | 'pending';
 export type ApplePayLineItem = {|

--- a/src/payment-flows/types.js
+++ b/src/payment-flows/types.js
@@ -137,7 +137,7 @@ export type ApplePayMerchantCapabilities =
     'supports3DS' | 'supportsEMV' | 'supportsCredit' | 'supportsDebit';
 
 export type ApplePaySupportedNetworks =
-    'discover' | 'visa' | 'masterCard' | 'amex' | 'jcb' | 'chinaUnionPay' | 'cartesBancaires';
+    'discover' | 'visa' | 'masterCard' | 'amex' | 'jcb' | 'chinaUnionPay' | 'cartesBancaires' | 'maestro' | 'eftpos' | 'electron' | 'vPay';
 
 export type ApplePayLineItemType = 'final' | 'pending';
 export type ApplePayLineItem = {|

--- a/test/client/native-qrcode.js
+++ b/test/client/native-qrcode.js
@@ -21,22 +21,6 @@ describe('native qrcode cases', () => {
 
             const gqlMock = getGraphQLApiMock({
                 extraHandler: expect('firebaseGQLCall', ({ data }) => {
-                    if (data.query.includes('query GetNativeEligibility')) {
-                        return {
-                            data: {
-                                mobileSDKEligibility: {
-                                    paypal: {
-                                        eligibility: true
-                                    },
-                                    venmo: {
-                                        eligibility:         false,
-                                        ineligibilityReason: ''
-                                    }
-                                }
-                            }
-                        };
-                    }
-
                     if (!data.query.includes('query GetFireBaseSessionToken')) {
                         return;
                     }

--- a/test/client/native-qrcode.js
+++ b/test/client/native-qrcode.js
@@ -8,7 +8,7 @@ import { FUNDING, PLATFORM } from '@paypal/sdk-constants/src';
 import { promiseNoop } from '../../src/lib';
 
 import { mockSetupButton, mockAsyncProp, createButtonHTML, clickButton,
-    getNativeFirebaseMock, getGraphQLApiMock, mockFunction } from './mocks';
+    getNativeFirebaseMock, getGraphQLApiMock, mockFunction, generateOrderID } from './mocks';
 
 describe('native qrcode cases', () => {
 
@@ -150,6 +150,7 @@ describe('native qrcode cases', () => {
             delete window.xprops.onClick;
 
             const sessionToken = uniqueID();
+            const payerID = 'XXYYZZ123456';
 
             const gqlMock = getGraphQLApiMock({
                 extraHandler: expect('firebaseGQLCall', ({ data }) => {
@@ -190,33 +191,27 @@ describe('native qrcode cases', () => {
                 })
             }).expectCalls();
 
-            let sessionUID;
+            let mockWebSocketServer;
 
             mockFunction(window.paypal, 'QRCode', expect('QRCode', ({ original, args: [ props ] }) => {
                 const query = parseQuery(props.qrPath.split('?')[1]);
-                sessionUID = query.sessionUID;
+
+                const { expect: expectSocket, onInit, onApprove } = getNativeFirebaseMock({
+                    sessionUID:   query.sessionUID
+                });
+
+                mockWebSocketServer = expectSocket();
+                
+                ZalgoPromise.try(() => {
+                    return onInit();
+                }).then(() => {
+                    return onApprove({ payerID });
+                });
+
                 return original(props);
             }));
 
-            const { expect: expectSocket, onInit, onApprove } = getNativeFirebaseMock({
-                getSessionUID: () => {
-                    if (!sessionUID) {
-                        throw new Error(`Session UID not present`);
-                    }
-
-                    return sessionUID;
-                },
-                extraHandler: expect('extraHandler', ({ message_name, message_type }) => {
-                    if (message_name === 'onInit' && message_type === 'request') {
-                        ZalgoPromise.delay(50).then(onApprove);
-                    }
-                })
-            });
-
-            const mockWebSocketServer = expectSocket();
-
             const orderID = generateOrderID();
-            const payerID = 'XXYYZZ123456';
 
             window.xprops.createOrder = mockAsyncProp(expect('createOrder', async () => {
                 return ZalgoPromise.try(() => {
@@ -252,10 +247,12 @@ describe('native qrcode cases', () => {
             });
 
             await clickButton(FUNDING.VENMO);
-            await ZalgoPromise.delay(50).then(onInit);
             await window.xprops.onApprove.await();
 
-            await mockWebSocketServer.done();
+            if (mockWebSocketServer) {
+                mockWebSocketServer.done();
+            }
+            
             gqlMock.done();
         });
     });


### PR DESCRIPTION
* Current QR code logic would let everything through on second eligibility call.  Only want to let `isUserAgentEligible` and `isBrowserMobileAndroid` through.

* Enable Amplitude in popup.