### PR TITLE
Set dist tag in pre release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build-commit": "npm run build && git add dist && (git commit -m 'Dist' || echo 'Nothing to commit') && git push",
     "release": "npm run build-commit && grabthar-release",
     "postrelease": "npm run cdnify -- --commitonly",
-    "release:pre": "npm run build-commit && grabthar-release prerelease",
+    "release:pre": "npm run build-commit && DIST_TAG=alpha grabthar-release prerelease",
     "deploy": "npm run cdnify",
     "activate:cli": "CDN='https://www.paypalobjects.com' grabthar-activate",
     "activate": "CDNIFY=false grabthar-activate",


### PR DESCRIPTION
### Description

Set the dist-tag to alpha when publishing a prelease. 

This is used by grabthar-release when doing `npm publish`: https://github.com/krakenjs/grabthar-release/blob/master/scripts/release.sh#L18

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

We want to support using `npm run release:pre` for easily publishing prereleases to npm without impacting the latest version.
