### PR TITLE
Use closeOnUnload

### DIFF
--- a/src/qrcode/qrcard.jsx
+++ b/src/qrcode/qrcard.jsx
@@ -57,7 +57,7 @@ function QRCard({
 
     const handleClick = (selectedFundingSource : $Values<typeof FUNDING>) => {
         window.xprops.hide();
-        const win = openPopup({ width: CHECKOUT_POPUP_DIMENSIONS.WIDTH, height: CHECKOUT_POPUP_DIMENSIONS.HEIGHT });
+        const win = openPopup({ width: CHECKOUT_POPUP_DIMENSIONS.WIDTH, height: CHECKOUT_POPUP_DIMENSIONS.HEIGHT, closeOnUnload: 0 });
         window.xprops.onEscapePath(win, selectedFundingSource).then(() => {
             window.xprops.close();
         });

--- a/src/ui/popup.jsx
+++ b/src/ui/popup.jsx
@@ -8,8 +8,8 @@ import { assertSameDomain, type CrossDomainWindowType } from 'cross-domain-utils
 
 import { getNonce } from '../lib';
 
-export function openPopup({ width, height } : {| width : number, height : number |}) : CrossDomainWindowType {
-    const win = assertSameDomain(popup('', { width, height }));
+export function openPopup({ width, height, closeOnUnload = 1 } : {| width : number, height : number, closeOnUnload : 0 | 1 |}) : CrossDomainWindowType {
+    const win = assertSameDomain(popup('', { width, height, closeOnUnload }));
 
     const doc = win.document;
 

--- a/src/ui/popup.jsx
+++ b/src/ui/popup.jsx
@@ -8,7 +8,7 @@ import { assertSameDomain, type CrossDomainWindowType } from 'cross-domain-utils
 
 import { getNonce } from '../lib';
 
-export function openPopup({ width, height, closeOnUnload = 1 } : {| width : number, height : number, closeOnUnload : 0 | 1 |}) : CrossDomainWindowType {
+export function openPopup({ width, height, closeOnUnload = 1 } : {| width : number, height : number, closeOnUnload? : 0 | 1 |}) : CrossDomainWindowType {
     const win = assertSameDomain(popup('', { width, height, closeOnUnload }));
 
     const doc = win.document;


### PR DESCRIPTION
### Description
`closeOnUnload` allows us to set responsibilities on whether the popup is closed if parent is refreshed.  For QR escape paths, we don't want the child to close when the parent closes.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->

❤️  Thank you!
