### PR TITLE
Fix unprocessale entity error handler

### DIFF
--- a/src/api/order.js
+++ b/src/api/order.js
@@ -126,10 +126,9 @@ export function isProcessorDeclineError(err : mixed) : boolean {
     }));
 }
 
-
 export function isUnprocessableEntityError(err : mixed) : boolean {
     // $FlowFixMe
-    return Boolean(err?.response?.body?.data?.details?.some(detail => {
+    return Boolean(err?.response?.body?.details?.some(detail => {
         return detail.issue === ORDER_API_ERROR.DUPLICATE_INVOICE_ID;
     }));
 }

--- a/src/props/onApprove.js
+++ b/src/props/onApprove.js
@@ -103,6 +103,7 @@ const redirect = (url) => {
 const handleProcessorError = <T>(err : mixed, restart : () => ZalgoPromise<void>, onError : OnError) : ZalgoPromise<T> => {
 
     if (isUnprocessableEntityError(err)) {
+        err.message = JSON.stringify(err.response);
         return onError(err).then(unresolvedPromise);
     }
 

--- a/test/client/contingency.js
+++ b/test/client/contingency.js
@@ -125,14 +125,12 @@ describe('contingency cases', () => {
                 const captureOrderMock = getRestfulCaptureOrderApiMock({
                     status: 422,
                     data:   {
-                        name: 'UNPROCESSABLE_ENTITY',
-                        data: {
-                            details: [
-                                {
-                                    issue: 'DUPLICATE_INVOICE_ID'
-                                }
-                            ]
-                        }
+                        name:    'UNPROCESSABLE_ENTITY',
+                        details: [
+                            {
+                                issue: 'DUPLICATE_INVOICE_ID'
+                            }
+                        ]
                     }
                 });
 
@@ -142,7 +140,7 @@ describe('contingency cases', () => {
             });
             
             const onError = (err) => {
-                if (err.response.body.data.details[0].issue !== 'DUPLICATE_INVOICE_ID') {
+                if (err.response.body.details[0].issue !== 'DUPLICATE_INVOICE_ID') {
                     throw new Error(`Expected errors to match, got ${ err.data.details[0].issue } expected to be: DUPLICATE_INVOICE_ID`);
                 }
             };


### PR DESCRIPTION
### Description

Fix related with [this previous PR](https://github.com/paypal/paypal-smart-payment-buttons/pull/344). The solution was not working properly since the error [data was not within](https://github.com/paypal/paypal-smart-payment-buttons/pull/344/files#diff-92796ca22889c6ae6e5b1d0a4e4e0ea5c0e60745885e5549f2d7352ad4ca438eR132) a `data object`, so we removed such a key.

Besides, it seems we need to reassign the error message since the object got in the browser in error.message doest not contain the expected body, instead, it shows a useless string, as can be observed in the following image. However this part of the pr is open to discussion

![image](https://user-images.githubusercontent.com/17114924/162183795-e2c879e2-064b-4c5b-b776-dc3fe5df3d00.png)


### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

[Jira ticket](https://engineering.paypalcorp.com/jira/browse/DTPPSDK-437)

