### PR TITLE
Allow for variants to be carried over from initial fundingEligibility

### DIFF
--- a/server/components/buttons/params.js
+++ b/server/components/buttons/params.js
@@ -184,6 +184,11 @@ function getFundingEligibilityParam(req : ExpressRequest) : FundingEligibilityTy
                             productEligibility.eligible = productEligibilityInput.eligible;
                             productsEligibility[product] = productEligibility;
                         }
+
+                        if (typeof productEligibilityInput.variant === 'string') {
+                            productEligibility.variant = productEligibilityInput.variant;
+                            productsEligibility[product] = productEligibility;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Related to https://github.com/paypal/paypal-checkout-components/pull/1725 and https://github.paypal.com/Checkout-R/clientsdknodeweb/pull/285

In order for the variant based eligibility to carry over it has to be preserved by SPB middleware