### PR TITLE
key time added to fpti logs

### DIFF
--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -76,7 +76,6 @@ export function setupLogger({ env, sessionID, clientID, sdkCorrelationID, buyerC
             [FPTI_KEY.USER_AGENT]:             window.navigator && window.navigator.userAgent,
             [FPTI_KEY.CONTEXT_CORRID]:         sdkCorrelationID,
             [FPTI_KEY.TIMESTAMP]:              Date.now().toString(),
-            [FPTI_KEY.TIME]:                   Date.now().toString(),
             [FPTI_KEY.CHOSEN_FUNDING]:         fundingSource
         };
     });

--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -76,6 +76,7 @@ export function setupLogger({ env, sessionID, clientID, sdkCorrelationID, buyerC
             [FPTI_KEY.USER_AGENT]:             window.navigator && window.navigator.userAgent,
             [FPTI_KEY.CONTEXT_CORRID]:         sdkCorrelationID,
             [FPTI_KEY.TIMESTAMP]:              Date.now().toString(),
+            [FPTI_KEY.TIME]:                   Date.now().toString(),
             [FPTI_KEY.CHOSEN_FUNDING]:         fundingSource
         };
     });

--- a/src/native/lib/logger.js
+++ b/src/native/lib/logger.js
@@ -42,7 +42,8 @@ export function setupNativeLogger({ env, sessionID, buttonSessionID, sdkCorrelat
             [FPTI_KEY.CONTEXT_ID]:                   buttonSessionID,
             [FPTI_KEY.BUTTON_SESSION_UID]:           buttonSessionID,
             [FPTI_KEY.BUTTON_VERSION]:               __SMART_BUTTONS__.__MINOR_VERSION__,
-            [AMPLITUDE_KEY.USER_ID]:                 buttonSessionID
+            [AMPLITUDE_KEY.USER_ID]:                 buttonSessionID,
+            [AMPLITUDE_KEY.TIME]:                    Date.now().toString()
         };
     });
 


### PR DESCRIPTION
### Description

Some events logged in Amplitude are not appearing in the right order, this is because we are not sending the key `time` in the properties of each log. We are sending the key `t` however it is got as an extra event property, not as the timestamp of the event. 

Here there is a small experiment made locally using the library [beaver-logger](https://github.com/krakenjs/beaver-logger)

[In the first case](https://analytics.amplitude.com/paypal/project/295320/search/amplitude_id%3D356432994144), logs are sent just like are sent here, without the time key, and they appear disordered... 

[Here is the result](https://analytics.amplitude.com/paypal/project/295320/search/amplitude_id%3D356438516641) when we add the key time


### Why are we making these changes?

[Jira Ticket](https://engineering.paypalcorp.com/jira/browse/DTCHKINT-1067)


### Screenshots (Before)

![image](https://user-images.githubusercontent.com/17114924/151878876-e4bc7be9-9631-4e13-98f0-6b582953ecff.png)


### Screenshots (After)

![image](https://user-images.githubusercontent.com/17114924/151878785-8b5092b1-2937-4a08-904d-e68e85813652.png)


### Dependent Changes

Depends on https://github.com/paypal/paypal-sdk-constants/pull/80
