### PR TITLE
Card holder name component

### DIFF
--- a/src/api/order.js
+++ b/src/api/order.js
@@ -876,7 +876,8 @@ type ApproveCardPaymentOptions = {|
         expirationDate? : string,
         securityCode? : string,
         postalCode? : string,
-        name? : string
+        name? : string,
+        billingAddress? : string
     |}
 |};
 

--- a/src/api/order.js
+++ b/src/api/order.js
@@ -875,7 +875,8 @@ type ApproveCardPaymentOptions = {|
         cardNumber : string,
         expirationDate? : string,
         securityCode? : string,
-        postalCode? : string
+        postalCode? : string,
+        name? : string
     |}
 |};
 

--- a/src/api/order.js
+++ b/src/api/order.js
@@ -847,7 +847,8 @@ type TokenizeCardOptions = {|
     card : {|
         number : string,
         cvv? : string,
-        expiry? : string
+        expiry? : string,
+        name? : string
     |}
 |};
 

--- a/src/card/components/CardName.jsx
+++ b/src/card/components/CardName.jsx
@@ -1,0 +1,117 @@
+/* @flow */
+/** @jsx h */
+
+import { h } from 'preact';
+import { useState, useEffect } from 'preact/hooks';
+
+import { checkName, defaultNavigation, defaultInputState, navigateOnKeyDown } from '../lib';
+import type { CardNameChangeEvent, CardNavigation, FieldValidity, InputState, InputEvent } from '../types';
+
+type CardNameProps = {|
+    name : string,
+    ref : () => void,
+    type : string,
+    state? : InputState,
+    className : string,
+    placeholder : string,
+    style : Object,
+    maxLength : string,
+    navigation : CardNavigation,
+    onChange : (nameEvent : CardNameChangeEvent) => void,
+    onFocus : (event : InputEvent) => void,
+    onBlur : (event : InputEvent) => void,
+    allowNavigation : boolean,
+    onValidityChange? : (numberValidity : FieldValidity) => void
+|};
+
+
+export function CardName(
+    {
+        name = 'name',
+        navigation = defaultNavigation,
+        allowNavigation = false,
+        state,
+        ref,
+        type,
+        className,
+        placeholder,
+        style,
+        maxLength,
+        onChange,
+        onFocus,
+        onBlur,
+        onValidityChange
+    } : CardNameProps
+) : mixed {
+    const [ inputState, setInputState ] : [ InputState, (InputState | InputState => InputState) => InputState ] = useState({ ...defaultInputState, ...state });
+    const { inputValue, keyStrokeCount, isValid, isPotentiallyValid } = inputState;
+
+    useEffect(() => {
+        const validity = checkName(inputValue);
+        setInputState(newState => ({ ...newState, ...validity }));
+    }, [ inputValue ]);
+
+    useEffect(() => {
+        if (typeof onValidityChange === 'function') {
+            onValidityChange({ isValid, isPotentiallyValid });
+        }
+        if (allowNavigation && inputValue && isValid) {
+            navigation.next();
+        }
+    }, [ isValid, isPotentiallyValid ]);
+
+    const setNameValue : (InputEvent) => void = (event : InputEvent) : void => {
+        const { value  } = event.target;
+
+        setInputState({
+            ...inputState,
+            inputValue:       value,
+            maskedInputValue: value,
+            keyStrokeCount:   keyStrokeCount + 1
+        });
+
+        onChange({ event, cardName: value  });
+    };
+
+    const onKeyDownEvent : (InputEvent) => void = (event : InputEvent) : void => {
+        if (allowNavigation) {
+            navigateOnKeyDown(event, navigation);
+        }
+    };
+
+    const onFocusEvent : (InputEvent) => void = (event : InputEvent) : void => {
+        if (typeof onFocus === 'function') {
+            onFocus(event);
+        }
+        if (!isValid) {
+            setInputState(newState => ({ ...newState, isPotentiallyValid: true }));
+        }
+    };
+
+    const onBlurEvent : (InputEvent) => void = (event : InputEvent) : void => {
+        if (typeof onBlur === 'function') {
+            onBlur(event);
+        }
+        if (!isValid) {
+            setInputState(newState => ({ ...newState, isPotentiallyValid: false }));
+        }
+    };
+
+    return (
+        <input
+            name={ name }
+            inputmode='text'
+            ref={ ref }
+            type={ type }
+            className={ className }
+            placeholder={ placeholder }
+            value={ inputValue }
+            style={ style }
+            maxLength={ maxLength }
+            onKeyDown={ onKeyDownEvent }
+            onInput={ setNameValue }
+            onFocus={ onFocusEvent }
+            onBlur={ onBlurEvent }
+        />
+    );
+}

--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -363,13 +363,13 @@ export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholde
     const [ name, setName ] : [ string, (string) => string ] = useState('');
     const [ nameValidity, setNameValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
     const [ generalStyle, inputStyle ] = getStyles(styleObject);
-    const cvvRef = useRef();
+    const nameRef = useRef();
     
     const composedStyles = { ...{ input: DEFAULT_INPUT_STYLE },  ...generalStyle };
     const { isValid, isPotentiallyValid } = nameValidity;
 
     useEffect(() => {
-        autoFocusRef(cvvRef);
+        autoFocusRef(nameRef);
     }, []);
 
     useEffect(() => {
@@ -392,7 +392,7 @@ export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholde
             </style>
 
             <CardName
-                ref={ cvvRef }
+                ref={ nameRef }
                 type='text'
                 // eslint-disable-next-line react/forbid-component-props
                 className={ `name ${ nameValidity.isPotentiallyValid || nameValidity.isValid ? 'valid' : 'invalid' }` }

--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -21,6 +21,7 @@ import type {
     CardNumberChangeEvent,
     CardExpiryChangeEvent,
     CardCvvChangeEvent,
+    CardNameChangeEvent,
     FieldValidity,
     CardNavigation,
     CardType
@@ -37,6 +38,7 @@ import {
 import { CardNumber } from './CardNumber';
 import { CardExpiry } from './CardExpiry';
 import { CardCVV } from './CardCVV';
+import { CardName } from './CardName';
 
 
 type CardFieldProps = {|
@@ -183,7 +185,7 @@ type CardNumberFieldProps = {|
     cspNonce : string,
     onChange : ({| value : string, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
-    placeholder : {| number? : string, expiry? : string, cvv? : string  |},
+    placeholder : {| number? : string, expiry? : string, cvv? : string, name? : string  |},
     autoFocusRef : (mixed) => void,
     gqlErrors : []
 |};
@@ -239,7 +241,7 @@ type CardExpiryFieldProps = {|
     cspNonce : string,
     onChange : ({| value : string, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
-    placeholder : {| number? : string, expiry? : string, cvv? : string  |},
+    placeholder : {| number? : string, expiry? : string, cvv? : string, name? : string  |},
     autoFocusRef : (mixed) => void,
     gqlErrors : []
 |};
@@ -295,7 +297,7 @@ type CardCvvFieldProps = {|
     cspNonce : string,
     onChange : ({| value : string, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
-    placeholder : {| number? : string, expiry? : string, cvv? : string  |},
+    placeholder : {| number? : string, expiry? : string, cvv? : string, name? : string  |},
     autoFocusRef : (mixed) => void,
     gqlErrors : []
 |};
@@ -343,6 +345,63 @@ export function CardCVVField({ cspNonce, onChange, styleObject = {}, placeholder
                 maxLength='4'
                 onChange={ ({ cardCvv } : CardCvvChangeEvent) => setCvv(cardCvv) }
                 onValidityChange={ (validity : FieldValidity) => setCvvValidity(validity) }
+            />
+        </Fragment>
+    );
+}
+
+type CardNameFieldProps = {|
+    cspNonce : string,
+    onChange : ({| value : string, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
+    styleObject : CardStyle,
+    placeholder : {| number? : string, expiry? : string, cvv? : string, name? : string  |},
+    autoFocusRef : (mixed) => void,
+    gqlErrors : []
+|};
+
+export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholder = {}, autoFocusRef, gqlErrors = [] } : CardNameFieldProps) : mixed {
+    const [ name, setName ] : [ string, (string) => string ] = useState('');
+    const [ nameValidity, setNameValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
+    const [ generalStyle, inputStyle ] = getStyles(styleObject);
+    const cvvRef = useRef();
+    
+    const composedStyles = { ...{ input: DEFAULT_INPUT_STYLE },  ...generalStyle };
+    const { isValid, isPotentiallyValid } = nameValidity;
+
+    useEffect(() => {
+        autoFocusRef(cvvRef);
+    }, []);
+
+    useEffect(() => {
+        const hasGQLErrors = gqlErrors.length > 0;
+        if (hasGQLErrors) {
+            setNameValidity({ isPotentiallyValid: false, isValid: false });
+        }
+    }, [ gqlErrors ]);
+
+    useEffect(() => {
+        const errors = setErrors({ isNameValid: nameValidity.isValid });
+
+        onChange({ value: name, valid: nameValidity.isValid, errors });
+    }, [ name, isValid, isPotentiallyValid  ]);
+
+    return (
+        <Fragment>
+            <style nonce={ cspNonce }>
+                {styleToString(composedStyles)}
+            </style>
+
+            <CardName
+                ref={ cvvRef }
+                type='text'
+                // eslint-disable-next-line react/forbid-component-props
+                className={ `name ${ nameValidity.isPotentiallyValid || nameValidity.isValid ? 'valid' : 'invalid' }` }
+                // eslint-disable-next-line react/forbid-component-props
+                style={ inputStyle }
+                placeholder={ placeholder.name ?? DEFAULT_PLACEHOLDERS.name }
+                maxLength='100'
+                onChange={ ({ cardName } : CardNameChangeEvent) => setName(cardName) }
+                onValidityChange={ (validity : FieldValidity) => setNameValidity(validity) }
             />
         </Fragment>
     );

--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -399,7 +399,7 @@ export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholde
                 // eslint-disable-next-line react/forbid-component-props
                 style={ inputStyle }
                 placeholder={ placeholder.name ?? DEFAULT_PLACEHOLDERS.name }
-                maxLength='100'
+                maxLength='255'
                 onChange={ ({ cardName } : CardNameChangeEvent) => setName(cardName) }
                 onValidityChange={ (validity : FieldValidity) => setNameValidity(validity) }
             />

--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -136,64 +136,64 @@ function Page({ cspNonce, props } : PageProps) : mixed {
             {
                 (type === CARD_FIELD_TYPE.SINGLE)
                     ? <CardField
-                        gqlErrorsObject={ fieldGQLErrors.singleField }
-                        cspNonce={ cspNonce }
-                        onChange={ onFieldChange }
-                        styleObject={ style }
-                        placeholder={ placeholder }
-                        autoFocusRef={ (ref) => setRef(ref.current.base) }
+                            gqlErrorsObject={ fieldGQLErrors.singleField }
+                            cspNonce={ cspNonce }
+                            onChange={ onFieldChange }
+                            styleObject={ style }
+                            placeholder={ placeholder }
+                            autoFocusRef={ (ref) => setRef(ref.current.base) }
                     /> : null
             }
 
             {
                 (type === CARD_FIELD_TYPE.NUMBER)
                     ? <CardNumberField
-                        ref={ mainRef }
-                        gqlErrors={ fieldGQLErrors.numberField }
-                        cspNonce={ cspNonce }
-                        onChange={ onFieldChange }
-                        styleObject={ style }
-                        placeholder={ placeholder }
-                        autoFocusRef={ (ref) => setRef(ref.current.base) }
+                            ref={ mainRef }
+                            gqlErrors={ fieldGQLErrors.numberField }
+                            cspNonce={ cspNonce }
+                            onChange={ onFieldChange }
+                            styleObject={ style }
+                            placeholder={ placeholder }
+                            autoFocusRef={ (ref) => setRef(ref.current.base) }
                     /> : null
             }
 
             {
                 (type === CARD_FIELD_TYPE.CVV)
                     ? <CardCVVField
-                        ref={ mainRef }
-                        gqlErrors={ fieldGQLErrors.cvvField }
-                        cspNonce={ cspNonce }
-                        onChange={ onFieldChange }
-                        styleObject={ style }
-                        placeholder={ placeholder }
-                        autoFocusRef={ (ref) => setRef(ref.current.base) }
+                            ref={ mainRef }
+                            gqlErrors={ fieldGQLErrors.cvvField }
+                            cspNonce={ cspNonce }
+                            onChange={ onFieldChange }
+                            styleObject={ style }
+                            placeholder={ placeholder }
+                            autoFocusRef={ (ref) => setRef(ref.current.base) }
                     /> : null
             }
 
             {
                 (type === CARD_FIELD_TYPE.EXPIRY)
                     ? <CardExpiryField
-                        ref={ mainRef }
-                        gqlErrors={ fieldGQLErrors.expiryField }
-                        cspNonce={ cspNonce }
-                        onChange={ onFieldChange }
-                        styleObject={ style }
-                        placeholder={ placeholder }
-                        autoFocusRef={ (ref) => setRef(ref.current.base) }
+                            ref={ mainRef }
+                            gqlErrors={ fieldGQLErrors.expiryField }
+                            cspNonce={ cspNonce }
+                            onChange={ onFieldChange }
+                            styleObject={ style }
+                            placeholder={ placeholder }
+                            autoFocusRef={ (ref) => setRef(ref.current.base) }
                     /> : null
             }
 
             {
                 (type === CARD_FIELD_TYPE.NAME)
                     ? <CardNameField
-                        ref={ mainRef }
-                        gqlErrors={ fieldGQLErrors.nameField }
-                        cspNonce={ cspNonce }
-                        onChange={ onFieldChange }
-                        styleObject={ style }
-                        placeholder={ placeholder }
-                        autoFocusRef={ (ref) => setRef(ref.current.base) }
+                            ref={ mainRef }
+                            gqlErrors={ fieldGQLErrors.nameField }
+                            cspNonce={ cspNonce }
+                            onChange={ onFieldChange }
+                            styleObject={ style }
+                            placeholder={ placeholder }
+                            autoFocusRef={ (ref) => setRef(ref.current.base) }
                     /> : null
             }
         </Fragment>

--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -5,7 +5,7 @@ import { h, render, Fragment } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 
 import { getBody } from '../../lib';
-import { setupExports, formatFieldValue, autoFocusOnFirstInput } from '../lib';
+import { setupExports, formatFieldValue, autoFocusOnFirstInput, filterExtraFields } from '../lib';
 import { CARD_FIELD_TYPE_TO_FRAME_NAME, CARD_FIELD_TYPE } from '../constants';
 import { submitCardFields } from '../interface';
 import { getCardProps, type CardProps } from '../props';
@@ -81,8 +81,10 @@ function Page({ cspNonce, props } : PageProps) : mixed {
         });
 
         xport({
-            submit: () => {
-                return submitCardFields({ facilitatorAccessToken });
+            submit: (extraData) => {
+                console.log('TEST --->', extraData);
+                const extraFields = filterExtraFields(extraData);
+                return submitCardFields({ facilitatorAccessToken, extraFields });
             }
         });
     }, [ fieldValid, fieldValue ]);

--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -82,7 +82,6 @@ function Page({ cspNonce, props } : PageProps) : mixed {
 
         xport({
             submit: (extraData) => {
-                console.log('TEST --->', extraData);
                 const extraFields = filterExtraFields(extraData);
                 return submitCardFields({ facilitatorAccessToken, extraFields });
             }

--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -11,7 +11,7 @@ import { submitCardFields } from '../interface';
 import { getCardProps, type CardProps } from '../props';
 import type { SetupCardOptions } from '../types';
 
-import { CardField, CardNumberField, CardCVVField, CardExpiryField } from './fields';
+import { CardField, CardNumberField, CardCVVField, CardExpiryField, CardNameField } from './fields';
 
 type PageProps = {|
     cspNonce : string,
@@ -49,13 +49,15 @@ function Page({ cspNonce, props } : PageProps) : mixed {
             errorObject.expiryField = [ ...errors ];
         } else if (type === CARD_FIELD_TYPE.CVV && errors && errors.length) {
             errorObject.cvvField = [ ...errors ];
+        } else if (type === CARD_FIELD_TYPE.NAME && errors && errors.length) {
+            errorObject.nameField = [ ...errors ];
         }
 
         setFieldGQLErrors(errorObject);
     };
 
     const resetGQLErrors = () => {
-        setFieldGQLErrors({ singleField: {}, numberField: [], expiryField: [], cvvField: [] });
+        setFieldGQLErrors({ singleField: {}, numberField: [], expiryField: [], cvvField: [], nameField: [] });
     };
 
     useEffect(() => {
@@ -169,6 +171,19 @@ function Page({ cspNonce, props } : PageProps) : mixed {
                             styleObject={ style }
                             placeholder={ placeholder }
                             autoFocusRef={ (ref) => setRef(ref.current.base) }
+                    /> : null
+            }
+
+            {
+                (type === CARD_FIELD_TYPE.NAME)
+                    ? <CardNameField
+                        ref={ mainRef }
+                        gqlErrors={ fieldGQLErrors.nameField }
+                        cspNonce={ cspNonce }
+                        onChange={ onFieldChange }
+                        styleObject={ style }
+                        placeholder={ placeholder }
+                        autoFocusRef={ (ref) => setRef(ref.current.base) }
                     /> : null
             }
         </Fragment>

--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -136,51 +136,51 @@ function Page({ cspNonce, props } : PageProps) : mixed {
             {
                 (type === CARD_FIELD_TYPE.SINGLE)
                     ? <CardField
-                            gqlErrorsObject={ fieldGQLErrors.singleField }
-                            cspNonce={ cspNonce }
-                            onChange={ onFieldChange }
-                            styleObject={ style }
-                            placeholder={ placeholder }
-                            autoFocusRef={ (ref) => setRef(ref.current.base) }
+                        gqlErrorsObject={ fieldGQLErrors.singleField }
+                        cspNonce={ cspNonce }
+                        onChange={ onFieldChange }
+                        styleObject={ style }
+                        placeholder={ placeholder }
+                        autoFocusRef={ (ref) => setRef(ref.current.base) }
                     /> : null
             }
 
             {
                 (type === CARD_FIELD_TYPE.NUMBER)
                     ? <CardNumberField
-                            ref={ mainRef }
-                            gqlErrors={ fieldGQLErrors.numberField }
-                            cspNonce={ cspNonce }
-                            onChange={ onFieldChange }
-                            styleObject={ style }
-                            placeholder={ placeholder }
-                            autoFocusRef={ (ref) => setRef(ref.current.base) }
+                        ref={ mainRef }
+                        gqlErrors={ fieldGQLErrors.numberField }
+                        cspNonce={ cspNonce }
+                        onChange={ onFieldChange }
+                        styleObject={ style }
+                        placeholder={ placeholder }
+                        autoFocusRef={ (ref) => setRef(ref.current.base) }
                     /> : null
             }
 
             {
                 (type === CARD_FIELD_TYPE.CVV)
                     ? <CardCVVField
-                            ref={ mainRef }
-                            gqlErrors={ fieldGQLErrors.cvvField }
-                            cspNonce={ cspNonce }
-                            onChange={ onFieldChange }
-                            styleObject={ style }
-                            placeholder={ placeholder }
-                            autoFocusRef={ (ref) => setRef(ref.current.base) }
+                        ref={ mainRef }
+                        gqlErrors={ fieldGQLErrors.cvvField }
+                        cspNonce={ cspNonce }
+                        onChange={ onFieldChange }
+                        styleObject={ style }
+                        placeholder={ placeholder }
+                        autoFocusRef={ (ref) => setRef(ref.current.base) }
                     /> : null
             }
 
             {
                 (type === CARD_FIELD_TYPE.EXPIRY)
                     ? <CardExpiryField
-                            ref={ mainRef }
-                            gqlErrors={ fieldGQLErrors.expiryField }
-                            cspNonce={ cspNonce }
-                            onChange={ onFieldChange }
-                            styleObject={ style }
-                            placeholder={ placeholder }
-                            autoFocusRef={ (ref) => setRef(ref.current.base) }
+                        ref={ mainRef }
+                        gqlErrors={ fieldGQLErrors.expiryField }
+                        cspNonce={ cspNonce }
+                        onChange={ onFieldChange }
+                        styleObject={ style }
+                        placeholder={ placeholder }
+                        autoFocusRef={ (ref) => setRef(ref.current.base) }
                     /> : null
             }
 
@@ -207,4 +207,3 @@ export function setupCard({ cspNonce, facilitatorAccessToken } : SetupCardOption
 
     render(<Page cspNonce={ cspNonce } props={ props } />, getBody());
 }
- 

--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -43,14 +43,23 @@ function Page({ cspNonce, props } : PageProps) : mixed {
 
         if (type === CARD_FIELD_TYPE.SINGLE) {
             errorObject.singleField = { ...errorData };
-        } else if (type === CARD_FIELD_TYPE.NUMBER && errors && errors.length) {
-            errorObject.numberField = [ ...errors ];
-        } else if (type === CARD_FIELD_TYPE.EXPIRY && errors && errors.length) {
-            errorObject.expiryField = [ ...errors ];
-        } else if (type === CARD_FIELD_TYPE.CVV && errors && errors.length) {
-            errorObject.cvvField = [ ...errors ];
-        } else if (type === CARD_FIELD_TYPE.NAME && errors && errors.length) {
-            errorObject.nameField = [ ...errors ];
+        } else if (errors && errors.length) {
+            switch (type) {
+            case CARD_FIELD_TYPE.NUMBER:
+                errorObject.numberField = [ ...errors ];
+                break;
+            case CARD_FIELD_TYPE.EXPIRY:
+                errorObject.expiryField = [ ...errors ];
+                break;
+            case CARD_FIELD_TYPE.CVV:
+                errorObject.cvvField = [ ...errors ];
+                break;
+            case CARD_FIELD_TYPE.NAME:
+                errorObject.nameField = [ ...errors ];
+                break;
+            default:
+                break;
+            }
         }
 
         setFieldGQLErrors(errorObject);

--- a/src/card/constants.js
+++ b/src/card/constants.js
@@ -10,7 +10,8 @@ export const CARD_FIELD_TYPE = {
     SINGLE: 'single',
     NUMBER: 'number',
     CVV:    'cvv',
-    EXPIRY: 'expiry'
+    EXPIRY: 'expiry',
+    NAME:   'name'
 };
 
 export const GQL_ERRORS = {
@@ -33,14 +34,16 @@ export const GQL_ERRORS = {
 export const CARD_ERRORS = {
     INVALID_NUMBER:       ('INVALID_NUMBER' : 'INVALID_NUMBER'),
     INVALID_EXPIRY:       ('INVALID_EXPIRY' : 'INVALID_EXPIRY'),
-    INVALID_CVV:          ('INVALID_CVV' : 'INVALID_CVV')
+    INVALID_CVV:          ('INVALID_CVV' : 'INVALID_CVV'),
+    INVALID_NAME:         ('INVALID_NAME' : 'INVALID_NAME')
 };
 
 export const CARD_FIELD_TYPE_TO_FRAME_NAME : {| [$Values<typeof CARD_FIELD_TYPE>] : $Values<typeof FRAME_NAME> |} = {
     [ CARD_FIELD_TYPE.SINGLE ]: FRAME_NAME.CARD_FIELD,
     [ CARD_FIELD_TYPE.NUMBER ]: FRAME_NAME.CARD_NUMBER_FIELD,
     [ CARD_FIELD_TYPE.CVV ]:    FRAME_NAME.CARD_CVV_FIELD,
-    [ CARD_FIELD_TYPE.EXPIRY ]: FRAME_NAME.CARD_EXPIRY_FIELD
+    [ CARD_FIELD_TYPE.EXPIRY ]: FRAME_NAME.CARD_EXPIRY_FIELD,
+    [ CARD_FIELD_TYPE.NAME ]:   FRAME_NAME.CARD_NAME_FIELD
 };
 
 export const FIELD_STYLE : FieldStyle = {
@@ -148,5 +151,6 @@ export const DEFAULT_STYLE = {
 export const DEFAULT_PLACEHOLDERS : CardPlaceholder = {
     number: 'Card number',
     expiry: 'MM/YY',
-    cvv:    'CVV'
+    cvv:    'CVV',
+    name:   'Card holder\'s name'
 };

--- a/src/card/constants.js
+++ b/src/card/constants.js
@@ -154,3 +154,7 @@ export const DEFAULT_PLACEHOLDERS : CardPlaceholder = {
     cvv:    'CVV',
     name:   'Cardholder name'
 };
+
+export const VALID_EXTRA_FIELDS = [
+    'billingAddress'
+];

--- a/src/card/constants.js
+++ b/src/card/constants.js
@@ -152,5 +152,5 @@ export const DEFAULT_PLACEHOLDERS : CardPlaceholder = {
     number: 'Card number',
     expiry: 'MM/YY',
     cvv:    'CVV',
-    name:   'Card holder\'s name'
+    name:   'Cardholder name'
 };

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -146,6 +146,14 @@ type SubmitCardFieldsOptions = {|
     facilitatorAccessToken : string
 |};
 
+type CardValues = {|
+    cardNumber : string,
+    expirationDate? : string,
+    securityCode? : string,
+    postalCode? : string,
+    name? : string
+|};
+
 export function submitCardFields({ facilitatorAccessToken } : SubmitCardFieldsOptions) : ZalgoPromise<void> {
     const { intent, branded, vault, createOrder, onApprove, clientID } = getCardProps({ facilitatorAccessToken });
 
@@ -175,12 +183,15 @@ export function submitCardFields({ facilitatorAccessToken } : SubmitCardFieldsOp
         if (intent === INTENT.CAPTURE || intent === INTENT.AUTHORIZE) {
             return createOrder().then(orderID => {
 
-                const cardObject = {
+                const cardObject : CardValues = {
                     cardNumber:     card.number,
                     expirationDate: card.expiry,
                     securityCode:   card.cvv
-                    // name:           card.name
                 };
+
+                if (card.name) {
+                    cardObject.name = card.name;
+                }
 
                 return approveCardPayment({ card: cardObject, orderID, vault, branded, clientID }).catch((error) => {
 

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -32,18 +32,20 @@ function getExportsByFrameName<T>(name : $Values<typeof FRAME_NAME>) : ?CardExpo
 }
 
 
-function getCardFrames() : {| cardFrame : ?ExportsOptions,  cardNumberFrame : ?ExportsOptions, cardCVVFrame : ?ExportsOptions, cardExpiryFrame : ?ExportsOptions |} {
+function getCardFrames() : {| cardFrame : ?ExportsOptions,  cardNumberFrame : ?ExportsOptions, cardCVVFrame : ?ExportsOptions, cardExpiryFrame : ?ExportsOptions, cardNameFrame : ?ExportsOptions |} {
 
     const cardFrame = getExportsByFrameName(FRAME_NAME.CARD_FIELD);
     const cardNumberFrame = getExportsByFrameName(FRAME_NAME.CARD_NUMBER_FIELD);
     const cardCVVFrame = getExportsByFrameName(FRAME_NAME.CARD_CVV_FIELD);
     const cardExpiryFrame = getExportsByFrameName(FRAME_NAME.CARD_EXPIRY_FIELD);
+    const cardNameFrame = getExportsByFrameName(FRAME_NAME.CARD_NAME_FIELD);
 
     return {
         cardFrame,
         cardNumberFrame,
         cardCVVFrame,
-        cardExpiryFrame
+        cardExpiryFrame,
+        cardNameFrame
     };
 }
 
@@ -65,17 +67,19 @@ export function getCardFields() : ?Card {
         return cardFrame.getFieldValue();
     }
 
-    const { cardNumberFrame, cardCVVFrame, cardExpiryFrame } = getCardFrames();
+    const { cardNumberFrame, cardCVVFrame, cardExpiryFrame, cardNameFrame } = getCardFrames();
 
     if (
         cardNumberFrame && cardNumberFrame.isFieldValid() &&
         cardCVVFrame && cardCVVFrame.isFieldValid() &&
-        cardExpiryFrame && cardExpiryFrame.isFieldValid()
+        cardExpiryFrame && cardExpiryFrame.isFieldValid() &&
+        (cardNameFrame ? cardExpiryFrame.isFieldValid() : true)
     ) {
         return {
             number: cardNumberFrame.getFieldValue(),
             cvv:    cardCVVFrame.getFieldValue(),
-            expiry: cardExpiryFrame.getFieldValue()
+            expiry: cardExpiryFrame.getFieldValue(),
+            name:   cardNameFrame && cardExpiryFrame.isFieldValid() ? cardNameFrame.getFieldValue() : ''
         };
     }
 

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -179,6 +179,7 @@ export function submitCardFields({ facilitatorAccessToken } : SubmitCardFieldsOp
                     cardNumber:     card.number,
                     expirationDate: card.expiry,
                     securityCode:   card.cvv
+                    // name:           card.name
                 };
 
                 return approveCardPayment({ card: cardObject, orderID, vault, branded, clientID }).catch((error) => {

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -79,7 +79,7 @@ export function getCardFields() : ?Card {
             number: cardNumberFrame.getFieldValue(),
             cvv:    cardCVVFrame.getFieldValue(),
             expiry: cardExpiryFrame.getFieldValue(),
-            name:   cardNameFrame && cardNameFrame.isFieldValid() ? cardNameFrame.getFieldValue() : ''
+            name:   cardNameFrame?.getFieldValue() || ''
         };
     }
 

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -10,7 +10,7 @@ import { tokenizeCard, approveCardPayment } from '../api';
 import { getLogger } from '../lib';
 
 import { getCardProps } from './props';
-import type { Card } from './types';
+import type { Card, ExtraFields } from './types';
 import { type CardExports, type ExportsOptions, parseGQLErrors } from './lib';
 
 function getExportsByFrameName<T>(name : $Values<typeof FRAME_NAME>) : ?CardExports<T> {
@@ -143,7 +143,10 @@ export function resetGQLErrors() : void {
 }
 
 type SubmitCardFieldsOptions = {|
-    facilitatorAccessToken : string
+    facilitatorAccessToken : string,
+    extraFields? : {|
+        billingAddress? : string
+    |}
 |};
 
 type CardValues = {|
@@ -151,10 +154,11 @@ type CardValues = {|
     expirationDate? : string,
     securityCode? : string,
     postalCode? : string,
-    name? : string
+    name? : string,
+    ...ExtraFields
 |};
 
-export function submitCardFields({ facilitatorAccessToken } : SubmitCardFieldsOptions) : ZalgoPromise<void> {
+export function submitCardFields({ facilitatorAccessToken, extraFields } : SubmitCardFieldsOptions) : ZalgoPromise<void> {
     const { intent, branded, vault, createOrder, onApprove, clientID } = getCardProps({ facilitatorAccessToken });
 
     resetGQLErrors();
@@ -186,7 +190,8 @@ export function submitCardFields({ facilitatorAccessToken } : SubmitCardFieldsOp
                 const cardObject : CardValues = {
                     cardNumber:     card.number,
                     expirationDate: card.expiry,
-                    securityCode:   card.cvv
+                    securityCode:   card.cvv,
+                    ...extraFields
                 };
 
                 if (card.name) {

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -73,13 +73,13 @@ export function getCardFields() : ?Card {
         cardNumberFrame && cardNumberFrame.isFieldValid() &&
         cardCVVFrame && cardCVVFrame.isFieldValid() &&
         cardExpiryFrame && cardExpiryFrame.isFieldValid() &&
-        (cardNameFrame ? cardExpiryFrame.isFieldValid() : true)
+        (cardNameFrame ? cardNameFrame.isFieldValid() : true)
     ) {
         return {
             number: cardNumberFrame.getFieldValue(),
             cvv:    cardCVVFrame.getFieldValue(),
             expiry: cardExpiryFrame.getFieldValue(),
-            name:   cardNameFrame && cardExpiryFrame.isFieldValid() ? cardNameFrame.getFieldValue() : ''
+            name:   cardNameFrame && cardNameFrame.isFieldValid() ? cardNameFrame.getFieldValue() : ''
         };
     }
 

--- a/src/card/lib/card-utils.js
+++ b/src/card/lib/card-utils.js
@@ -273,7 +273,7 @@ export function checkCVV(value : string, cardType : CardType) : {| isValid : boo
 
 export function checkName(value : string) : {| isValid : boolean, isPotentiallyValid : boolean |} {
     let isValid = false;
-    if (value.length >= 5 && value.length <= 200) {
+    if (value.length >= 1 && value.length <= 255) {
         isValid = true;
     }
     return {

--- a/src/card/lib/card-utils.js
+++ b/src/card/lib/card-utils.js
@@ -325,9 +325,9 @@ export function setErrors({ isNumberValid, isCvvValid, isExpiryValid, isNameVali
         }
     }
 
-    if (typeof isNameValid === 'boolean' &&  !isNameValid) {
+    if (typeof isNameValid === 'boolean' && !isNameValid) {
 
-        if (field === CARD_FIELD_TYPE.NAME  && gqlErrors.length) {
+        if (field === CARD_FIELD_TYPE.NAME && gqlErrors.length) {
             errors.push(...gqlErrors);
         } else {
             errors.push(CARD_ERRORS.INVALID_NAME);

--- a/src/card/lib/card-utils.js
+++ b/src/card/lib/card-utils.js
@@ -271,6 +271,17 @@ export function checkCVV(value : string, cardType : CardType) : {| isValid : boo
     };
 }
 
+export function checkName(value : string) : {| isValid : boolean, isPotentiallyValid : boolean |} {
+    let isValid = false;
+    if (value.length >= 5 && value.length <= 200) {
+        isValid = true;
+    }
+    return {
+        isValid,
+        isPotentiallyValid: true
+    };
+}
+
 export function checkExpiry(value : string) : {| isValid : boolean, isPotentiallyValid : boolean |} {
     const { expirationDate } = cardValidator;
     const { isValid } = expirationDate(value);
@@ -281,7 +292,7 @@ export function checkExpiry(value : string) : {| isValid : boolean, isPotentiall
     };
 }
 
-export function setErrors({ isNumberValid, isCvvValid, isExpiryValid, gqlErrorsObject = {} } : {| isNumberValid? : boolean, isCvvValid? : boolean, isExpiryValid? : boolean, gqlErrorsObject? : {| field : string, errors : [] |} |}) : [$Values<typeof CARD_ERRORS>] | [] {
+export function setErrors({ isNumberValid, isCvvValid, isExpiryValid, isNameValid, gqlErrorsObject = {} } : {| isNumberValid? : boolean, isCvvValid? : boolean, isExpiryValid? : boolean, isNameValid? : boolean, gqlErrorsObject? : {| field : string, errors : [] |} |}) : [$Values<typeof CARD_ERRORS>] | [] {
     const errors = [];
 
     const { field, errors: gqlErrors } = gqlErrorsObject;
@@ -311,6 +322,15 @@ export function setErrors({ isNumberValid, isCvvValid, isExpiryValid, gqlErrorsO
             errors.push(...gqlErrors);
         } else {
             errors.push(CARD_ERRORS.INVALID_CVV);
+        }
+    }
+
+    if (typeof isNameValid === 'boolean' &&  !isNameValid) {
+
+        if (field === CARD_FIELD_TYPE.NAME  && gqlErrors.length) {
+            errors.push(...gqlErrors);
+        } else {
+            errors.push(CARD_ERRORS.INVALID_NAME);
         }
     }
 

--- a/src/card/lib/card-utils.js
+++ b/src/card/lib/card-utils.js
@@ -5,8 +5,8 @@ import creditCardType from 'credit-card-type';
 import luhn10 from 'card-validator/src/luhn-10';
 import cardValidator from 'card-validator';
 
-import type { CardType, CardNavigation, InputState, FieldValidity, FieldStyle, InputEvent, Card } from '../types';
-import { CARD_ERRORS, FIELD_STYLE, VALIDATOR_TO_TYPE_MAP, DEFAULT_CARD_TYPE, GQL_ERRORS, CARD_FIELD_TYPE } from '../constants';
+import type { CardType, CardNavigation, InputState, FieldValidity, FieldStyle, InputEvent, Card, ExtraFields } from '../types';
+import { CARD_ERRORS, FIELD_STYLE, VALIDATOR_TO_TYPE_MAP, DEFAULT_CARD_TYPE, GQL_ERRORS, CARD_FIELD_TYPE, VALID_EXTRA_FIELDS } from '../constants';
 import { getActiveElement } from '../../lib/dom';
 
 // Add additional supported card types
@@ -503,4 +503,17 @@ export function parseGQLErrors(errorsObject : Object) : {| parsedErrors : $ReadO
         parsedErrors,
         errorsMap
     };
+}
+
+export function filterExtraFields(extraData : Object) : ExtraFields | Object {
+    if (!extraData || typeof extraData !== 'object' || Array.isArray(extraData)) {
+        return {};
+    }
+
+    return Object.keys(extraData).reduce((acc, key) => {
+        if (VALID_EXTRA_FIELDS.includes(key)) {
+            acc[key] = extraData[key];
+        }
+        return acc;
+    }, {});
 }

--- a/src/card/lib/card-utils.js
+++ b/src/card/lib/card-utils.js
@@ -297,7 +297,7 @@ export function setErrors({ isNumberValid, isCvvValid, isExpiryValid, isNameVali
 
     const { field, errors: gqlErrors } = gqlErrorsObject;
 
-    if (typeof isNumberValid === 'boolean' && !isNumberValid) {
+    if (isNumberValid === false) {
 
         if (field === CARD_FIELD_TYPE.NUMBER && gqlErrors.length) {
             errors.push(...gqlErrors);
@@ -306,7 +306,7 @@ export function setErrors({ isNumberValid, isCvvValid, isExpiryValid, isNameVali
         }
     }
 
-    if (typeof isExpiryValid === 'boolean' && !isExpiryValid) {
+    if (isExpiryValid === false) {
 
         if (field === CARD_FIELD_TYPE.EXPIRY  && gqlErrors.length) {
             errors.push(...gqlErrors);
@@ -316,7 +316,7 @@ export function setErrors({ isNumberValid, isCvvValid, isExpiryValid, isNameVali
 
     }
 
-    if (typeof isCvvValid === 'boolean' &&  !isCvvValid) {
+    if (isCvvValid === false) {
 
         if (field === CARD_FIELD_TYPE.CVV  && gqlErrors.length) {
             errors.push(...gqlErrors);
@@ -325,7 +325,7 @@ export function setErrors({ isNumberValid, isCvvValid, isExpiryValid, isNameVali
         }
     }
 
-    if (typeof isNameValid === 'boolean' && !isNameValid) {
+    if (isNameValid === false) {
 
         if (field === CARD_FIELD_TYPE.NAME && gqlErrors.length) {
             errors.push(...gqlErrors);

--- a/src/card/lib/card-utils.test.js
+++ b/src/card/lib/card-utils.test.js
@@ -8,7 +8,8 @@ import {
     formatDate,
     parseGQLErrors,
     styleToString,
-    getStyles
+    getStyles,
+    filterExtraFields
 } from './card-utils';
 
 jest.mock('../../lib/dom');
@@ -410,5 +411,28 @@ describe('card utils', () => {
         });
     });
 
-});
+    describe('filterExtraFields', () => {
 
+        it('should return empty object for invalid data', () => {
+            const extraFields = filterExtraFields(123);
+            
+            expect(typeof extraFields).toBe('object');
+            expect(Object.keys(extraFields).length).toBe(0);
+            
+        });
+
+        it('should check for valid object with valid props', () => {
+            const extraData = {
+                billingAddress: 'Av. test, 12324',
+                cardHolderName: 'Joe Dow'
+            };
+
+            const extraFields = filterExtraFields(extraData);
+
+            expect(Object.keys(extraFields).length).toBe(1);
+            expect(extraFields.billingAddress).toBe('Av. test, 12324');
+
+        });
+    });
+
+});

--- a/src/card/types.js
+++ b/src/card/types.js
@@ -134,3 +134,7 @@ export type InputOptions = {|
     inputState : InputState,
     validationFn : () => mixed
 |};
+
+export type ExtraFields = {|
+    billingAddress? : string
+|};

--- a/src/card/types.js
+++ b/src/card/types.js
@@ -8,7 +8,8 @@ export type SetupCardOptions = {|
 export type Card = {|
     number : string,
     cvv? : string,
-    expiry? : string
+    expiry? : string,
+    name? : string
 |};
 
 export type FieldStyle = {|
@@ -63,7 +64,8 @@ export type CardStyle = {| |};
 export type CardPlaceholder = {|
     number? : string,
     expiry? : string,
-    cvv? : string
+    cvv? : string,
+    name? : string
 |};
 
 export type CardType = {|
@@ -100,6 +102,11 @@ export type CardExpiryChangeEvent = {|
 export type CardCvvChangeEvent = {|
     event : InputEvent,
     cardCvv : string
+|};
+
+export type CardNameChangeEvent = {|
+    event : InputEvent,
+    cardName : string
 |};
 
 export type FieldValidity = {|

--- a/src/constants.js
+++ b/src/constants.js
@@ -233,7 +233,8 @@ export const FRAME_NAME = {
     CARD_FIELD:        'card-field',
     CARD_NUMBER_FIELD: 'card-number-field',
     CARD_CVV_FIELD:    'card-cvv-field',
-    CARD_EXPIRY_FIELD: 'card-expiry-field'
+    CARD_EXPIRY_FIELD: 'card-expiry-field',
+    CARD_NAME_FIELD:   'card-name-field'
 };
 
 export const AMPLITUDE_KEY = {

--- a/src/menu/page.jsx
+++ b/src/menu/page.jsx
@@ -68,13 +68,13 @@ function Page({ cspNonce } : PageProps) : mixed {
             {
                 (choices && visible)
                     ? <Menu
-                            choices={ choices }
-                            onChoose={ onChooseHandler }
-                            onBlur={ onBlurHandler }
-                            onFocus={ onFocus }
-                            onFocusFail={ onFocusFail }
-                            cspNonce={ cspNonce }
-                            verticalOffset={ verticalOffset } />
+                        choices={ choices }
+                        onChoose={ onChooseHandler }
+                        onBlur={ onBlurHandler }
+                        onFocus={ onFocus }
+                        onFocusFail={ onFocusFail }
+                        cspNonce={ cspNonce }
+                        verticalOffset={ verticalOffset } />
                     : null
             }
         </Fragment>

--- a/src/menu/page.jsx
+++ b/src/menu/page.jsx
@@ -68,13 +68,13 @@ function Page({ cspNonce } : PageProps) : mixed {
             {
                 (choices && visible)
                     ? <Menu
-                        choices={ choices }
-                        onChoose={ onChooseHandler }
-                        onBlur={ onBlurHandler }
-                        onFocus={ onFocus }
-                        onFocusFail={ onFocusFail }
-                        cspNonce={ cspNonce }
-                        verticalOffset={ verticalOffset } />
+                            choices={ choices }
+                            onChoose={ onChooseHandler }
+                            onBlur={ onBlurHandler }
+                            onFocus={ onFocus }
+                            onFocusFail={ onFocusFail }
+                            cspNonce={ cspNonce }
+                            verticalOffset={ verticalOffset } />
                     : null
             }
         </Fragment>

--- a/test/client/card-fields.js
+++ b/test/client/card-fields.js
@@ -1096,10 +1096,6 @@ describe('card fields cases', () => {
 
                 const cardFields = window.paypal.CardFields(window.xprops);
 
-                window.xprops.type = CARD_FIELD_TYPE.NAME;
-                await mockSetupCardFields();
-                cardFields.NameField(window.xprops).render(nameContainer);
-
                 window.xprops.type = CARD_FIELD_TYPE.NUMBER;
                 await mockSetupCardFields();
                 cardFields.NumberField(window.xprops).render(numberContainer);
@@ -1112,6 +1108,9 @@ describe('card fields cases', () => {
                 await mockSetupCardFields();
                 cardFields.CVVField(window.xprops).render(cvvContainer);
 
+                window.xprops.type = CARD_FIELD_TYPE.NAME;
+                await mockSetupCardFields();
+                cardFields.NameField(window.xprops).render(nameContainer);
             });
 
         });

--- a/test/client/card-fields.js
+++ b/test/client/card-fields.js
@@ -968,6 +968,146 @@ describe('card fields cases', () => {
 
         });
 
+        it.only('should render multi card fields with createOrder and optinal field card holder\'s name', async () => {
+
+            return await wrapPromise(async ({ expect }) => {
+
+                const orderID = generateOrderID();
+
+                window.xprops.intent = INTENT.CAPTURE;
+                window.xprops.style = {
+                    'height':          '60px',
+                    'padding':         '10px',
+                    'fontSize':        '18px',
+                    'fontFamily':      '"Open Sans", sans-serif',
+                    'transition':      'all 0.5s ease-out',
+                    'input.invalid': {
+                        color: 'red'
+                    }
+                };
+                window.xprops.placeholder = {
+                    number: 'Card number',
+                    expiry: 'MM/YY',
+                    cvv:    'CVV'
+                };
+
+                window.xprops.createOrder = mockAsyncProp(expect('createOrder', async () => {
+                    return ZalgoPromise.try(() => {
+                        return orderID;
+                    });
+                }));
+
+                mockFunction(window.paypal, 'CardFields', expect('CardFields', ({ original: CardFieldOriginal, args: [ props ] }) => {
+
+                    const cardFieldInstance = CardFieldOriginal(props);
+
+                    mockFunction(cardFieldInstance, 'NumberField', expect('NumberField', ({ original: NumberFieldToOriginal, args: numberArgs }) => {
+                        
+                        const numberFieldToOriginal = NumberFieldToOriginal(...numberArgs);
+
+                        mockFunction(numberFieldToOriginal, 'render', expect('render', async ({ original: renderToOriginal, args }) => {
+                            return props.createOrder().then(id => {
+
+                                if (id !== orderID) {
+                                    throw new Error(`Expected orderID to be ${ orderID }, got ${ id }`);
+                                }
+
+                                return renderToOriginal(...args);
+                            });
+                        }));
+
+                        return numberFieldToOriginal;
+                        
+                    }));
+
+                    mockFunction(cardFieldInstance, 'ExpiryField', expect('ExpiryField', ({ original: ExpiryFieldToOriginal, args: expiryArgs }) => {
+                        
+                        const expiryFieldToOriginal = ExpiryFieldToOriginal(...expiryArgs);
+
+                        mockFunction(expiryFieldToOriginal, 'render', expect('render', async ({ original: renderToOriginal, args }) => {
+                            return props.createOrder().then(id => {
+
+                                if (id !== orderID) {
+                                    throw new Error(`Expected orderID to be ${ orderID }, got ${ id }`);
+                                }
+
+                                return renderToOriginal(...args);
+                            });
+                        }));
+
+                        return expiryFieldToOriginal;
+                        
+                    }));
+
+                    mockFunction(cardFieldInstance, 'CVVField', expect('CVVField', ({ original: CVVFieldToOriginal, args: cvvArgs }) => {
+                        
+                        const cVVFieldToOriginal = CVVFieldToOriginal(...cvvArgs);
+
+                        mockFunction(cVVFieldToOriginal, 'render', expect('render', async ({ original: renderToOriginal, args }) => {
+                            return props.createOrder().then(id => {
+
+                                if (id !== orderID) {
+                                    throw new Error(`Expected orderID to be ${ orderID }, got ${ id }`);
+                                }
+
+                                return renderToOriginal(...args);
+                            });
+                        }));
+
+                        return cVVFieldToOriginal;
+                        
+                    }));
+
+                    mockFunction(cardFieldInstance, 'NameField', expect('NameField', ({ original: NameFieldToOriginal, args: nameArgs }) => {
+                        
+                        const nameFieldToOriginal = NameFieldToOriginal(...nameArgs);
+
+                        mockFunction(nameFieldToOriginal, 'render', expect('render', async ({ original: renderToOriginal, args }) => {
+                            return props.createOrder().then(id => {
+
+                                if (id !== orderID) {
+                                    throw new Error(`Expected orderID to be ${ orderID }, got ${ id }`);
+                                }
+
+                                return renderToOriginal(...args);
+                            });
+                        }));
+
+                        return nameFieldToOriginal;
+                        
+                    }));
+
+                    return cardFieldInstance;
+                }));
+                
+
+                const numberContainer = createCardFieldsContainerHTML('number');
+                const expiryContainer = createCardFieldsContainerHTML('expiry');
+                const cvvContainer = createCardFieldsContainerHTML('cvv');
+                const nameContainer = createCardFieldsContainerHTML('name');
+
+                const cardFields = window.paypal.CardFields(window.xprops);
+
+                window.xprops.type = CARD_FIELD_TYPE.NAME;
+                await mockSetupCardFields();
+                cardFields.NameField(window.xprops).render(nameContainer);
+
+                window.xprops.type = CARD_FIELD_TYPE.NUMBER;
+                await mockSetupCardFields();
+                cardFields.NumberField(window.xprops).render(numberContainer);
+                
+                window.xprops.type = CARD_FIELD_TYPE.EXPIRY;
+                await mockSetupCardFields();
+                cardFields.ExpiryField(window.xprops).render(expiryContainer);
+
+                window.xprops.type = CARD_FIELD_TYPE.CVV;
+                await mockSetupCardFields();
+                cardFields.CVVField(window.xprops).render(cvvContainer);
+
+            });
+
+        });
+
     });
 
 

--- a/test/client/card-fields.js
+++ b/test/client/card-fields.js
@@ -623,8 +623,6 @@ describe('card fields cases', () => {
                 const cardExpiry = '01/2022';
                 const cardCvv = '123';
 
-                renderCardFieldMock({ name: 'card-cvv-field', isFieldValid: () => true, getFieldValue: () => cardCvv });
-
                 const gqlMock = getGraphQLApiMock({
                     extraHandler: ({ data }) => {
                         if (!data.variables.orderID) {
@@ -808,8 +806,6 @@ describe('card fields cases', () => {
                 const cardExpiry = '01/20';
                 const cardCvv = '12';
 
-                renderCardFieldMock({ name: 'card-cvv-field', isFieldValid: () => true, getFieldValue: () => cardCvv });
-
                 const gqlMock = getGraphQLApiMock({
                     extraHandler: ({ data }) => {
                         if (!data.variables.orderID) {
@@ -968,7 +964,7 @@ describe('card fields cases', () => {
 
         });
 
-        it.only('should render multi card fields with createOrder and optinal field card holder\'s name', async () => {
+        it('should render multi card fields with createOrder and optinal field card holder\'s name', async () => {
 
             return await wrapPromise(async ({ expect }) => {
 
@@ -990,6 +986,11 @@ describe('card fields cases', () => {
                     expiry: 'MM/YY',
                     cvv:    'CVV'
                 };
+
+                const cardNumber = '5555555555554444';
+                const cardExpiry = '01/2022';
+                const cardCvv = '123';
+                const cardName = 'John Doe';
 
                 window.xprops.createOrder = mockAsyncProp(expect('createOrder', async () => {
                     return ZalgoPromise.try(() => {
@@ -1016,6 +1017,8 @@ describe('card fields cases', () => {
                             });
                         }));
 
+                        renderCardFieldMock({ name: 'card-number-field', isFieldValid: () => true, getFieldValue: () => cardNumber });
+                        setCardFieldsValues({ number: cardNumber });
                         return numberFieldToOriginal;
                         
                     }));
@@ -1035,6 +1038,8 @@ describe('card fields cases', () => {
                             });
                         }));
 
+                        renderCardFieldMock({ name: 'card-expiry-field', isFieldValid: () => true, getFieldValue: () => cardExpiry });
+                        setCardFieldsValues({ expiry: cardExpiry });
                         return expiryFieldToOriginal;
                         
                     }));
@@ -1054,6 +1059,8 @@ describe('card fields cases', () => {
                             });
                         }));
 
+                        renderCardFieldMock({ name: 'card-cvv-field', isFieldValid: () => true, getFieldValue: () => cardCvv });
+                        setCardFieldsValues({ cvv: cardCvv });
                         return cVVFieldToOriginal;
                         
                     }));
@@ -1077,6 +1084,8 @@ describe('card fields cases', () => {
                         
                     }));
 
+                    renderCardFieldMock({ name: 'card-name-field', isFieldValid: () => true, getFieldValue: () => cardCvv });
+                    setCardFieldsValues({ name: cardName });
                     return cardFieldInstance;
                 }));
                 

--- a/test/client/card-fields.js
+++ b/test/client/card-fields.js
@@ -1080,12 +1080,11 @@ describe('card fields cases', () => {
                             });
                         }));
 
+                        renderCardFieldMock({ name: 'card-name-field', isFieldValid: () => true, getFieldValue: () => cardName });
+                        setCardFieldsValues({ name: cardName });
                         return nameFieldToOriginal;
                         
                     }));
-
-                    renderCardFieldMock({ name: 'card-name-field', isFieldValid: () => true, getFieldValue: () => cardCvv });
-                    setCardFieldsValues({ name: cardName });
                     return cardFieldInstance;
                 }));
                 

--- a/test/client/card-fields.js
+++ b/test/client/card-fields.js
@@ -964,7 +964,7 @@ describe('card fields cases', () => {
 
         });
 
-        it('should render multi card fields with createOrder and optinal field card holder\'s name', async () => {
+        it('should render multi card fields with createOrder and optional cardholder name field', async () => {
 
             return await wrapPromise(async ({ expect }) => {
 

--- a/test/client/mocks.js
+++ b/test/client/mocks.js
@@ -249,6 +249,22 @@ export function setupMocks() {
                         }
                     };
                 },
+                NameField: () => {
+                    return {
+                        render: () => {
+                            return props.createOrder().then(orderID => {
+                                return ZalgoPromise.delay(50).then(() => {
+                                    return props.onApprove({
+                                        orderID,
+                                        payerID: 'AAABBBCCC'
+                                    }).catch(err => {
+                                        return props.onError(err);
+                                    });
+                                });
+                            });
+                        }
+                    };
+                },
                 submit: () => {
                     return submitCardFields({ facilitatorAccessToken: 'ABCDEF12345' });
                 }

--- a/test/client/mocks.js
+++ b/test/client/mocks.js
@@ -1574,11 +1574,12 @@ export async function mockSetupCardFields() : Promise<void> {
     });
 }
 
-export function setCardFieldsValues({ number, expiry, cvv } : {| number? : string, expiry? : string, cvv? : string |}) : mixed {
+export function setCardFieldsValues({ number, expiry, cvv, name } : {| number? : string, expiry? : string, cvv? : string, name? : string |}) : mixed {
     
     const numberInput = number ? document.getElementsByName('number')[0] : null;
     const expiryInput = expiry ? document.getElementsByName('expiry')[0] : null;
     const cvvInput = cvv ? document.getElementsByName('cvv')[0] : null;
+    const nameInput = name ? document.getElementsByName('name')[0] : null;
 
     const inputEvent = new Event('input', { bubbles: true });
     const pasteEvent = new Event('paste', { bubbles: true });
@@ -1614,6 +1615,16 @@ export function setCardFieldsValues({ number, expiry, cvv } : {| number? : strin
         cvvInput.dispatchEvent(inputEvent);
         cvvInput.dispatchEvent(keydownEvent);
         cvvInput.dispatchEvent(blurEvent);
+    }
+
+    if (nameInput) {
+        nameInput.dispatchEvent(focusEvent);
+        // $FlowFixMe
+        nameInput.value = name;
+        nameInput.dispatchEvent(pasteEvent);
+        nameInput.dispatchEvent(inputEvent);
+        nameInput.dispatchEvent(keydownEvent);
+        nameInput.dispatchEvent(blurEvent);
     }
 }
 


### PR DESCRIPTION
### Description

Created new preact component and logic for the **optional** Card Holder's Name input for the card fields.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

- https://engineering.paypalcorp.com/jira/browse/DTNOR-288

For the card fields we need an optional hosted field for the card holder's name.

The name is not PCI compliance but for the auto-fill browser autofill feature all the card fields related inputs need to be on an iframe for it to work as expected.

### Reproduction Steps (if applicable)

This new input can be defined the same way as the `number`, `expiry` and `cvv` the difference is that this input is optional and if is not defined the card fields will be still submit-able.

This new component will only be applicable for the multi card fields meaning that this field won't be able to use in the current implementation for the single card fields. 

### Screenshots (if applicable)

![image](https://user-images.githubusercontent.com/5726810/145278778-7abdb4f0-6492-48de-b961-3c3c483460dd.png)


### Dependent Changes (if applicable)

This change depends on a change in `paypal-checkout-components`.

- https://github.com/paypal/paypal-checkout-components/pull/1809

❤️  Thank you!
