### PR TITLE
tech(exit survey): Don't show survey on close

### DIFF
--- a/src/qrcode/qrcard.jsx
+++ b/src/qrcode/qrcard.jsx
@@ -76,9 +76,17 @@ function QRCard({
                 [FPTI_CUSTOM_KEY.DESKTOP_EXIT_SURVEY_REASON]:   survey.reason
             }).flush();
             close();
-        } else {
-            survey.enable();
         }
+
+        /**
+         * Survey will be reused in the future.  Supressing the enablement on the close button.
+         *
+         *  } else {
+         *       survey.enable();
+         *  }
+         */
+
+        return close();
     };
 
     const errorMessage = (


### PR DESCRIPTION
### Description

Removing launching the survey on closing the QR code.  Trini asked we keep the survey for future use.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

1. Launch QR code
2. Click X button
3. Should not see exit survey

### Screenshots (if applicable)

![chrome-capture](https://user-images.githubusercontent.com/1623146/140967936-67a5e390-61ae-4c39-bb89-f71bf1d7070c.gif)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->

https://engineering.paypalcorp.com/jira/browse/DTCHKINT-1033

❤️  Thank you!
