### PR TITLE
fix(qr modal): onCancel was not being called with model with closed 

### DIFF
--- a/src/payment-flows/native/qrcode.js
+++ b/src/payment-flows/native/qrcode.js
@@ -206,12 +206,23 @@ export function initNativeQRCode({ props, serviceData, config, components, payme
                 return createOrder().then((orderID) => {
                     const url = getNativeUrl({ props, serviceData, config, fundingSource, sessionUID, orderID, stickinessID, pageUrl });
 
+                    const cancelModal = () => {
+                        return ZalgoPromise.try(() => {
+                            return onCancel();
+                        }).then(() => {
+                            // eslint-disable-next-line no-use-before-define
+                            qrCodeComponentInstance.close();
+                            return onDestroy();
+                        });
+                    };
+
                     const qrCodeComponentInstance = QRCode({
                         cspNonce:     config.cspNonce,
                         qrPath:       url,
                         state:        QRCODE_STATE.DEFAULT,
                         orderID,
                         onClose:      onQRClose,
+                        onCancel:     cancelModal,
                         onEscapePath
                     });
 
@@ -224,6 +235,7 @@ export function initNativeQRCode({ props, serviceData, config, components, payme
                             qrPath:       url,
                             orderID,
                             onClose:      onQRClose,
+                            onCancel:     cancelModal,
                             onEscapePath,
                             ...newState
                         });
@@ -257,9 +269,11 @@ export function initNativeQRCode({ props, serviceData, config, components, payme
 
                     const onCancelQR = () => {
                         return ZalgoPromise.try(() => {
+                            return onCancel();
+                        }).then(() => {
                             return closeQRCode('onCancel');
                         }).then(() => {
-                            return onCancel();
+                            return { buttonSessionID };
                         });
                     };
 

--- a/src/qrcode/qrcard.jsx
+++ b/src/qrcode/qrcard.jsx
@@ -50,7 +50,7 @@ function QRCard({
     svgString : string
 |}) : mixed {
 
-    const { state, errorText, setState, close } = useXProps();
+    const { state, errorText, setState, close, onCancel: cancel } = useXProps();
     const survey = useSurvey();
     const isError = () => {
         return state === QRCODE_STATE.ERROR;
@@ -66,7 +66,7 @@ function QRCard({
 
     const onCloseClick = () => {
         if (state !== QRCODE_STATE.DEFAULT) {
-            close();
+            cancel();
         } else if (survey.isEnabled) {
             logger.info(`VenmoDesktopPay_qrcode_survey`).track({
                 [FPTI_KEY.STATE]:                               FPTI_STATE.BUTTON,
@@ -75,7 +75,7 @@ function QRCard({
                 [FPTI_KEY.TRANSITION]:                          `${ FPTI_TRANSITION.QR_SURVEY }`,
                 [FPTI_CUSTOM_KEY.DESKTOP_EXIT_SURVEY_REASON]:   survey.reason
             }).flush();
-            close();
+            cancel();
         }
 
         /**
@@ -86,7 +86,7 @@ function QRCard({
          *  }
          */
 
-        return close();
+        return cancel();
     };
 
     const errorMessage = (

--- a/src/types.js
+++ b/src/types.js
@@ -132,6 +132,7 @@ export type QRCodeProps = {|
     errorText? : string,
     orderID : string,
     onClose? : () => ZalgoPromise<void>,
+    onCancel? : () => ZalgoPromise<void>,
     onEscapePath? : (win : CrossDomainWindowType,
     selectedFundingSource : $Values<typeof FUNDING>) => ZalgoPromise<void>
 |};


### PR DESCRIPTION
### Description

Issue found on customer integration with Blackbaud.  When a payee manually closed the QR window we were not firing the `onCancel` callback to SPB.  This caused an issue with Blackbaud integration and resulted in a bad customer experience.  


### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

1. Visit http://dioceseoftrenton.org/aca-donate-page on Desktop
2. Fill out form at bottom of page
3. Tap "secure payment"
4. Wait for Blackbaud payment page to show Venmo button
5. Click Venmo button
6. Click X to close.  The Blackbaud page will keep spinner because `onCancel` was not called.


### Screenshots (if applicable)

### Dependent Changes (if applicable)


❤️  Thank you!
