### PR TITLE
Fix bug on the iOS opt-out flow.

### DIFF
--- a/src/payment-flows/native/eligibility.js
+++ b/src/payment-flows/native/eligibility.js
@@ -6,7 +6,7 @@ import { supportsPopups, isIos, isAndroid } from 'belter/src';
 
 import { type NativeEligibility, getNativeEligibility } from '../../api';
 import { enableAmplitude, getStorageState, isIOSSafari, isAndroidChrome } from '../../lib';
-import { LSAT_UPGRADE_EXCLUDED_MERCHANTS, FPTI_TRANSITION } from '../../constants';
+import { LSAT_UPGRADE_EXCLUDED_MERCHANTS } from '../../constants';
 import type { ButtonProps, ServiceData } from '../../button/props';
 import type { IsEligibleOptions, IsPaymentEligibleOptions } from '../types';
 
@@ -221,16 +221,17 @@ export function getDefaultNativeOptOutOptions() : NativeOptOutOptions {
 }
 
 export function setNativeOptOut(optOut : NativeOptOutOptions) : boolean {
+    const NATIVE_OPT_OUT = 'native_opt_out';
     const { type, skip_native_duration } = optOut;
 
-    if (type && type === FPTI_TRANSITION.NATIVE_OPT_OUT) {
+    if (type && type === NATIVE_OPT_OUT) {
 
         // Opt-out 6 weeks from native experience as default
         let OPT_OUT_TIME = 6 * 7 * 24 * 60 * 60 * 1000;
         if (skip_native_duration && typeof skip_native_duration === 'number') {
             OPT_OUT_TIME = skip_native_duration;
         }
-
+        
         const now = Date.now();
         getStorageState(state => {
             state.nativeOptOutLifetime = now + OPT_OUT_TIME;

--- a/src/payment-flows/native/eligibility.js
+++ b/src/payment-flows/native/eligibility.js
@@ -221,12 +221,14 @@ export function getDefaultNativeOptOutOptions() : NativeOptOutOptions {
 }
 
 export function setNativeOptOut(optOut : NativeOptOutOptions) : boolean {
-    if (optOut.type === FPTI_TRANSITION.NATIVE_OPT_OUT) {
+    const { type, skip_native_duration } = optOut;
+
+    if (type && type === FPTI_TRANSITION.NATIVE_OPT_OUT) {
 
         // Opt-out 6 weeks from native experience as default
         let OPT_OUT_TIME = 6 * 7 * 24 * 60 * 60 * 1000;
-        if (optOut.skip_native_duration && typeof optOut.skip_native_duration === 'number') {
-            OPT_OUT_TIME = optOut.skip_native_duration;
+        if (skip_native_duration && typeof skip_native_duration === 'number') {
+            OPT_OUT_TIME = skip_native_duration;
         }
 
         const now = Date.now();

--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -160,17 +160,16 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
         const { win, optOut = getDefaultNativeOptOutOptions() } = opts || {};
         
         return ZalgoPromise.try(() => {
-            if (optOut) {
-                const result = setNativeOptOut(optOut);
-                const { fallback_reason } = optOut;
 
-                getLogger().info(`native_message_onfallback`)
-                    .track({
-                        [FPTI_KEY.TRANSITION]:               FPTI_TRANSITION.NATIVE_ON_FALLBACK,
-                        [FPTI_CUSTOM_KEY.TRANSITION_TYPE]:   result ? FPTI_TRANSITION.NATIVE_OPT_OUT :  FPTI_TRANSITION.NATIVE_FALLBACK,
-                        [FPTI_CUSTOM_KEY.TRANSITION_REASON]: fallback_reason || ''
-                    }).flush();
-            }
+            const result = setNativeOptOut(optOut);
+            const { fallback_reason } = optOut;
+
+            getLogger().info(`native_message_onfallback`)
+                .track({
+                    [FPTI_KEY.TRANSITION]:               FPTI_TRANSITION.NATIVE_ON_FALLBACK,
+                    [FPTI_CUSTOM_KEY.TRANSITION_TYPE]:   result ? FPTI_TRANSITION.NATIVE_OPT_OUT :  FPTI_TRANSITION.NATIVE_FALLBACK,
+                    [FPTI_CUSTOM_KEY.TRANSITION_REASON]: fallback_reason || ''
+                }).flush();
 
             fallbackToWebCheckout(win);
             return { buttonSessionID };

--- a/src/payment-flows/native/popup.js
+++ b/src/payment-flows/native/popup.js
@@ -470,8 +470,7 @@ export function initNativePopup({ props, serviceData, config, fundingSource, ses
                     closePopup('onCancel');
                 });
 
-                const onFallbackListener = onPostMessage(nativePopupWin, nativePopupDomain, POST_MESSAGE.ON_FALLBACK, (data) => {
-                    detectAppSwitch();
+                const onFallbackListener = onPostMessage(nativePopupWin, nativePopupDomain, POST_MESSAGE.ON_FALLBACK, ({ data }) => {
                     getLogger().info(`native_message_onfallback`)
                         .track({
                             [FPTI_KEY.TRANSITION]: FPTI_TRANSITION.NATIVE_ON_FALLBACK


### PR DESCRIPTION
**Reasoning**
After an initial test from the iOS team we found that the opt-out logic wasn't working as expected for the iOS Venice app.

**Changes**
In this PR I'm fixing an issue with the payload data object when passing this payload received from the `fallback` event back to its parent window via `onPostMessage` (postRobot).

I also did a refactor on the existing native opt-out logic.