### PR TITLE
set error message based on issue code

### DIFF
--- a/src/api/order.js
+++ b/src/api/order.js
@@ -346,10 +346,10 @@ export type ValidatePaymentMethodResponse = {|
     links? : $ReadOnlyArray<{|
         rel : string
     |}>,
-    details? : $ReadOnlyArray<{
+    details? : $ReadOnlyArray<{|
         issue? : string,
         description? : string
-    }>
+    |}>
 |};
 
 type PaymentSource = {|

--- a/src/api/order.js
+++ b/src/api/order.js
@@ -345,7 +345,11 @@ const VALIDATE_CONTINGENCIES = {
 export type ValidatePaymentMethodResponse = {|
     links? : $ReadOnlyArray<{|
         rel : string
-    |}>
+    |}>,
+    details? : $ReadOnlyArray<{
+        issue? : string,
+        description? : string
+    }>
 |};
 
 type PaymentSource = {|
@@ -681,7 +685,7 @@ export type DetailedOrderInfo = {|
                     currencyValue : string,
                     currencyCode : $Values<typeof CURRENCY>
                 |},
-                
+
                 subtotal : {|
                     currencyFormatSymbolISOCurrency : string,
                     currencyValue : string,

--- a/src/payment-flows/vault-capture.js
+++ b/src/payment-flows/vault-capture.js
@@ -106,7 +106,7 @@ function handleValidateResponse({ ThreeDomainSecure, status, body, createOrder, 
                 const { issue, description } = details || {};
 
                 message = [
-                    ...(issue ? [ `Code: ${ issue }` ] : []),
+                    ...(issue ? [ `issue:${ issue }` ] : []),
                     ...(description ? [ `Description: ${ description }` ] : [])
                 ].join(', ');
                 message = message.trim().length === 0 ? DEFAULT_ERROR_MESSAGE : message;

--- a/src/payment-flows/vault-capture.js
+++ b/src/payment-flows/vault-capture.js
@@ -97,22 +97,17 @@ function handleValidateResponse({ ThreeDomainSecure, status, body, createOrder, 
         }
 
         if (status !== 200) {
-            const DEFAULT_ERROR_MESSAGE = `Validate payment failed with status: ${ status }`;
-            let message = DEFAULT_ERROR_MESSAGE;
 
             const hasDescriptiveErrorCode = Array.isArray(body.details);
             if (hasDescriptiveErrorCode) {
                 const details = body.details && body.details[0];
-                const { issue, description } = details || {};
-
-                message = [
-                    ...(issue ? [ `issue:${ issue }` ] : []),
-                    ...(description ? [ `Description: ${ description }` ] : [])
-                ].join(', ');
-                message = message.trim().length === 0 ? DEFAULT_ERROR_MESSAGE : message;
+                const { issue = '' } = details || {};
+                if (issue.trim().length === 0) {
+                    throw new Error(`Validate payment failed with issue: ${ issue }`);
+                }
             }
 
-            throw new Error(message);
+            throw new Error(`Validate payment failed with status: ${ status }`);
         }
     });
 }

--- a/src/payment-flows/vault-capture.js
+++ b/src/payment-flows/vault-capture.js
@@ -68,7 +68,7 @@ type ThreeDomainSecureProps = {|
 |};
 
 function handleThreeDomainSecure({ ThreeDomainSecure, createOrder, getParent } : ThreeDomainSecureProps) : ZalgoPromise<void> {
-    
+
     const promise = new ZalgoPromise();
     const instance = ThreeDomainSecure({
         createOrder,
@@ -97,7 +97,22 @@ function handleValidateResponse({ ThreeDomainSecure, status, body, createOrder, 
         }
 
         if (status !== 200) {
-            throw new Error(`Validate payment failed with status: ${ status }`);
+            const DEFAULT_ERROR_MESSAGE = `Validate payment failed with status: ${ status }`;
+            let message = DEFAULT_ERROR_MESSAGE;
+
+            const hasDescriptiveErrorCode = Array.isArray(body.details);
+            if (hasDescriptiveErrorCode) {
+                const details = body.details && body.details[0];
+                const { issue, description } = details || {};
+
+                message = [
+                    ...(issue ? [ `Code: ${ issue }` ] : []),
+                    ...(description ? [ `Description: ${ description }` ] : [])
+                ].join(', ');
+                message = message.trim().length === 0 ? DEFAULT_ERROR_MESSAGE : message;
+            }
+
+            throw new Error(message);
         }
     });
 }
@@ -173,7 +188,7 @@ function initVaultCapture({ props, components, payment, serviceData, config } : 
         return createOrder().then(orderID => {
             return loadFraudnet({ env, clientMetadataID, cspNonce }).catch(noop).then(() => {
                 const installmentsEligible = isVaultCaptureInstallmentsEligible({ props, serviceData });
-            
+
                 getLogger()
                     .info(installmentsEligible ? 'vault_merchant_installments_eligible' : 'vault_merchant_installments_ineligible')
                     .track({
@@ -248,7 +263,7 @@ function setupVaultMenu({ props, payment, serviceData, components, config } : Me
                 [FPTI_KEY.TRANSITION]:      FPTI_TRANSITION.CLICK_CHOOSE_FUNDING,
                 [FPTI_KEY.OPTION_SELECTED]: FPTI_MENU_OPTION.CHOOSE_FUNDING
             }).flush();
-            
+
             return ZalgoPromise.try(() => {
                 return updateMenuClientConfig();
             }).then(() => {

--- a/src/payment-flows/vault-capture.js
+++ b/src/payment-flows/vault-capture.js
@@ -102,7 +102,7 @@ function handleValidateResponse({ ThreeDomainSecure, status, body, createOrder, 
             if (hasDescriptiveErrorCode) {
                 const details = body.details && body.details[0];
                 const { issue = '' } = details || {};
-                if (issue.trim().length === 0) {
+                if (issue.trim().length !== 0) {
                     throw new Error(`Validate payment failed with issue: ${ issue }`);
                 }
             }


### PR DESCRIPTION
### Description

Smart payment buttons throws a generic `Validate payment failed with status: ${ status }` error when `validate-payment-method` call  fails as per [this](https://github.com/paypal/paypal-smart-payment-buttons/blob/master/src/payment-flows/vault-capture.js#L100). Instead we should throw the error message with`issue` code, if available.

### Why are we making these changes?

Merchants needs to know the exact `issue` code to display the relevant actionable message to the user. 

### Screenshots

**Existing**
<img width="1729" alt="Screenshot 2021-09-27 at 1 01 40 PM" src="https://user-images.githubusercontent.com/1156953/134904702-89bb6954-5928-49f8-b456-5c11a2467fa9.png">

**Proposed**
<img width="1717" alt="Screenshot 2021-09-27 at 12 59 44 PM" src="https://user-images.githubusercontent.com/1156953/134904765-e3bd7637-9d66-4a84-beca-6314aac722cb.png">



