### PR TITLE
chore: only run ci on node 14

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [12, 14]
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v2
@@ -19,7 +16,7 @@ jobs:
       - name: ⎔ Setup node
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node }}
+          node-version: '14'
 
       - name: 📥 Download deps
         uses: bahmutov/npm-install@v1


### PR DESCRIPTION
### Description

CI to run on node14 only

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

We don't need node 12
