### PR TITLE
Remove `npm run release:pre`

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "release": "npm run build-commit && grabthar-release",
     "release:cli": "rm -rf node_modules && npm i && npm run build-commit && grabthar-release",
     "postrelease": "npm run cdnify -- --commitonly",
-    "release:pre": "npm run build-commit && grabthar-release --DIST_TAG=alpha --BUMP=prerelease",
     "deploy": "npm run cdnify",
     "activate:cli": "CDN='https://www.paypalobjects.com' grabthar-activate",
     "activate": "grabthar-activate --CDNIFY=false",


### PR DESCRIPTION
### Purpose

We no longer need the `npm run release:pre` command, since a new version of **grabthar-release** was cut. Dist-tag and version auto-selection got merged, and `alpha` releases will now be handled via the `npm run release` command: https://github.com/krakenjs/grabthar-release/pull/26