### PR TITLE
fix(qrcode): Close QR model on cancel

### DIFF
--- a/src/payment-flows/native/qrcode.js
+++ b/src/payment-flows/native/qrcode.js
@@ -256,9 +256,8 @@ export function initNativeQRCode({ props, serviceData, config, components, payme
                     };
 
                     const onCancelQR = () => {
-                        return updateQRCodeComponentState({
-                            state:     QRCODE_STATE.ERROR,
-                            errorText: 'The authorization was canceled'
+                        return ZalgoPromise.try(() => {
+                            return closeQRCode('onCancel');
                         }).then(() => {
                             return onCancel();
                         });

--- a/src/qrcode/components.jsx
+++ b/src/qrcode/components.jsx
@@ -189,7 +189,7 @@ export const cardStyle : string = `
         min-width: 160px;
         min-height: 160px;
         width: calc(100% - 32px);
-        max-width: 250px;
+        max-width: 325px;
     }
     #instructions {
         background-color: #FFFF;


### PR DESCRIPTION
### Description

1. QRCode model should close now with canceled Venmo app payment.
2. Resized the QRCode to be better scannable

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

1. Launch QRCode
2. Scan with Venmo App
3. Cancel payment in app

Model should close.

### Screenshots (if applicable)

![Screen Shot 2021-11-09 at 11 03 50 AM](https://user-images.githubusercontent.com/1623146/140984231-bdc6648c-a1c6-4e3b-9940-8f450009778b.png)

![onclose-part-1](https://user-images.githubusercontent.com/1623146/140984182-0afb1e6c-5bfd-4e48-8fe2-39c552771261.gif)

![onclose-part-2](https://user-images.githubusercontent.com/1623146/140984195-7f6335b3-72dc-4082-88db-b17519a5a5cd.gif)


### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->

https://engineering.paypalcorp.com/jira/browse/DTCHKINT-1026

❤️  Thank you!
