### PR TITLE
[QRC Improvements] - Display Venmo escape path only for default state

### DIFF
--- a/src/qrcode/qrcard.jsx
+++ b/src/qrcode/qrcard.jsx
@@ -117,9 +117,10 @@ function QRCard({
     );
 
     const displaySurvey = survey.isEnabled && state === QRCODE_STATE.DEFAULT;
+    const displayEscapePath = !survey.isEnabled && state === QRCODE_STATE.DEFAULT;
 
     const content = displaySurvey ? surveyElement : frontView;
-    const escapePathFooter = !survey.isEnabled && (
+    const escapePathFooter = displayEscapePath && (
         <p className="escape-path">Don&apos;t have the app? Pay with <span className="escape-path__link" onClick={ () => handleClick(FUNDING.PAYPAL) }>PayPal</span> or <span className="escape-path__link" onClick={ () => handleClick(FUNDING.CARD) }>Credit/Debit card</span></p>
     );
 


### PR DESCRIPTION
### Description

Displaying the Venmo escape path only for the default state. This is explained on the jira ticket.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

https://venmoinc.atlassian.net/browse/VMORECOMBO-386

### Reproduction Steps (if applicable)

1. Press the venmo button on staging/local
2. Press the next state button to see the variations on the QRC 

### Screenshots (if applicable)

| Default | Authorize |
| ---- | ---- |
| ![image](https://user-images.githubusercontent.com/89796119/150851824-b30c91aa-c8b5-4654-bd5a-1f1c289ff29b.png) | ![image](https://user-images.githubusercontent.com/89796119/150851879-18e7d392-5bc8-4a48-a6c4-7f95f77a2218.png) |


