### PR TITLE
feat(fraudnet): resend fraudnet data for one click checkout

### DIFF
--- a/src/api/fraudnet.js
+++ b/src/api/fraudnet.js
@@ -69,3 +69,9 @@ export const loadFraudnet : Memoized<LoadFraudnet> = memoize(({ env, clientMetad
         body.appendChild(fraudnetScript);
     });
 });
+
+export const retriggerFraudnet: void = () => {
+    if (PAYPAL.asyncData && typeof PAYPAL.asyncData.initAndCollect === 'function') {
+        PAYPAL.asyncData.initAndCollect()
+    }
+}

--- a/src/api/fraudnet.js
+++ b/src/api/fraudnet.js
@@ -70,10 +70,8 @@ export const loadFraudnet : Memoized<LoadFraudnet> = memoize(({ env, clientMetad
     });
 });
 
-export const retriggerFraudnet : void = () => {
-    /* eslint-disable no-undef */
-    if (PAYPAL.asyncData && typeof PAYPAL.asyncData.initAndCollect === 'function') {
-        PAYPAL.asyncData.initAndCollect();
+export const retriggerFraudnet : () => void = () => {
+    if (window.PAYPAL && window.PAYPAL.asyncData && typeof window.PAYPAL.asyncData.initAndCollect === 'function') {
+        window.PAYPAL.asyncData.initAndCollect();
     }
-    /* eslint-enable no-undef */
 };

--- a/src/api/fraudnet.js
+++ b/src/api/fraudnet.js
@@ -70,8 +70,10 @@ export const loadFraudnet : Memoized<LoadFraudnet> = memoize(({ env, clientMetad
     });
 });
 
-export const retriggerFraudnet: void = () => {
+export const retriggerFraudnet : void = () => {
+    /* eslint-disable no-undef */
     if (PAYPAL.asyncData && typeof PAYPAL.asyncData.initAndCollect === 'function') {
-        PAYPAL.asyncData.initAndCollect()
+        PAYPAL.asyncData.initAndCollect();
     }
-}
+    /* eslint-enable no-undef */
+};

--- a/src/api/order.js
+++ b/src/api/order.js
@@ -13,6 +13,7 @@ import type { ShippingMethod, ShippingAddress } from '../payment-flows/types';
 
 import { callSmartAPI, callGraphQL, callRestAPI, getResponseCorrelationID, getErrorResponseCorrelationID } from './api';
 import { getLsatUpgradeError, getLsatUpgradeCalled } from './auth';
+import { retriggerFraudnet } from '../api/fraudnet';
 
 export type OrderCreateRequest = {|
     intent? : 'CAPTURE' | 'AUTHORIZE',
@@ -560,7 +561,10 @@ type OneClickApproveOrderOptions = {|
     clientMetadataID : ?string
 |};
 
-export function oneClickApproveOrder({ orderID, instrumentType, instrumentID, buyerAccessToken, clientMetadataID } : OneClickApproveOrderOptions) : ZalgoPromise<ApproveData> {
+export function oneClickApproveOrder({ orderID, instrumentType, instrumentID, buyerAccessToken, clientMetadataID } : OneClickApproveOrderOptions) : ZalgoPromise<ApproveData> { 
+    // resend fraudnet data for one click checkout
+    retriggerFraudnet();
+
     return callGraphQL({
         name:  'OneClickApproveOrder',
         query: `

--- a/src/api/order.js
+++ b/src/api/order.js
@@ -13,7 +13,8 @@ import type { ShippingMethod, ShippingAddress } from '../payment-flows/types';
 
 import { callSmartAPI, callGraphQL, callRestAPI, getResponseCorrelationID, getErrorResponseCorrelationID } from './api';
 import { getLsatUpgradeError, getLsatUpgradeCalled } from './auth';
-import { retriggerFraudnet } from '../api/fraudnet';
+import { retriggerFraudnet } from './fraudnet';
+
 
 export type OrderCreateRequest = {|
     intent? : 'CAPTURE' | 'AUTHORIZE',
@@ -561,7 +562,7 @@ type OneClickApproveOrderOptions = {|
     clientMetadataID : ?string
 |};
 
-export function oneClickApproveOrder({ orderID, instrumentType, instrumentID, buyerAccessToken, clientMetadataID } : OneClickApproveOrderOptions) : ZalgoPromise<ApproveData> { 
+export function oneClickApproveOrder({ orderID, instrumentType, instrumentID, buyerAccessToken, clientMetadataID } : OneClickApproveOrderOptions) : ZalgoPromise<ApproveData> {
     // resend fraudnet data for one click checkout
     retriggerFraudnet();
 


### PR DESCRIPTION
### Description

The risk team requires Fraudnet data to be resent when one-click checkout is triggered. We will not need to reload the Fraudnet scripts again, instead, there's a [function](https://engineering.paypalcorp.com/confluence/pages/viewpage.action?spaceKey=RiskDataAcquisition&title=Retrigger+Fraudnet) to call to retrigger and resend Fraudnet data.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
https://engineering.paypalcorp.com/jira/browse/DTXOUP-36

### Reproduction Steps (if applicable)
1. Alias `paypal-smart-payment-buttons` in `smartcomponentnodeweb`
2. Follow [these steps](https://engineering.paypalcorp.com/confluence/display/CheckoutTOF/LIPP+SPB+Token+Integration) to run the LIPP SPB flow
3. Verify another fraudnet request is sent when the one-click checkout button is clicked

### Screenshots (if applicable)
![Google Chrome_2021-11-16 16-10-06](https://user-images.githubusercontent.com/6020627/142085917-0dfe812e-ac41-4a80-9942-688c062a2efa.jpg)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->

❤️  Thank you!
