### PR TITLE
chore: update webpack-mem-compile to krakenjs scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,14 +93,14 @@
     "zalgo-promise": "^1.0.28"
   },
   "devDependencies": {
+    "@krakenjs/webpack-mem-compile": "^2.0.1",
     "babel-core": "^7.0.0-bridge.0",
     "express": "^4.16.3",
     "flow-bin": "0.155.0",
     "grabthar-release": "^1.0.8",
     "grumbler-scripts": "^5.0.1",
     "post-robot": "^10.0.13",
-    "sync-browser-mocks": "^2.0.8",
-    "webpack-mem-compile": "^1.0.2"
+    "sync-browser-mocks": "^2.0.8"
   },
   "license": "Apache-2.0"
 }

--- a/server/lib/util.js
+++ b/server/lib/util.js
@@ -2,7 +2,7 @@
 
 import { dirname } from 'path';
 
-import { webpackCompile } from 'webpack-mem-compile';
+import { webpackCompile } from '@krakenjs/webpack-mem-compile';
 import webpack from 'webpack';
 import { regexTokenize } from 'belter';
 import type { ChildType, NullableChildType } from 'jsx-pragmatic/src';
@@ -231,7 +231,7 @@ export function copy<T>(obj : T) : T {
         // $FlowFixMe
         return;
     }
-    
+
     return JSON.parse(stringified);
 }
 


### PR DESCRIPTION
### Description
Update webpack-mem-compile to the krakenjs scoped version. There should be no code changes between these packages. I also moved webpack-mem-compile from devDependencies to dependencies given its usage is in production code.