### PR TITLE
feat: log and track onError checkout calls

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -113,6 +113,7 @@ export const FPTI_TRANSITION = {
     CHECKOUT_SHIPPING_CHANGE: ('process_checkout_shipping_change' : 'process_checkout_shipping_change'),
     CHECKOUT_APPROVE:         ('process_checkout_approve' : 'process_checkout_approve'),
     CHECKOUT_CANCEL:          ('process_checkout_cancel' : 'process_checkout_cancel'),
+    CHECKOUT_ERROR:           ('process_checkout_error' : 'process_checkout_error'),
 
     TOKENIZE_APPROVE:         ('process_tokenize_approve' : 'process_tokenize_approve'),
 

--- a/src/payment-flows/checkout.js
+++ b/src/payment-flows/checkout.js
@@ -265,18 +265,13 @@ function initCheckout({ props, components, serviceData, payment, config } : Init
             },
 
             onError: (err) => {
-                return createOrder().then(orderID => {
-                    getLogger()
-                        .info('on_error_tracking')
-                        .track({
-                            [FPTI_KEY.TRANSITION]:   FPTI_TRANSITION.CHECKOUT_ERROR,
-                            [FPTI_KEY.CONTEXT_TYPE]: FPTI_CONTEXT_TYPE.ORDER_ID,
-                            [FPTI_KEY.TOKEN]:        orderID,
-                            [FPTI_KEY.CONTEXT_ID]:   orderID,
-                            [FPTI_KEY.ERROR_DESC]:   JSON.stringify(err)
-                        }).flush();
-                    return onError(err);
-                });
+                getLogger()
+                    .info(`checkout_flow_error `, { err: stringifyError(err) })
+                    .track({
+                        [FPTI_KEY.TRANSITION]:   FPTI_TRANSITION.CHECKOUT_ERROR,
+                        [FPTI_KEY.ERROR_DESC]:   stringifyError(err)
+                    }).flush();
+                return onError(err);
             },
 
             dimensions: getDimensions(fundingSource),

--- a/src/payment-flows/checkout.js
+++ b/src/payment-flows/checkout.js
@@ -264,7 +264,21 @@ function initCheckout({ props, components, serviceData, payment, config } : Init
                 }
             },
 
-            onError,
+            onError: (err) => {
+                return createOrder().then(orderID => {
+                    getLogger()
+                        .info('on_error_tracking')
+                        .track({
+                            [FPTI_KEY.TRANSITION]:   FPTI_TRANSITION.CHECKOUT_ERROR,
+                            [FPTI_KEY.CONTEXT_TYPE]: FPTI_CONTEXT_TYPE.ORDER_ID,
+                            [FPTI_KEY.TOKEN]:        orderID,
+                            [FPTI_KEY.CONTEXT_ID]:   orderID,
+                            [FPTI_KEY.ERROR_DESC]:   JSON.stringify(err)
+                        }).flush();
+                    return onError(err);
+                });
+            },
+
             dimensions: getDimensions(fundingSource),
 
             fundingSource,


### PR DESCRIPTION
Track onError calls to determine flow interaction of proposed onError changes:

`onError: (err) => {
                // eslint-disable-next-line no-use-before-define
                return close().then(() => {
                    return onError(err);
                });
            },`