### PR TITLE
Venmo - Update/fix instructions content on Desktop QR code footer

### DIFF
--- a/src/qrcode/qrcard.jsx
+++ b/src/qrcode/qrcard.jsx
@@ -66,7 +66,7 @@ function QRCard({
             <div id="instructions">
                 <InstructionIcon stylingClass="instruction-icon" />
                 <span>
-                    To pay, open the Venmo app and <br />scan the QR code above.
+                    To pay, scan the QR code with <br />your Venmo app
                 </span>
             </div>
             <QRCodeElement svgString={ svgString } />


### PR DESCRIPTION
### Why do we need this change?
The instruction text
```
To pay, open the Venmo app and scan the QR code above.
```
only makes sense if the QR code is above the instructions.

### Solution
Replace the instructions with a new text
```
To pay, scan the QR code with your Venmo app
```

# Screenshot
![image](https://user-images.githubusercontent.com/33497086/131891142-f897a687-a465-4b75-9c82-b4fb218b9bb8.png)
