### PR TITLE
Convert skip native duration from a string to integer

### DIFF
--- a/src/payment-flows/native/eligibility.js
+++ b/src/payment-flows/native/eligibility.js
@@ -228,8 +228,11 @@ export function setNativeOptOut(optOut : NativeOptOutOptions) : boolean {
 
         // Opt-out 6 weeks from native experience as default
         let OPT_OUT_TIME = 6 * 7 * 24 * 60 * 60 * 1000;
-        if (skip_native_duration && typeof parseInt(skip_native_duration, 10) === 'number') {
-            OPT_OUT_TIME = parseInt(skip_native_duration, 10);
+
+        const parsedSkipDuration = parseInt(skip_native_duration, 10);
+
+        if (parsedSkipDuration && typeof parsedSkipDuration === 'number') {
+            OPT_OUT_TIME = parsedSkipDuration;
         }
         
         const now = Date.now();

--- a/src/payment-flows/native/eligibility.js
+++ b/src/payment-flows/native/eligibility.js
@@ -228,8 +228,8 @@ export function setNativeOptOut(optOut : NativeOptOutOptions) : boolean {
 
         // Opt-out 6 weeks from native experience as default
         let OPT_OUT_TIME = 6 * 7 * 24 * 60 * 60 * 1000;
-        if (skip_native_duration && typeof skip_native_duration === 'number') {
-            OPT_OUT_TIME = skip_native_duration;
+        if (skip_native_duration && typeof parseInt(skip_native_duration, 10) === 'number') {
+            OPT_OUT_TIME = parseInt(skip_native_duration, 10);
         }
         
         const now = Date.now();

--- a/src/payment-flows/native/eligibility.js
+++ b/src/payment-flows/native/eligibility.js
@@ -228,11 +228,8 @@ export function setNativeOptOut(optOut : NativeOptOutOptions) : boolean {
 
         // Opt-out 6 weeks from native experience as default
         let OPT_OUT_TIME = 6 * 7 * 24 * 60 * 60 * 1000;
-
-        const parsedSkipDuration = parseInt(skip_native_duration, 10);
-
-        if (parsedSkipDuration && typeof parsedSkipDuration === 'number') {
-            OPT_OUT_TIME = parsedSkipDuration;
+        if (skip_native_duration && typeof parseInt(skip_native_duration, 10) === 'number') {
+            OPT_OUT_TIME = parseInt(skip_native_duration, 10);
         }
         
         const now = Date.now();

--- a/src/payment-flows/native/popup.js
+++ b/src/payment-flows/native/popup.js
@@ -526,3 +526,4 @@ export function initNativePopup({ props, serviceData, config, payment, sessionUI
         }
     };
 }
+


### PR DESCRIPTION
### Description

On the iOS fallback the params are always string and for the iOS opt-out it is required to have the `skip_native_duration` as integer.

#### What is being changed from a technical perspective?

Added logic on the `setNativeOptOut` to parse to int the `skip_native_duration` on the fallback event.

#### Why are we making these changes? Include and reference tickets (Jira, Github Issue, etc)

- https://engineering.paypalcorp.com/jira/browse/DTPPSDK-345

### Reproduction Steps (if applicable)

When using the opt-out fallback event and passing `skip_native_duration` (in milliseconds) the JS SDK should handle this properly and set the `nativeOptOutLifetime` calculated as `Date.now()` + `skip_native_duration` (all in milliseconds, unix timestamp).

If the params `skip_native_duration` is not passed on the fallback event the default value should be: `let OPT_OUT_TIME = 6 * 7 * 24 * 60 * 60 * 1000;`
