### PR TITLE
fix: extend session lifetime to reduce occurrence of branded flow redirect

### DIFF
--- a/src/lib/session.js
+++ b/src/lib/session.js
@@ -4,8 +4,10 @@ import { hashStr, getStorage, type Storage } from 'belter/src';
 import getBrowserFingerprint from 'get-browser-fingerprint';
 
 function getSDKStorage() : Storage {
+    const STORAGE_LIFETIME_1_HOUR = 60 * 60 * 1000;
     return getStorage({
-        name: 'paypal'
+        name:     'paypal',
+        lifetime: STORAGE_LIFETIME_1_HOUR
     });
 }
 


### PR DESCRIPTION
### Description

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
Support for https://engineering.paypalcorp.com/jira/browse/DTALTPAY-854
Buyers who wait 20+ minutes to click on payment button are losing the __session__.state object required to continue through unbranded flow. The default lifetime for belter session (saved in localStorage) is 20 minutes. This change leaves belter default untouched and extends the expiration to 60 minutes through the `lifetime` param of the `getStorage()` function.
The goal of extending the expiration is to reduce the occurrence of the buyer being redirected to branded flow.


### Reproduction Steps (if applicable)

- Use drop-in UI (alternative payments unbranded SDK) integration. Enter buyer information.
- Observe localStorage `__session__` contents (check Application tab in dev tools or `window.localStorage.__paypal_storage__` in console).
- Leave window untouched for over 20 minutes (created time value +20 min).
- Click on payment button.
- Observe flow type (branded instead of unbranded)
- Check localStorage contents. New `guid` and `created` values will exist, `state` will be removed from `__session__`.


### Screenshots (if applicable)
![image](https://user-images.githubusercontent.com/29203245/162539320-2d7903f2-c32f-4c76-af8a-a1c693a144ab.png)


### Dependent Changes (if applicable)
N/A


❤️  Thank you!
