### PR TITLE
Cleanup QRCode Escape Path

### DIFF
--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -4,7 +4,7 @@
 import { uniqueID, memoize, stringifyError,
     stringifyErrorMessage, cleanup, noop } from 'belter/src';
 import { ZalgoPromise } from 'zalgo-promise/src';
-import { FPTI_KEY, FUNDING } from '@paypal/sdk-constants/src';
+import { FPTI_KEY } from '@paypal/sdk-constants/src';
 import { type CrossDomainWindowType } from 'cross-domain-utils/src';
 
 import { updateButtonClientConfig, onLsatUpgradeCalled } from '../../api';
@@ -176,18 +176,6 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
         });
     };
 
-    const onQrEscapePathCallback = (qrInstance, selectedFundingSource : $Values<typeof FUNDING>) => {
-        return ZalgoPromise.try(() => {
-            const paymentInfo = { ...payment, fundingSource: selectedFundingSource };
-            const instance = checkout.init({ props, components, payment: paymentInfo, config, serviceData });
-            clean.register(() => instance.close());
-            
-            return instance.start().then(() => {
-                return true;
-            });
-        });
-    };
-
     const onCloseCallback = () => {
         return ZalgoPromise.delay(1000).then(() => {
             
@@ -211,7 +199,7 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
     }
 
     const flow = initFlow({
-        props, serviceData, config, components, fundingSource, clean, sessionUID,
+        props, serviceData, config, components, payment, clean, sessionUID,
         callbacks: {
             onInit:            onInitCallback,
             onApprove:         onApproveCallback,
@@ -220,7 +208,6 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
             onShippingChange:  onShippingChangeCallback,
             onFallback:        onFallbackCallback,
             onClose:           onCloseCallback,
-            onQrEscapePath:    onQrEscapePathCallback,
             onDestroy:         destroy
         }
     });

--- a/src/payment-flows/native/native.js
+++ b/src/payment-flows/native/native.js
@@ -56,13 +56,6 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
         return instance.start();
     };
 
-    const qrEscapePath = (selectedFundingSource : $Values<typeof FUNDING>) => {
-        const paymentInfo = { ...payment, fundingSource: selectedFundingSource };
-        const instance = checkout.init({ props, components, payment: paymentInfo, config, serviceData });
-        clean.register(() => instance.close());
-        return instance.start();
-    };
-
     const onInitCallback = () => {
         return ZalgoPromise.try(() => {
             onLsatUpgradeCalled();
@@ -183,9 +176,15 @@ function initNative({ props, components, config, payment, serviceData } : InitOp
         });
     };
 
-    const onQrEscapePathCallback = (selectedFundingSource : $Values<typeof FUNDING>) => {
+    const onQrEscapePathCallback = (qrInstance, selectedFundingSource : $Values<typeof FUNDING>) => {
         return ZalgoPromise.try(() => {
-            return qrEscapePath(selectedFundingSource);
+            const paymentInfo = { ...payment, fundingSource: selectedFundingSource };
+            const instance = checkout.init({ props, components, payment: paymentInfo, config, serviceData });
+            clean.register(() => instance.close());
+            
+            return instance.start().then(() => {
+                return true;
+            });
         });
     };
 

--- a/src/payment-flows/native/popup.js
+++ b/src/payment-flows/native/popup.js
@@ -10,6 +10,7 @@ import { getLogger, isAndroidChrome, unresolvedPromise, getStorageState } from '
 import { FPTI_STATE, FPTI_TRANSITION, FPTI_CUSTOM_KEY } from '../../constants';
 import type { ButtonProps, ServiceData, Config, Components } from '../../button/props';
 import { type OnShippingChangeData } from '../../props/onShippingChange';
+import type { Payment } from '../types';
 
 
 import { isNativeOptedIn, type NativeOptOutOptions } from './eligibility';
@@ -108,7 +109,7 @@ type NativePopupOptions = {|
     serviceData : ServiceData,
     config : Config,
     components : Components,
-    fundingSource : $Values<typeof FUNDING>,
+    payment : Payment,
     sessionUID : string,
     clean : CleanupType,
     callbacks : {|
@@ -146,8 +147,7 @@ type NativePopupOptions = {|
             buttonSessionID : string
         |}>,
         onClose : () => ZalgoPromise<void>,
-        onDestroy : () => ZalgoPromise<void>,
-        onQrEscapePath : (selectedFundingSource : $Values<typeof FUNDING>) => ZalgoPromise<void>
+        onDestroy : () => ZalgoPromise<void>
     |}
 |};
 
@@ -156,9 +156,10 @@ type NativePopup = {|
     start : () => ZalgoPromise<void>
 |};
 
-export function initNativePopup({ props, serviceData, config, fundingSource, sessionUID, callbacks, clean } : NativePopupOptions) : NativePopup {
+export function initNativePopup({ props, serviceData, config, payment, sessionUID, callbacks, clean } : NativePopupOptions) : NativePopup {
     const { onClick, createOrder } = props;
     const { firebase: firebaseConfig } = config;
+    const { fundingSource } = payment;
     const { onInit, onApprove, onCancel, onError, onFallback, onClose, onDestroy, onShippingChange } = callbacks;
 
     if (!firebaseConfig) {

--- a/src/payment-flows/native/qrcode.js
+++ b/src/payment-flows/native/qrcode.js
@@ -10,6 +10,8 @@ import { getLogger, getStorageID } from '../../lib';
 import { FPTI_STATE, FPTI_TRANSITION, TARGET_ELEMENT, QRCODE_STATE, FPTI_CUSTOM_KEY } from '../../constants';
 import type { ButtonProps, ServiceData, Config, Components } from '../../button/props';
 import { type OnShippingChangeData } from '../../props/onShippingChange';
+import type { Payment } from '../types';
+import { checkout } from '../checkout';
 
 import { getNativeUrl } from './url';
 import { connectNative } from './socket';
@@ -77,7 +79,7 @@ type NativeQRCodeOptions = {|
     serviceData : ServiceData,
     config : Config,
     components : Components,
-    fundingSource : $Values<typeof FUNDING>,
+    payment : Payment,
     sessionUID : string,
     clean : CleanupType,
     callbacks : {|
@@ -115,8 +117,7 @@ type NativeQRCodeOptions = {|
             buttonSessionID : string
         |}>,
         onClose : () => ZalgoPromise<void>,
-        onDestroy : () => ZalgoPromise<void>,
-        onQrEscapePath : (selectedFundingSource : $Values<typeof FUNDING>) => ZalgoPromise<void>
+        onDestroy : () => ZalgoPromise<void>
     |}
 |};
 
@@ -125,10 +126,11 @@ type NativeQRCode = {|
     start : () => ZalgoPromise<void>
 |};
 
-export function initNativeQRCode({ props, serviceData, config, components, fundingSource, clean, callbacks, sessionUID } : NativeQRCodeOptions) : NativeQRCode {
+export function initNativeQRCode({ props, serviceData, config, components, payment, clean, callbacks, sessionUID } : NativeQRCodeOptions) : NativeQRCode {
     const { createOrder, onClick } = props;
     const { QRCode } = components;
-    const { onInit, onApprove, onCancel, onError, onFallback, onClose, onDestroy, onShippingChange, onQrEscapePath } = callbacks;
+    const { fundingSource } = payment;
+    const { onInit, onApprove, onCancel, onError, onFallback, onClose, onDestroy, onShippingChange } = callbacks;
 
     const qrCodeRenderTarget = window.xprops.getParent();
     const pageUrl = window.xprops.getPageUrl();
@@ -161,7 +163,15 @@ export function initNativeQRCode({ props, serviceData, config, components, fundi
                     [FPTI_KEY.TRANSITION]:  `${ FPTI_TRANSITION.QR_PROCESS_PAY_WITH }_${ selectedFundingSource }`
                 }).flush();
 
-                return onQrEscapePath(selectedFundingSource);
+                return ZalgoPromise.try(() => {
+                    const paymentInfo = { ...payment, fundingSource: selectedFundingSource };
+                    const instance = checkout.init({ props, components, payment: paymentInfo, config, serviceData });
+                    clean.register(() => instance.close());
+                    
+                    return instance.start().then(() => {
+                        return ZalgoPromise.resolve();
+                    });
+                });
             };
 
             const validatePromise = ZalgoPromise.try(() => {

--- a/src/payment-flows/native/qrcode.js
+++ b/src/payment-flows/native/qrcode.js
@@ -160,6 +160,7 @@ export function initNativeQRCode({ props, serviceData, config, components, fundi
                     [FPTI_KEY.STATE]:       FPTI_STATE.BUTTON,
                     [FPTI_KEY.TRANSITION]:  `${ FPTI_TRANSITION.QR_PROCESS_PAY_WITH }_${ selectedFundingSource }`
                 }).flush();
+
                 return onQrEscapePath(selectedFundingSource);
             };
 

--- a/src/qrcode/qrcard.jsx
+++ b/src/qrcode/qrcard.jsx
@@ -57,7 +57,9 @@ function QRCard({
 
     const handleClick = (selectedFundingSource : $Values<typeof FUNDING>) => {
         window.xprops.hide();
-        window.xprops.onEscapePath(selectedFundingSource);
+        window.xprops.onEscapePath(selectedFundingSource).then(() => {
+            window.xprops.close();
+        });
     };
 
     const errorMessage = (


### PR DESCRIPTION
### Your checklist for this pull request
🚨 Please review the [guidelines for a good PR Description](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)

- [x] Ensure you have a PR description that answers: What? Why? How?
- [ ] Link to any reference tickets if they are available. This includes Jira ticket or Github issues.
- [x] Include any relevant screenshots for the change set if it modifies any visual functionality.
- [x] Ensure you have added passing tests to cover new functionality, bug fixes, etc.

### Description

Currently the `qrcode` frame does not get cleaned up and there is QRCode specific code in native.js which is a shared location amongst all native flows.  This currently does not impact the customer but want to make this right and tight.

#### What is being changed from a technical perspective?

#### Why are we making these changes? Include and reference tickets (Jira, Github Issue, etc)

### Reproduction Steps (if applicable)

### Screenshots (if applicable)
**QR Code**
<img width="1128" alt="modal_shown" src="https://user-images.githubusercontent.com/1324812/133848161-c0fe1f36-bf93-41d7-b5ff-6b1bcd2a2010.png">

**QR Escape Path - PayPal**
<img width="1098" alt="paypal_escape" src="https://user-images.githubusercontent.com/1324812/133848229-48f5099c-a009-4b2d-8a26-f6524c4091fb.png">

**QR Escape Path - Guest (Card)**
<img width="1008" alt="guest_escape" src="https://user-images.githubusercontent.com/1324812/133848278-1a19fb0f-ac46-45cb-ba90-14c2db2152b8.png">

**QR Escape Path Cleanup of iframe after Checkout**
<img width="484" alt="closed_qr_code_after_closed_paypal" src="https://user-images.githubusercontent.com/1324812/133848336-d3ed7219-6c68-4590-8645-25b2d7729ddb.png">



❤️  Thank you!
