### PR TITLE
Pass selected funding to callback data

### DIFF
--- a/src/button/button.js
+++ b/src/button/button.js
@@ -163,7 +163,8 @@ export function setupButton(opts : ButtonOpts) : ZalgoPromise<void> {
             event.preventDefault();
             event.stopPropagation();
 
-            const paymentProps = getButtonProps({ facilitatorAccessToken, brandedDefault });
+            const paymentProps = getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource: paymentFundingSource });
+
             const payPromise = initiatePayment({ payment, props: paymentProps });
             const { onError } = paymentProps;
 

--- a/src/button/button.js
+++ b/src/button/button.js
@@ -67,7 +67,7 @@ export function setupButton(opts : ButtonOpts) : ZalgoPromise<void> {
         sdkMeta, buyerAccessToken, wallet, content, personalization });
     const { merchantID, buyerCountry } = serviceData;
 
-    const props = getButtonProps({ facilitatorAccessToken, brandedDefault });
+    const props = getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource: null });
     const { env, sessionID, partnerAttributionID, commit, sdkCorrelationID, locale, onShippingChange,
         buttonSessionID, merchantDomain, onInit, getPrerenderDetails, rememberFunding, getQueriedEligibleFunding,
         style, fundingSource, intent, createBillingAgreement, createSubscription, stickinessID } = props;
@@ -205,7 +205,7 @@ export function setupButton(opts : ButtonOpts) : ZalgoPromise<void> {
                 throw new Error(`Can not find button element`);
             }
 
-            const paymentProps = getButtonProps({ facilitatorAccessToken, brandedDefault });
+            const paymentProps = getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource: paymentFundingSource });
             const payment = { win, button, fundingSource: paymentFundingSource, card, buyerIntent: BUYER_INTENT.PAY };
             const payPromise = initiatePayment({ payment, props: paymentProps });
             const { onError } = paymentProps;

--- a/src/button/pay.js
+++ b/src/button/pay.js
@@ -137,7 +137,7 @@ export function initiatePaymentFlow({ payment, serviceData, config, components, 
                 enableLoadingSpinner(button);
             }
 
-            const updateClientConfigPromise = createOrder().then(orderID => {
+            const updateClientConfigPromise = createOrder({ fundingSource }).then(orderID => {
                 if (updateFlowClientConfig) {
                     return updateFlowClientConfig({ orderID, payment, userExperienceFlow, buttonSessionID });
                 }
@@ -148,7 +148,7 @@ export function initiatePaymentFlow({ payment, serviceData, config, components, 
                 });
             }).catch(noop);
 
-            const vaultPromise = createOrder().then(orderID => {
+            const vaultPromise = createOrder({ fundingSource }).then(orderID => {
                 return ZalgoPromise.try(() => {
                     if (clientID && buyerIntent === BUYER_INTENT.PAY) {
                         return enableVaultSetup({ orderID, vault, clientAccessToken, fundingEligibility, fundingSource, createBillingAgreement, createSubscription,
@@ -161,11 +161,11 @@ export function initiatePaymentFlow({ payment, serviceData, config, components, 
                 return start();
             });
 
-            const validateOrderPromise = createOrder().then(orderID => {
+            const validateOrderPromise = createOrder({ fundingSource }).then(orderID => {
                 return validateOrder(orderID, { env, clientID, merchantID, intent, currency, vault, buttonLabel });
             });
              
-            const confirmOrderPromise = createOrder().then((orderID) => {
+            const confirmOrderPromise = createOrder({ fundingSource }).then((orderID) => {
                 return window.xprops.sessionState.get(
                     `__confirm_${ fundingSource }_payload__`
                 ).then(confirmOrderPayload => {

--- a/src/button/pay.js
+++ b/src/button/pay.js
@@ -137,7 +137,7 @@ export function initiatePaymentFlow({ payment, serviceData, config, components, 
                 enableLoadingSpinner(button);
             }
 
-            const updateClientConfigPromise = createOrder({ fundingSource }).then(orderID => {
+            const updateClientConfigPromise = createOrder().then(orderID => {
                 if (updateFlowClientConfig) {
                     return updateFlowClientConfig({ orderID, payment, userExperienceFlow, buttonSessionID });
                 }
@@ -148,7 +148,7 @@ export function initiatePaymentFlow({ payment, serviceData, config, components, 
                 });
             }).catch(noop);
 
-            const vaultPromise = createOrder({ fundingSource }).then(orderID => {
+            const vaultPromise = createOrder().then(orderID => {
                 return ZalgoPromise.try(() => {
                     if (clientID && buyerIntent === BUYER_INTENT.PAY) {
                         return enableVaultSetup({ orderID, vault, clientAccessToken, fundingEligibility, fundingSource, createBillingAgreement, createSubscription,
@@ -161,11 +161,11 @@ export function initiatePaymentFlow({ payment, serviceData, config, components, 
                 return start();
             });
 
-            const validateOrderPromise = createOrder({ fundingSource }).then(orderID => {
+            const validateOrderPromise = createOrder().then(orderID => {
                 return validateOrder(orderID, { env, clientID, merchantID, intent, currency, vault, buttonLabel });
             });
              
-            const confirmOrderPromise = createOrder({ fundingSource }).then((orderID) => {
+            const confirmOrderPromise = createOrder().then((orderID) => {
                 return window.xprops.sessionState.get(
                     `__confirm_${ fundingSource }_payload__`
                 ).then(confirmOrderPayload => {

--- a/src/button/props.js
+++ b/src/button/props.js
@@ -42,7 +42,7 @@ export type ButtonProps = {|
     buttonSessionID : string
 |};
 
-export function getButtonProps({ facilitatorAccessToken, brandedDefault } : {| facilitatorAccessToken : string, brandedDefault : boolean | null |}) : ButtonProps {
+export function getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource }: {| facilitatorAccessToken : string, brandedDefault: boolean | null, paymentSource : $Values<typeof FUNDING> |}) : ButtonProps {
     const xprops : ButtonXProps = window.xprops;
 
     let {
@@ -100,7 +100,7 @@ export function getButtonProps({ facilitatorAccessToken, brandedDefault } : {| f
     }
 
     return {
-        ...getProps({ facilitatorAccessToken, branded }),
+        ...getProps({ facilitatorAccessToken, branded, paymentSource }),
         style,
         buttonSessionID,
         branded,

--- a/src/button/props.js
+++ b/src/button/props.js
@@ -42,7 +42,7 @@ export type ButtonProps = {|
     buttonSessionID : string
 |};
 
-export function getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource }: {| facilitatorAccessToken : string, brandedDefault: boolean | null, paymentSource : $Values<typeof FUNDING> |}) : ButtonProps {
+export function getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource } : {| facilitatorAccessToken : string, brandedDefault : boolean | null, paymentSource : $Values<typeof FUNDING> | null |}) : ButtonProps {
     const xprops : ButtonXProps = window.xprops;
 
     let {

--- a/src/button/props.test.js
+++ b/src/button/props.test.js
@@ -6,6 +6,7 @@ import { getButtonProps } from './props';
 
 describe('getButtonProps', () => {
     const brandedDefault = true;
+    const paymentSource = 'paypal';
     const facilitatorAccessToken = 'ABCDEFG12345';
     beforeEach(() => {
         window.xprops = {};
@@ -14,48 +15,48 @@ describe('getButtonProps', () => {
     it('should fail if createBillingAgreement & createOrder are both passed in', () => {
         window.xprops.createBillingAgreement = jest.fn();
         window.xprops.createOrder = jest.fn();
-        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault })).toThrowError();
+        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource })).toThrowError();
     });
 
     it('should fail if createBillingAgreement is passed in but not vault', () => {
         window.xprops.createBillingAgreement =  jest.fn();
-        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault })).toThrowError();
+        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource })).toThrowError();
     });
 
     it('should fail if createSubscription & createOrder are both passed in', () => {
         window.xprops.createSubscription = jest.fn();
         window.xprops.createOrder = jest.fn();
-        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault })).toThrowError();
+        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource })).toThrowError();
     });
 
     it('should fail if createSubscription but not vault', () => {
         window.xprops.createSubscription = jest.fn();
-        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault })).toThrowError();
+        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource })).toThrowError();
     });
 
     it('should fail if intent is tokenize but no createBillingAgreement', () => {
         window.xprops.intent = INTENT.TOKENIZE;
-        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault })).toThrowError();
+        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource })).toThrowError();
     });
 
     it('should fail if intent is tokenize but contains createOrder', () => {
         window.xprops.intent = INTENT.TOKENIZE;
         window.xprops.createBillingAgreement = jest.fn();
         window.xprops.createOrder = () => 'ok';
-        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault })).toThrowError();
+        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource })).toThrowError();
     });
 
     it('should fail if intent is tokenize but contains createSubscription', () => {
         window.xprops.intent = INTENT.TOKENIZE;
         window.xprops.createBillingAgreement = jest.fn();
         window.xprops.createSubscription = jest.fn();
-        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault })).toThrowError();
+        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource })).toThrowError();
     });
 
     it('should fail if intent is subscription but does not contain createSubscription', () => {
         window.xprops.intent = INTENT.SUBSCRIPTION;
         window.xprops.vault = true;
-        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault })).toThrowError();
+        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource })).toThrowError();
     });
 
     it('should fail if intent is subscription but contains createOrder', () => {
@@ -63,7 +64,7 @@ describe('getButtonProps', () => {
         window.xprops.vault = true;
         window.xprops.createSubscription = jest.fn();
         window.xprops.createOrder = jest.fn();
-        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault })).toThrowError();
+        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource })).toThrowError();
     });
 
     it('should fail if intent is subscription but contains createBillingAgreement', () => {
@@ -71,13 +72,13 @@ describe('getButtonProps', () => {
         window.xprops.vault = true;
         window.xprops.createSubscription = jest.fn();
         window.xprops.createBillingAgreement = jest.fn();
-        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault })).toThrowError();
+        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource })).toThrowError();
     });
 
     it('should not fail with correct values passed in', () => {
         window.xprops.intent = INTENT.SUBSCRIPTION;
         window.xprops.vault = true;
         window.xprops.createSubscription = jest.fn();
-        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault })).not.toThrowError();
+        expect(() => getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource })).not.toThrowError();
     });
 });

--- a/src/card/props.js
+++ b/src/card/props.js
@@ -80,7 +80,7 @@ export function getCardProps({ facilitatorAccessToken } : GetCardPropsOptions) :
         export: xport
     } = xprops;
 
-    const props = getProps({ facilitatorAccessToken, branded });
+    const props = getProps({ facilitatorAccessToken, branded, paymentSource: null });
 
     return {
         ...props,

--- a/src/props/createBillingAgreement.js
+++ b/src/props/createBillingAgreement.js
@@ -1,9 +1,11 @@
 /* @flow */
 
 import { type ZalgoPromise } from 'zalgo-promise/src';
+import { FUNDING } from '@paypal/sdk-constants/src';
+
 
 export type XCreateBillingAgreementDataType = {|
-    
+    paymentSource : $Values<typeof FUNDING> | null
 |};
 
 export type XCreateBillingAgreementActionsType = {|
@@ -12,9 +14,8 @@ export type XCreateBillingAgreementActionsType = {|
 
 export type XCreateBillingAgreement = (?XCreateBillingAgreementDataType, ?XCreateBillingAgreementActionsType) => ZalgoPromise<string>;
 
-export function buildXCreateBillingAgreementData() : XCreateBillingAgreementDataType {
-    // $FlowFixMe
-    return {};
+export function buildXCreateBillingAgreementData({ paymentSource } : {| paymentSource : $Values<typeof FUNDING> | null |}) : XCreateBillingAgreementDataType {
+    return { paymentSource };
 }
 
 export function buildXCreateBillingAgreementActions() : XCreateBillingAgreementActionsType {
@@ -24,10 +25,10 @@ export function buildXCreateBillingAgreementActions() : XCreateBillingAgreementA
 
 export type CreateBillingAgreement = XCreateBillingAgreement;
 
-export function getCreateBillingAgreement({ createBillingAgreement } : {| createBillingAgreement : ?XCreateBillingAgreement |}) : ?CreateBillingAgreement {
+export function getCreateBillingAgreement({ createBillingAgreement, paymentSource } : {| createBillingAgreement : ?XCreateBillingAgreement, paymentSource : $Values<typeof FUNDING> | null |}) : ?CreateBillingAgreement {
     if (createBillingAgreement) {
         return () => {
-            return createBillingAgreement(buildXCreateBillingAgreementData(), buildXCreateBillingAgreementActions()).then(billingToken => {
+            return createBillingAgreement(buildXCreateBillingAgreementData({ paymentSource }), buildXCreateBillingAgreementActions()).then(billingToken => {
                 if (!billingToken || typeof billingToken !== 'string') {
                     throw new Error(`Expected a billing token to be passed to createBillingAgreement`);
                 }

--- a/src/props/createOrder.js
+++ b/src/props/createOrder.js
@@ -161,6 +161,7 @@ type CreateOrderXProps = {|
 |};
 
 export function getCreateOrder({ createOrder, intent, currency, merchantID, partnerAttributionID, paymentSource } : CreateOrderXProps, { facilitatorAccessToken, createBillingAgreement, createSubscription } : {| facilitatorAccessToken : string, createBillingAgreement? : ?CreateBillingAgreement, createSubscription? : ?CreateSubscription |}) : CreateOrder {
+    const data = buildXCreateOrderData({ paymentSource });
     const actions = buildXCreateOrderActions({ facilitatorAccessToken, intent, currency, merchantID, partnerAttributionID });
 
     return memoize(() => {
@@ -177,7 +178,7 @@ export function getCreateOrder({ createOrder, intent, currency, merchantID, part
             } else if (createSubscription) {
                 return createSubscription().then(subscriptionIdToCartId);
             } else if (createOrder) {
-                return createOrder(buildXCreateOrderData({ paymentSource }), actions);
+                return createOrder(data, actions);
             } else {
                 return actions.order.create({
                     purchase_units: [

--- a/src/props/createOrder.js
+++ b/src/props/createOrder.js
@@ -14,7 +14,7 @@ import type { CreateSubscription } from './createSubscription';
 import type { CreateBillingAgreement } from './createBillingAgreement';
 
 export type XCreateOrderDataType = {|
-    paymentSource? : $Values<typeof FUNDING>
+    paymentSource : $Values<typeof FUNDING> | null
 |};
 
 type OrderActions = {|
@@ -34,7 +34,7 @@ export type XCreateOrder = (XCreateOrderDataType, XCreateOrderActionsType) => Za
 
 export type CreateOrder = () => ZalgoPromise<string>;
 
-export function buildXCreateOrderData({ paymentSource }: {| paymentSource : $Values<typeof FUNDING> |}) : XCreateOrderDataType {
+export function buildXCreateOrderData({ paymentSource } : {| paymentSource : $Values<typeof FUNDING> | null |}) : XCreateOrderDataType {
     return { paymentSource };
 }
 
@@ -157,7 +157,7 @@ type CreateOrderXProps = {|
     currency : $Values<typeof CURRENCY>,
     merchantID : $ReadOnlyArray<string>,
     partnerAttributionID : ?string,
-    paymentSource : $Values<typeof FUNDING>
+    paymentSource : $Values<typeof FUNDING> | null
 |};
 
 export function getCreateOrder({ createOrder, intent, currency, merchantID, partnerAttributionID, paymentSource } : CreateOrderXProps, { facilitatorAccessToken, createBillingAgreement, createSubscription } : {| facilitatorAccessToken : string, createBillingAgreement? : ?CreateBillingAgreement, createSubscription? : ?CreateSubscription |}) : CreateOrder {

--- a/src/props/props.js
+++ b/src/props/props.js
@@ -233,8 +233,8 @@ export function getProps({ facilitatorAccessToken, branded, paymentSource } : {|
         ? storageID
         : getStorageID();
 
-    const createBillingAgreement = getCreateBillingAgreement({ createBillingAgreement: xprops.createBillingAgreement });
-    const createSubscription = getCreateSubscription({ createSubscription: xprops.createSubscription, partnerAttributionID, merchantID, clientID }, { facilitatorAccessToken });
+    const createBillingAgreement = getCreateBillingAgreement({ createBillingAgreement: xprops.createBillingAgreement, paymentSource });
+    const createSubscription = getCreateSubscription({ createSubscription: xprops.createSubscription, partnerAttributionID, merchantID, clientID, paymentSource }, { facilitatorAccessToken });
 
     const createOrder = getCreateOrder({ createOrder: xprops.createOrder, currency, intent, merchantID, partnerAttributionID, paymentSource }, { facilitatorAccessToken, createBillingAgreement, createSubscription });
 

--- a/src/props/props.js
+++ b/src/props/props.js
@@ -171,7 +171,7 @@ export type Props = {|
     allowBillingPayments : boolean
 |};
 
-export function getProps({ facilitatorAccessToken, branded } : {| facilitatorAccessToken : string, branded : boolean | null |}) : Props {
+export function getProps({ facilitatorAccessToken, branded, paymentSource }: {| facilitatorAccessToken : string, branded: boolean | null, paymentSource: $Values<typeof FUNDING>  |}) : Props {
     const xprops : XProps = window.xprops;
 
     let {
@@ -236,7 +236,7 @@ export function getProps({ facilitatorAccessToken, branded } : {| facilitatorAcc
     const createBillingAgreement = getCreateBillingAgreement({ createBillingAgreement: xprops.createBillingAgreement });
     const createSubscription = getCreateSubscription({ createSubscription: xprops.createSubscription, partnerAttributionID, merchantID, clientID }, { facilitatorAccessToken });
 
-    const createOrder = getCreateOrder({ createOrder: xprops.createOrder, currency, intent, merchantID, partnerAttributionID }, { facilitatorAccessToken, createBillingAgreement, createSubscription });
+    const createOrder = getCreateOrder({ createOrder: xprops.createOrder, currency, intent, merchantID, partnerAttributionID, paymentSource }, { facilitatorAccessToken, createBillingAgreement, createSubscription });
 
     const onError = getOnError({ onError: xprops.onError });
     const onApprove = getOnApprove({ onApprove: xprops.onApprove, createBillingAgreement, createSubscription, intent, onError, partnerAttributionID, clientAccessToken, vault, clientID, facilitatorAccessToken, branded, createOrder });

--- a/src/props/props.js
+++ b/src/props/props.js
@@ -239,7 +239,7 @@ export function getProps({ facilitatorAccessToken, branded, paymentSource } : {|
     const createOrder = getCreateOrder({ createOrder: xprops.createOrder, currency, intent, merchantID, partnerAttributionID, paymentSource }, { facilitatorAccessToken, createBillingAgreement, createSubscription });
 
     const onError = getOnError({ onError: xprops.onError });
-    const onApprove = getOnApprove({ onApprove: xprops.onApprove, createBillingAgreement, createSubscription, intent, onError, partnerAttributionID, clientAccessToken, vault, clientID, facilitatorAccessToken, branded, createOrder });
+    const onApprove = getOnApprove({ onApprove: xprops.onApprove, createBillingAgreement, createSubscription, intent, onError, partnerAttributionID, clientAccessToken, vault, clientID, facilitatorAccessToken, branded, createOrder, paymentSource });
     const onCancel = getOnCancel({ onCancel: xprops.onCancel, onError }, { createOrder });
     const onShippingChange = getOnShippingChange({ onShippingChange: xprops.onShippingChange, partnerAttributionID, clientID }, { facilitatorAccessToken, createOrder });
     const onAuth = getOnAuth({ facilitatorAccessToken, createOrder, createSubscription, clientID });

--- a/src/props/props.js
+++ b/src/props/props.js
@@ -171,7 +171,7 @@ export type Props = {|
     allowBillingPayments : boolean
 |};
 
-export function getProps({ facilitatorAccessToken, branded, paymentSource }: {| facilitatorAccessToken : string, branded: boolean | null, paymentSource: $Values<typeof FUNDING>  |}) : Props {
+export function getProps({ facilitatorAccessToken, branded, paymentSource } : {| facilitatorAccessToken : string, branded : boolean | null, paymentSource : $Values<typeof FUNDING> | null |}) : Props {
     const xprops : XProps = window.xprops;
 
     let {

--- a/test/client/data.js
+++ b/test/client/data.js
@@ -14,7 +14,7 @@ import {
 } from './mocks';
 
 describe('callback data cases', () => {
-    it('should render a button, click the button, and have the payment source in the createOrder callback data', async () => {
+    it('should render a button, click the button, pass the selected funding to the createOrder data', async () => {
         return await wrapPromise(async ({ expect }) => {
 
             const orderID = generateOrderID();
@@ -38,7 +38,7 @@ describe('callback data cases', () => {
         });
     });
 
-    it.only('should render a button, click the button, and have the payment source in the onApprove callback data', async () => {
+    it('should render a button, click the button, and pass the selected funding to the onApprove data', async () => {
         return await wrapPromise(async ({ expect }) => {
 
             const orderID = generateOrderID();

--- a/test/client/data.js
+++ b/test/client/data.js
@@ -17,25 +17,33 @@ import {
 describe('callback data cases', () => {
     it('should render a button, click the button, pass the selected funding to the createOrder data', async () => {
         return await wrapPromise(async ({ expect }) => {
-
             const orderID = generateOrderID();
 
             window.xprops.createOrder = mockAsyncProp(expect('createOrder', async (data) => {
-                if (data.paymentSource && data.paymentSource === 'paypal') {
+                if (data.paymentSource && data.paymentSource === 'venmo') {
                     return orderID;
                 }
 
                 throw new Error(`Expected paymentSource to be available in createOrder data`);
             }));
 
-            createButtonHTML();
+            const fundingEligibility = {
+                venmo: {
+                    eligible: true
+                }
+            };
+
+            createButtonHTML({ fundingEligibility });
 
             await mockSetupButton({
                 merchantID:         [ 'XYZ12345' ],
-                fundingEligibility: DEFAULT_FUNDING_ELIGIBILITY
+                eligibility: {
+                    cardFields: false,
+                    native:     true
+                }
             });
 
-            await clickButton(FUNDING.PAYPAL);
+            await clickButton(FUNDING.VENMO);
         });
     });
 

--- a/test/client/data.js
+++ b/test/client/data.js
@@ -1,0 +1,72 @@
+/* @flow */
+/* eslint require-await: off */
+
+import { wrapPromise } from 'belter/src';
+import { FUNDING } from '@paypal/sdk-constants/src';
+
+import {
+    mockAsyncProp,
+    createButtonHTML,
+    DEFAULT_FUNDING_ELIGIBILITY,
+    clickButton,
+    mockSetupButton,
+    generateOrderID
+} from './mocks';
+
+describe('callback data cases', () => {
+    it('should render a button, click the button, and have the payment source in the createOrder callback data', async () => {
+        return await wrapPromise(async ({ expect }) => {
+
+            const orderID = generateOrderID();
+
+            window.xprops.createOrder = mockAsyncProp(expect('createOrder', async (data) => {
+                if (data.paymentSource && data.paymentSource === 'paypal') {
+                    return orderID;
+                }
+
+                throw new Error(`Expected paymentSource to be available in createOrder data`);
+            }));
+
+            createButtonHTML();
+
+            await mockSetupButton({
+                merchantID:         [ 'XYZ12345' ],
+                fundingEligibility: DEFAULT_FUNDING_ELIGIBILITY
+            });
+
+            await clickButton(FUNDING.PAYPAL);
+        });
+    });
+
+    it.only('should render a button, click the button, and have the payment source in the onApprove callback data', async () => {
+        return await wrapPromise(async ({ expect }) => {
+
+            const orderID = generateOrderID();
+
+            window.xprops.createOrder = mockAsyncProp(expect('createOrder', async (data) => {
+                if (data.paymentSource && data.paymentSource === 'paypal') {
+                    return orderID;
+                }
+
+                throw new Error(`Expected paymentSource to be available in createOrder data`);
+            }));
+
+            window.xprops.onApprove = mockAsyncProp(expect('onApprove', (data) => {
+                if (data.paymentSource && data.paymentSource === 'paypal') {
+                    return;
+                }
+
+                throw new Error(`Expected paymentSource to be available in createOrder data`);
+            }));
+
+            createButtonHTML();
+
+            await mockSetupButton({
+                merchantID:         [ 'XYZ12345' ],
+                fundingEligibility: DEFAULT_FUNDING_ELIGIBILITY
+            });
+
+            await clickButton(FUNDING.PAYPAL);
+        });
+    });
+});

--- a/test/client/data.js
+++ b/test/client/data.js
@@ -1,11 +1,12 @@
 /* @flow */
-/* eslint require-await: off */
+/* eslint require-await: off, max-nested-callbacks: off */
 
 import { wrapPromise } from 'belter/src';
 import { FUNDING } from '@paypal/sdk-constants/src';
 
 import {
     mockAsyncProp,
+    mockFunction,
     createButtonHTML,
     DEFAULT_FUNDING_ELIGIBILITY,
     clickButton,
@@ -40,23 +41,100 @@ describe('callback data cases', () => {
 
     it('should render a button, click the button, and pass the selected funding to the onApprove data', async () => {
         return await wrapPromise(async ({ expect }) => {
-
-            const orderID = generateOrderID();
-
-            window.xprops.createOrder = mockAsyncProp(expect('createOrder', async (data) => {
-                if (data.paymentSource && data.paymentSource === 'paypal') {
-                    return orderID;
-                }
-
-                throw new Error(`Expected paymentSource to be available in createOrder data`);
-            }));
-
             window.xprops.onApprove = mockAsyncProp(expect('onApprove', (data) => {
                 if (data.paymentSource && data.paymentSource === 'paypal') {
                     return;
                 }
 
-                throw new Error(`Expected paymentSource to be available in createOrder data`);
+                throw new Error(`Expected paymentSource to be available in onApprove data`);
+            }));
+
+            createButtonHTML();
+
+            await mockSetupButton({
+                merchantID:         [ 'XYZ12345' ],
+                fundingEligibility: DEFAULT_FUNDING_ELIGIBILITY
+            });
+
+            await clickButton(FUNDING.PAYPAL);
+        });
+    });
+
+    it('should render a button, click the button, and pass the selected funding to the createBillingAgreement data', async () => {
+        return await wrapPromise(async ({ expect }) => {
+            const billingToken = 'BA-123';
+
+            delete window.xprops.createOrder;
+
+            window.xprops.vault = true;
+            window.xprops.createBillingAgreement = mockAsyncProp(expect('createBillingAgreement', async (data) => {
+                if (data.paymentSource && data.paymentSource === 'paypal') {
+                    return billingToken;
+                }
+
+                throw new Error(`Expected paymentSource to be available in createBillingAgreement data`);
+            }));
+
+            createButtonHTML();
+
+            await mockSetupButton({
+                merchantID:         [ 'XYZ12345' ],
+                fundingEligibility: DEFAULT_FUNDING_ELIGIBILITY
+            });
+
+            await clickButton(FUNDING.PAYPAL);
+        });
+    });
+
+    it('should render a button, click the button, and pass the selected funding to the createSubscription data, and render checkout', async () => {
+        return await wrapPromise(async ({ expect, avoid }) => {
+            const cartID = 'CARTIDOFSUBSCRIPTIONS';
+            const subscriptionID = 'I-SUBSCRIPTIONID';
+            const payerID = 'YYYYYYYYYY';
+
+            delete window.xprops.createOrder;
+            window.xprops.vault = true;
+
+            window.xprops.createSubscription = mockAsyncProp(expect('createSubscription', async (data) => {
+                if (data.paymentSource && data.paymentSource === 'paypal') {
+                    return subscriptionID;
+                }
+
+                throw new Error(`Expected paymentSource to be available in createSubscription data`);
+
+            }));
+
+            window.xprops.onCancel = avoid('onCancel');
+
+            window.xprops.onApprove = mockAsyncProp(expect('onApprove', async (data) => {
+                if (data.subscriptionID !== subscriptionID) {
+                    throw new Error(`Expected subscriptionID to be ${ subscriptionID }, got ${ data.subscriptionID }`);
+                }
+
+                if (data.payerID !== payerID) {
+                    throw new Error(`Expected payerID to be ${ payerID }, got ${ data.payerID }`);
+                }
+            }));
+
+            mockFunction(window.paypal, 'Checkout', expect('Checkout', ({ original: CheckoutOriginal, args: [ props ] }) => {
+
+                mockFunction(props, 'onApprove', expect('onApprove', ({ original: onApproveOriginal, args: [ data, actions ] }) => {
+                    return onApproveOriginal({ ...data, payerID, subscriptionID }, actions);
+                }));
+
+                const checkoutInstance = CheckoutOriginal(props);
+
+                mockFunction(checkoutInstance, 'renderTo', expect('renderTo', async ({ original: renderToOriginal, args }) => {
+                    return props.createOrder().then(id => {
+                        if (id !== cartID) {
+                            throw new Error(`Expected cartID to be ${ cartID }, got ${ id }`);
+                        }
+
+                        return renderToOriginal(...args);
+                    });
+                }));
+
+                return checkoutInstance;
             }));
 
             createButtonHTML();

--- a/test/client/index.js
+++ b/test/client/index.js
@@ -29,6 +29,7 @@ import './applepay';
 import './applepay-utils';
 import './exports';
 import './card-fields';
+import './data';
 
 beforeEach(() => {
     setupMocks();


### PR DESCRIPTION
### Description
This PR updates the callback data to include the selected payment source.
```js
createOrder: function (data, actions) {
          return fetch('/your-create-order-url', {
            method: 'post',
            body: JSON.stringify(
              paymentSource: data.paymentSource
            )
          })
```

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
This change is required for Venmo vault.

### Reproduction Steps (if applicable)
1. Set up local JS SDK with SPB alias
2. Set up createOrder and onApprove callbacks and `console.log(data)` in each
3. Click on a funding source and verify the selected one is available as `paymentSource` in createOrder
4. Complete the transaction and verify the selected one is available as `paymentSource` in onApprove

### Screenshots (if applicable)
![createorder-callback-data](https://user-images.githubusercontent.com/40329316/159026186-02a5f8bd-c0f0-43ae-831c-6fdb87f988d9.png)
![onapprove-callback-data](https://user-images.githubusercontent.com/40329316/159026201-0bf0c699-aa74-4f7d-84cd-4b7150a3b4cb.png)

### Dependent Changes (if applicable)
This change can go out independently.