### PR TITLE
Auto Retry for Native Flow

### DIFF
--- a/server/components/native/middleware.js
+++ b/server/components/native/middleware.js
@@ -95,13 +95,13 @@ export function getNativeFallbackMiddleware({
                 logger.info(req, `smart_native_fallback_cookie_${ name || 'unknown' }`);
             }
 
-            const { cspNonce, debug } = getNativeFallbackParams(params, req, res);
+            const { cspNonce, debug, retry } = getNativeFallbackParams(params, req, res);
 
             const { NativeFallback } = (await getNativeFallbackRenderScript({ logBuffer, cache, debug, useLocal, locationInformation })).fallback;
             const client = await getNativeFallbackClientScript({ debug, logBuffer, cache, useLocal, locationInformation });
 
             const setupParams = {
-                
+                retry
             };
 
             const pageHTML = `

--- a/server/components/native/params.js
+++ b/server/components/native/params.js
@@ -114,23 +114,27 @@ export function getNativePopupParams(params : NativePopupInputParams, req : Expr
 }
 
 type NativeFallbackInputParams = {|
-    debug? : boolean
+    debug? : boolean,
+    retry? : boolean
 |};
 
 type NativeFallbackParams = {|
     cspNonce : string,
-    debug : boolean
+    debug : boolean,
+    retry : boolean
 |};
 
 export function getNativeFallbackParams(params : NativeFallbackInputParams, req : ExpressRequest, res : ExpressResponse) : NativeFallbackParams {
     const {
-        debug = false
+        debug = false,
+        retry = false
     } = params;
 
     const cspNonce = getCSPNonce(res);
 
     return {
         cspNonce,
-        debug: Boolean(debug)
+        debug: Boolean(debug),
+        retry: Boolean(retry)
     };
 }

--- a/src/native/fallback/constants.js
+++ b/src/native/fallback/constants.js
@@ -1,5 +1,6 @@
 /* @flow */
 
 export const MESSAGE = {
+    DETECT_RETRY:      'detectRetry',
     DETECT_WEB_SWITCH: 'detectWebSwitch'
 };

--- a/src/native/fallback/fallback.js
+++ b/src/native/fallback/fallback.js
@@ -32,7 +32,7 @@ export function setupNativeFallback({ parentDomain = window.location.origin, ret
     };
 
     if (retry) {
-        window.xprops.restart({ win: window });
+        sendToParent(MESSAGE.DETECT_RETRY);
     }
 
     sendToParent(MESSAGE.DETECT_WEB_SWITCH);

--- a/src/native/fallback/fallback.js
+++ b/src/native/fallback/fallback.js
@@ -8,14 +8,15 @@ import { getPostRobot } from '../../lib';
 import { MESSAGE } from './constants';
 
 type SetupNativeFallbackOptions = {|
-    parentDomain : string
+    parentDomain : string,
+    retry : boolean
 |};
 
 type NativeFallback = {|
     destroy : () => ZalgoPromise<void>
 |};
 
-export function setupNativeFallback({ parentDomain = window.location.origin } : SetupNativeFallbackOptions) : NativeFallback {
+export function setupNativeFallback({ parentDomain = window.location.origin, retry } : SetupNativeFallbackOptions) : NativeFallback {
     if (!window.opener) {
         throw new Error(`Expected window to have opener`);
     }
@@ -29,6 +30,10 @@ export function setupNativeFallback({ parentDomain = window.location.origin } : 
         return postRobot.send(window.opener, event, payload, { domain: parentDomain })
             .then(({ data }) => data);
     };
+
+    if (retry) {
+        window.xprops.restart({ win: window });
+    }
 
     sendToParent(MESSAGE.DETECT_WEB_SWITCH);
 

--- a/src/payment-flows/native/popup.js
+++ b/src/payment-flows/native/popup.js
@@ -403,7 +403,7 @@ export function initNativePopup({ payment, props, serviceData, config, sessionUI
                 const onDetectRetry = once(({ orderID, pageUrl, stickinessID }) : ZalgoPromise<void> => {
                     return nativePopupWinProxy.setLocation(getNativeUrl({
                         props, serviceData, config, fundingSource, sessionUID, pageUrl, orderID, stickinessID
-                    })).then(noop);
+                    })).catch(reject);
                 });
 
                 const closeListener = onCloseProxyWindow(nativePopupWinProxy, () => {

--- a/src/payment-flows/native/popup.js
+++ b/src/payment-flows/native/popup.js
@@ -422,6 +422,19 @@ export function initNativePopup({ payment, props, serviceData, config, sessionUI
                     nativePopupWinProxy.close();
                 };
 
+                const appDetected = (() => {
+                    let called = false;
+
+                    return function detectApp({ app }) : boolean {
+                        if (called) {
+                            return false;
+                        }
+
+                        called = true;
+                        return app ? true : false;
+                    };
+                })();
+
                 const awaitRedirectListener = postRobotOnceProxy(POST_MESSAGE.AWAIT_REDIRECT, { proxyWin: nativePopupWinProxy, domain: nativePopupDomain }, ({ data: { app: appDetect, pageUrl, sfvc, stickinessID } }) => {
                     getLogger().info(`native_post_message_await_redirect`).flush();
                     logDetectedApp(appDetect);
@@ -526,7 +539,7 @@ export function initNativePopup({ payment, props, serviceData, config, sessionUI
                             });
                         }
 
-                        const retry = appDetect || false;
+                        const retry = appDetected({ app: appDetect });
 
                         return orderPromise.then(orderID => {
                             const nativeUrl = getNativeUrl({ props, serviceData, config, fundingSource, sessionUID, pageUrl, orderID, stickinessID, retry });

--- a/src/payment-flows/native/popup.js
+++ b/src/payment-flows/native/popup.js
@@ -526,7 +526,7 @@ export function initNativePopup({ payment, props, serviceData, config, sessionUI
                             });
                         }
 
-                        const retry = valid && eligible && fundingSource === FUNDING.VENMO;
+                        const retry = appDetect || false;
 
                         return orderPromise.then(orderID => {
                             const nativeUrl = getNativeUrl({ props, serviceData, config, fundingSource, sessionUID, pageUrl, orderID, stickinessID, retry });

--- a/src/payment-flows/native/popup.js
+++ b/src/payment-flows/native/popup.js
@@ -526,8 +526,10 @@ export function initNativePopup({ payment, props, serviceData, config, sessionUI
                             });
                         }
 
+                        const retry = valid && eligible && fundingSource === FUNDING.VENMO;
+
                         return orderPromise.then(orderID => {
-                            const nativeUrl = getNativeUrl({ props, serviceData, config, fundingSource, sessionUID, pageUrl, orderID, stickinessID });
+                            const nativeUrl = getNativeUrl({ props, serviceData, config, fundingSource, sessionUID, pageUrl, orderID, stickinessID, retry });
 
                             getLogger().info(`native_attempt_appswitch_url_popup`, { url: nativeUrl })
                                 .track({

--- a/src/payment-flows/native/url.js
+++ b/src/payment-flows/native/url.js
@@ -74,7 +74,8 @@ type GetNativeUrlOptions = {|
     sessionUID : string,
     pageUrl : string,
     orderID : string,
-    stickinessID : string
+    stickinessID : string,
+    retry? : boolean
 |};
 
 type NativeUrlQuery = {|
@@ -98,10 +99,11 @@ type NativeUrlQuery = {|
     domain : string,
     rtdbInstanceID : string,
     buyerCountry : $Values<typeof COUNTRY>,
-    sdkVersion : string
+    sdkVersion : string,
+    retry? : boolean
 |};
 
-function getNativeUrlQueryParams({ props, serviceData, config, fundingSource, sessionUID, pageUrl, orderID, stickinessID } : GetNativeUrlOptions) : NativeUrlQuery {
+function getNativeUrlQueryParams({ props, serviceData, config, fundingSource, sessionUID, pageUrl, orderID, stickinessID, retry } : GetNativeUrlOptions) : NativeUrlQuery {
     const { env, clientID, commit, buttonSessionID, stageHost, apiStageHost, enableFunding, merchantDomain } = props;
     const { facilitatorAccessToken, sdkMeta, buyerCountry } = serviceData;
     const { sdkVersion, firebase } = config;
@@ -134,7 +136,8 @@ function getNativeUrlQueryParams({ props, serviceData, config, fundingSource, se
         domain:         merchantDomain,
         rtdbInstanceID: firebase.databaseURL,
         buyerCountry,
-        sdkVersion
+        sdkVersion,
+        retry:          retry || false
     };
 
     if (queryParams.channel === CHANNEL.DESKTOP) {
@@ -144,8 +147,8 @@ function getNativeUrlQueryParams({ props, serviceData, config, fundingSource, se
     return queryParams;
 }
 
-export function getNativeUrl({ props, serviceData, config, fundingSource, sessionUID, pageUrl, orderID, stickinessID } : GetNativeUrlOptions) : string {
-    const queryParams = getNativeUrlQueryParams({ props, serviceData, config, fundingSource, sessionUID, pageUrl, orderID, stickinessID });
+export function getNativeUrl({ props, serviceData, config, fundingSource, sessionUID, pageUrl, orderID, stickinessID, retry } : GetNativeUrlOptions) : string {
+    const queryParams = getNativeUrlQueryParams({ props, serviceData, config, fundingSource, sessionUID, pageUrl, orderID, stickinessID, retry });
 
     return extendUrl(`${ getNativeDomain({ props }) }${ NATIVE_CHECKOUT_URI[fundingSource] }`, {
         // $FlowFixMe

--- a/src/payment-flows/native/url.js
+++ b/src/payment-flows/native/url.js
@@ -1,6 +1,5 @@
 /* @flow */
 
-
 import { extendUrl, isDevice } from 'belter/src';
 import { COUNTRY, ENV, FUNDING } from '@paypal/sdk-constants/src';
 import { getDomain } from 'cross-domain-utils/src';

--- a/src/payment-flows/native/util.js
+++ b/src/payment-flows/native/util.js
@@ -1,0 +1,16 @@
+/* @flow */
+
+import { type AppDetect } from '../types';
+
+export const appDetected : ({| app : AppDetect |}) => boolean = (() => {
+    let called = false;
+
+    return function detectApp({ app }) : boolean {
+        if (called) {
+            return false;
+        }
+
+        called = true;
+        return app ? true : false;
+    };
+})();

--- a/src/payment-flows/types.js
+++ b/src/payment-flows/types.js
@@ -276,3 +276,8 @@ type ApplePaySessionConfig = {|
 
 export type XApplePaySessionConfigRequest = (version : number, request : Object) => ZalgoPromise<ApplePaySessionConfig>;
 
+export type AppDetect = {|
+    id? : string,
+    installed : boolean,
+    version? : string
+|};


### PR DESCRIPTION
### Description
In some cases, when the user has the app, PayPal or Venmo, installed; the user doesn't app switch.  We have found that by trying again, the app switch goes through.  For cases where the app has been detected on the Android device, and is native eligible after getting order id, we will attempt to retry the app switch once.

https://engineering.paypalcorp.com/jira/browse/DTCHKINT-1028
