### PR TITLE
Remove api call to merchantID when resolving personalization promise

### DIFF
--- a/server/components/buttons/middleware.js
+++ b/server/components/buttons/middleware.js
@@ -93,11 +93,8 @@ export function getButtonMiddleware({
             const clientPromise = getSmartPaymentButtonsClientScript({ debug, logBuffer, cache, useLocal, locationInformation });
             const renderPromise = getPayPalSmartPaymentButtonsRenderScript({ logBuffer, cache, useLocal, locationInformation, sdkLocationInformation });
 
-            const isCardFieldsExperimentEnabledPromise = promiseTimeout(
-                merchantIDPromise.then(merchantID =>
-                    getInlineGuestExperiment(req, { merchantID: merchantID[0], locale, buttonSessionID, buyerCountry })),
-                EXPERIMENT_TIMEOUT
-            ).catch(() => false);
+            const isCardFieldsExperimentEnabledPromise = merchantIDPromise.then(merchantID =>
+                getInlineGuestExperiment(req, { merchantID: merchantID[0], locale, buttonSessionID, buyerCountry }));
 
             const fundingEligibilityPromise = resolveFundingEligibility(req, gqlBatch, {
                 logger, clientID, merchantID: sdkMerchantID, buttonSessionID, currency, intent, commit, vault,

--- a/server/components/buttons/middleware.js
+++ b/server/components/buttons/middleware.js
@@ -114,7 +114,6 @@ export function getButtonMiddleware({
                 logger, clientID, buyerCountry, locale, buttonSessionID, currency, intent, commit,
                 vault, label, period, tagline, personalizationEnabled, renderedButtons
             });
-               
 
             gqlBatch.flush();
 

--- a/server/components/buttons/middleware.js
+++ b/server/components/buttons/middleware.js
@@ -111,7 +111,7 @@ export function getButtonMiddleware({
 
             const personalizationEnabled = getPersonalizationEnabled(req);
             const personalizationPromise = resolvePersonalization(req, gqlBatch, {
-                logger, clientID,  buyerCountry, merchantID: undefined, locale, buttonSessionID, currency, intent, commit,
+                logger, clientID,  buyerCountry, merchantID: [], locale, buttonSessionID, currency, intent, commit,
                 vault, label, period, tagline, personalizationEnabled, renderedButtons
             });
                

--- a/server/components/buttons/middleware.js
+++ b/server/components/buttons/middleware.js
@@ -111,7 +111,7 @@ export function getButtonMiddleware({
 
             const personalizationEnabled = getPersonalizationEnabled(req);
             const personalizationPromise = resolvePersonalization(req, gqlBatch, {
-                logger, clientID,  buyerCountry, locale, buttonSessionID, currency, intent, commit,
+                logger, clientID,  buyerCountry, merchantID: undefined, locale, buttonSessionID, currency, intent, commit,
                 vault, label, period, tagline, personalizationEnabled, renderedButtons
             });
                

--- a/server/components/buttons/middleware.js
+++ b/server/components/buttons/middleware.js
@@ -111,7 +111,7 @@ export function getButtonMiddleware({
 
             const personalizationEnabled = getPersonalizationEnabled(req);
             const personalizationPromise = resolvePersonalization(req, gqlBatch, {
-                logger, clientID,  buyerCountry, merchantID: [], locale, buttonSessionID, currency, intent, commit,
+                logger, clientID,  buyerCountry, locale, buttonSessionID, currency, intent, commit,
                 vault, label, period, tagline, personalizationEnabled, renderedButtons
             });
                

--- a/server/components/buttons/middleware.js
+++ b/server/components/buttons/middleware.js
@@ -111,11 +111,10 @@ export function getButtonMiddleware({
 
             const personalizationEnabled = getPersonalizationEnabled(req);
             const personalizationPromise = promiseTimeout(
-                merchantIDPromise.then(merchantID =>
-                    resolvePersonalization(req, gqlBatch, {
-                        logger, clientID, merchantID, buyerCountry, locale, buttonSessionID, currency, intent, commit,
-                        vault, label, period, tagline, personalizationEnabled, renderedButtons
-                    })),
+                resolvePersonalization(req, gqlBatch, {
+                    logger, clientID,  buyerCountry, locale, buttonSessionID, currency, intent, commit,
+                    vault, label, period, tagline, personalizationEnabled, renderedButtons
+                }),
                 EXPERIMENT_TIMEOUT
             ).catch(() => {
                 return {};

--- a/server/components/buttons/middleware.js
+++ b/server/components/buttons/middleware.js
@@ -111,7 +111,7 @@ export function getButtonMiddleware({
 
             const personalizationEnabled = getPersonalizationEnabled(req);
             const personalizationPromise = resolvePersonalization(req, gqlBatch, {
-                logger, clientID,  buyerCountry, locale, buttonSessionID, currency, intent, commit,
+                logger, clientID, buyerCountry, locale, buttonSessionID, currency, intent, commit,
                 vault, label, period, tagline, personalizationEnabled, renderedButtons
             });
                

--- a/server/service/personalization.jsx
+++ b/server/service/personalization.jsx
@@ -92,7 +92,6 @@ const PERSONALIZATION_QUERY = `
 export type PersonalizationOptions = {|
     logger : LoggerType,
     clientID : string,
-    merchantID : ?$ReadOnlyArray<string>,
     locale : LocaleType,
     buyerCountry : $Values<typeof COUNTRY>,
     buttonSessionID : string,
@@ -135,7 +134,7 @@ function contentToJSX(content : string) : ComponentFunctionType<PersonalizationC
 }
 
 export async function resolvePersonalization(req : ExpressRequest, gqlBatch : GraphQLBatchCall, personalizationOptions : PersonalizationOptions) : Promise<Personalization> {
-    let { logger, clientID, merchantID, locale, buyerCountry, buttonSessionID, currency, intent, commit,
+    let { logger, clientID, locale,  buyerCountry, buttonSessionID, currency, intent, commit,
         vault, label, period, tagline, personalizationEnabled, renderedButtons } = personalizationOptions;
     
     if (!personalizationEnabled) {
@@ -154,7 +153,7 @@ export async function resolvePersonalization(req : ExpressRequest, gqlBatch : Gr
         const result = await gqlBatch({
             query:     PERSONALIZATION_QUERY,
             variables: {
-                clientID, merchantID, locale, buyerCountry, currency, intent, commit, vault, ip, cookies, userAgent,
+                clientID,  locale, buyerCountry, currency, intent, commit, vault, ip, cookies, userAgent,
                 buttonSessionID, label, period, taglineEnabled, renderedButtons
             },
             timeout: PERSONALIZATION_TIMEOUT

--- a/server/service/personalization.jsx
+++ b/server/service/personalization.jsx
@@ -134,7 +134,7 @@ function contentToJSX(content : string) : ComponentFunctionType<PersonalizationC
 }
 
 export async function resolvePersonalization(req : ExpressRequest, gqlBatch : GraphQLBatchCall, personalizationOptions : PersonalizationOptions) : Promise<Personalization> {
-    let { logger, clientID, locale,  buyerCountry, buttonSessionID, currency, intent, commit,
+    let { logger, clientID, locale, buyerCountry, buttonSessionID, currency, intent, commit,
         vault, label, period, tagline, personalizationEnabled, renderedButtons } = personalizationOptions;
     
     if (!personalizationEnabled) {
@@ -153,7 +153,7 @@ export async function resolvePersonalization(req : ExpressRequest, gqlBatch : Gr
         const result = await gqlBatch({
             query:     PERSONALIZATION_QUERY,
             variables: {
-                clientID,  locale, buyerCountry, currency, intent, commit, vault, ip, cookies, userAgent,
+                clientID, locale, buyerCountry, currency, intent, commit, vault, ip, cookies, userAgent,
                 buttonSessionID, label, period, taglineEnabled, renderedButtons
             },
             timeout: PERSONALIZATION_TIMEOUT


### PR DESCRIPTION
* Calling `merchantIDPromise` promise is not necessary since that parameter is being fetch in the graphl query already:
https://github.paypal.com/Checkout-R/xobuyernodeserv/blob/52923902b33f280bec2585063fbf476e57ef299f/src/graphql/data/Marketing/marketingofferread.js#L427. Therefor the call to `promiseTimeout` is not necessary neither