### PR TITLE
Ensure dom tests have elements in body

### DIFF
--- a/src/lib/dom.test.js
+++ b/src/lib/dom.test.js
@@ -8,6 +8,11 @@ describe('dom utils', () => {
             const input1 = document.createElement('input');
             const input2 = document.createElement('input');
 
+            // $FlowIssue - we know body exists as this runs in jsdom
+            document.body.appendChild(input1);
+            // $FlowIssue - we know body exists as this runs in jsdom
+            document.body.appendChild(input2);
+
             input1.focus();
 
             expect(getActiveElement()).toBe(input1);


### PR DESCRIPTION
ref: https://github.com/jsdom/jsdom/issues/2924#issuecomment-841831308


thank to @wsbrunson for finding the fix and @elizabethmv for noticing the failures!


We updated to jest 27, via grumbler-scripts v5, which included a new version of JSDOM where this behavior started to fail