### PR TITLE
Native flow opt-out `fallback_reason`.

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -184,7 +184,8 @@ export const FPTI_CUSTOM_KEY = {
     INTEGRATION_WHITELIST: ('whitelist' : 'whitelist'),
     INFO_MSG:              ('info_msg' : 'info_msg'),
     PMT_TOKEN:             ('pmt_token' : 'pmt_token'),
-    TRANSITION_TYPE:       ('transition_type' : 'transition_type')
+    TRANSITION_TYPE:       ('transition_type' : 'transition_type'),
+    TRANSITION_REASON:     ('transition_reason' : 'transition_reason')
 };
 
 export const FPTI_BUTTON_KEY = {

--- a/src/native/popup/popup.js
+++ b/src/native/popup/popup.js
@@ -253,8 +253,8 @@ export function setupNativePopup({ parentDomain, env, sessionID, buttonSessionID
             break;
         }
         case HASH.ON_FALLBACK: {
-            const { type, skip_native_duration } = parseQuery(queryString);
-            sendToParent(MESSAGE.ON_FALLBACK, { type, skip_native_duration });
+            const { type, skip_native_duration, fallback_reason } = parseQuery(queryString);
+            sendToParent(MESSAGE.ON_FALLBACK, { type, skip_native_duration, fallback_reason });
             break;
         }
         case HASH.ON_ERROR: {

--- a/src/payment-flows/native/eligibility.js
+++ b/src/payment-flows/native/eligibility.js
@@ -189,7 +189,8 @@ export function isNativePaymentEligible({ payment } : IsPaymentEligibleOptions) 
 
 export type NativeOptOutOptions = {|
     type? : string,
-    skip_native_duration? : number
+    skip_native_duration? : number,
+    fallback_reason? : string
 |};
 
 export function getDefaultNativeOptOutOptions() : NativeOptOutOptions {

--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -163,11 +163,13 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
         return ZalgoPromise.try(() => {
             if (optOut) {
                 const result = setNativeOptOut(optOut);
+                const { fallback_reason } = optOut;
 
                 getLogger().info(`native_message_onfallback`)
                     .track({
-                        [FPTI_KEY.TRANSITION]:             FPTI_TRANSITION.NATIVE_ON_FALLBACK,
-                        [FPTI_CUSTOM_KEY.TRANSITION_TYPE]:  result ? FPTI_TRANSITION.NATIVE_OPT_OUT :  FPTI_TRANSITION.NATIVE_FALLBACK
+                        [FPTI_KEY.TRANSITION]:               FPTI_TRANSITION.NATIVE_ON_FALLBACK,
+                        [FPTI_CUSTOM_KEY.TRANSITION_TYPE]:   result ? FPTI_TRANSITION.NATIVE_OPT_OUT :  FPTI_TRANSITION.NATIVE_FALLBACK,
+                        [FPTI_CUSTOM_KEY.TRANSITION_REASON]: fallback_reason || ''
                     }).flush();
             }
 

--- a/src/payment-flows/native/socket.js
+++ b/src/payment-flows/native/socket.js
@@ -90,7 +90,8 @@ type ConnectNativeOptions = {|
         onFallback : ({|
             data? : {|
                 type? : string,
-                skip_native_duration? : number
+                skip_native_duration? : number,
+                fallback_reason? : string
             |}
         |}) => ZalgoPromise<{|
             buttonSessionID : string


### PR DESCRIPTION
- Added support and logging for a possible fallback reason send from the native opt-out fallback event.
- This will be expected but optional for both iOS - Android opt-out data messages.