### PR TITLE
Fix for approving an order during the vault capture flow

### DIFF
--- a/src/api/order.js
+++ b/src/api/order.js
@@ -359,6 +359,16 @@ export type ValidatePaymentMethodResponse = {|
     |}>
 |};
 
+export function buildPaymentSource(tokenID: string): PaymentSource {
+    const paymentSource : PaymentSource = {
+        token: {
+            id:   tokenID,
+            type: 'NONCE'
+        }
+    };
+    return paymentSource;
+}
+
 type PaymentSource = {|
     token : {|
         id : string,

--- a/src/api/order.js
+++ b/src/api/order.js
@@ -303,17 +303,26 @@ export function patchOrder(orderID : string, data : PatchData, { facilitatorAcce
         return patchData;
     });
 }
+type ConfirmPaymentSource = {|
+    [$Values<typeof FUNDING>] : {
+        country_code? : string | null,
+        name? : string | null,
+        email? : string | null,
+        bic? : string | null,
+        bank_id? : string | null,
+        type?: string | 'NONCE',
+        id?: string
+    }
+|}
+type LimitedNonceSource = {|
+    token : {|
+        id : string,
+        type : 'NONCE'
+    |},
+|}
 
 export type ConfirmData = {|
-    payment_source : {
-        [$Values<typeof FUNDING>] : {|
-            country_code? : string | null,
-            name? : string | null,
-            email? : string | null,
-            bic? : string | null,
-            bank_id? : string | null
-        |}
-      }
+    payment_source : ConfirmPaymentSource | LimitedNonceSource
 |};
 
 export function confirmOrderAPI(orderID : string, data : ConfirmData, { facilitatorAccessToken, partnerAttributionID } : OrderAPIOptions) : ZalgoPromise<OrderConfirmResponse> {
@@ -359,8 +368,9 @@ export type ValidatePaymentMethodResponse = {|
     |}>
 |};
 
-export function buildPaymentSource(tokenID: string): PaymentSource {
-    const paymentSource : PaymentSource = {
+
+export function buildPaymentSource(tokenID: string): LimitedNonceSource {
+    const paymentSource = {
         token: {
             id:   tokenID,
             type: 'NONCE'

--- a/src/api/order.js
+++ b/src/api/order.js
@@ -304,7 +304,7 @@ export function patchOrder(orderID : string, data : PatchData, { facilitatorAcce
     });
 }
 type ConfirmPaymentSource = {|
-    [$Values<typeof FUNDING>] : {
+    [$Values<typeof FUNDING>] : {|
         country_code? : string | null,
         name? : string | null,
         email? : string | null,
@@ -312,7 +312,7 @@ type ConfirmPaymentSource = {|
         bank_id? : string | null,
         type?: string | 'NONCE',
         id?: string
-    }
+    |}
 |}
 type LimitedNonceSource = {|
     token : {|

--- a/src/payment-flows/vault-capture.js
+++ b/src/payment-flows/vault-capture.js
@@ -8,7 +8,7 @@ import { initiateInstallments } from '@paypal/installments/src/interface';
 
 import type { ThreeDomainSecureFlowType, MenuChoices } from '../types';
 import type { CreateOrder } from '../props';
-import { validatePaymentMethod, type ValidatePaymentMethodResponse, getSupplementalOrderInfo, deleteVault, updateButtonClientConfig, loadFraudnet } from '../api';
+import { validatePaymentMethod, type ValidatePaymentMethodResponse, getSupplementalOrderInfo, deleteVault, updateButtonClientConfig, loadFraudnet, confirmOrderAPI, buildPaymentSource } from '../api';
 import { TARGET_ELEMENT, BUYER_INTENT, FPTI_TRANSITION, FPTI_CONTEXT_TYPE, FPTI_MENU_OPTION } from '../constants';
 import { getLogger } from '../lib';
 import type { ButtonProps } from '../button/props';
@@ -174,7 +174,10 @@ function initVaultCapture({ props, components, payment, serviceData, config } : 
 
             const { status, body } = validate;
             return handleValidateResponse({ ThreeDomainSecure, status, body, createOrder, getParent }).then(() => {
-                return onApprove({}, { restart });
+                confirmOrderAPI(orderID, { payment_source: buildPaymentSource(paymentMethodID) }, { facilitatorAccessToken, partnerAttributionID })
+                .then(() => {
+                  return onApprove({}, { restart });
+                });
             });
         });
     };

--- a/src/payment-flows/vault-capture.js
+++ b/src/payment-flows/vault-capture.js
@@ -174,7 +174,7 @@ function initVaultCapture({ props, components, payment, serviceData, config } : 
 
             const { status, body } = validate;
             return handleValidateResponse({ ThreeDomainSecure, status, body, createOrder, getParent }).then(() => {
-                confirmOrderAPI(orderID, { payment_source: buildPaymentSource(paymentMethodID) }, { facilitatorAccessToken, partnerAttributionID })
+                return confirmOrderAPI(orderID, { payment_source: buildPaymentSource(paymentMethodID) }, { facilitatorAccessToken, partnerAttributionID })
                 .then(() => {
                   return onApprove({}, { restart });
                 });

--- a/test/client/mocks.js
+++ b/test/client/mocks.js
@@ -858,6 +858,25 @@ export function getValidatePaymentMethodApiMock(options : Object = {}) : MockEnd
     });
 }
 
+
+export function getConfirmOrderApiMock(options : Object = {}) : MockEndpoint {
+    return $mockEndpoint.register({
+        method:  'POST',
+        uri:     new RegExp('/v2/checkout/orders/[^/]+/confirm-payment-source'),
+        handler: ({ uri, method, query, data, headers }) => {
+            if (options.extraHandler) {
+                const result = options.extraHandler({ uri, method, query, data, headers });
+                if (result) {
+                    return result;
+                }
+            }
+
+            return {};
+        },
+        ...options
+    });
+}
+
 getCreateAccessTokenMock().listen();
 
 getCreateOrderApiMock().listen();

--- a/test/client/vault.js
+++ b/test/client/vault.js
@@ -5,7 +5,7 @@ import { wrapPromise } from '@krakenjs/belter/src';
 import { FUNDING, INTENT } from '@paypal/sdk-constants/src';
 import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 
-import { mockSetupButton, mockAsyncProp, createButtonHTML, getValidatePaymentMethodApiMock,
+import { mockSetupButton, mockAsyncProp, createButtonHTML, getValidatePaymentMethodApiMock, getConfirmOrderApiMock,
     clickButton, getGraphQLApiMock, generateOrderID, mockMenu, clickMenu, getMockWindowOpen } from './mocks';
 
 describe('vault cases', () => {
@@ -309,6 +309,7 @@ describe('vault cases', () => {
             }));
 
             const vpmCall = getValidatePaymentMethodApiMock().expectCalls();
+            const confirmCall = getConfirmOrderApiMock().expectCalls();
 
             window.xprops.onApprove = mockAsyncProp(expect('onApprove', async (data) => {
                 if (data.orderID !== orderID) {
@@ -316,6 +317,7 @@ describe('vault cases', () => {
                 }
 
                 vpmCall.done();
+                confirmCall.done();
             }));
 
             const fundingEligibility = {
@@ -390,6 +392,7 @@ describe('vault cases', () => {
             }));
 
             const vpmCall = getValidatePaymentMethodApiMock().expectCalls();
+            const confirmCall = getConfirmOrderApiMock().expectCalls();
 
             window.xprops.onApprove = mockAsyncProp(expect('onApprove', async (data) => {
                 if (data.orderID !== orderID) {
@@ -397,6 +400,7 @@ describe('vault cases', () => {
                 }
 
                 vpmCall.done();
+                confirmCall.done();
             }));
 
             const fundingEligibility = {
@@ -428,6 +432,7 @@ describe('vault cases', () => {
 
             await clickButton(FUNDING.CARD);
             gqlMock.done();
+            confirmCall.done();
         });
     });
 
@@ -481,6 +486,7 @@ describe('vault cases', () => {
             }));
 
             const vpmCall = getValidatePaymentMethodApiMock().expectCalls();
+            const confirmCall = getConfirmOrderApiMock().expectCalls();
 
             window.xprops.onApprove = mockAsyncProp(expect('onApprove', async (data) => {
                 if (data.orderID !== orderID) {
@@ -488,6 +494,7 @@ describe('vault cases', () => {
                 }
 
                 vpmCall.done();
+                confirmCall.done();
             }));
 
             const fundingEligibility = {
@@ -521,6 +528,7 @@ describe('vault cases', () => {
             await clickButton(FUNDING.CARD);
             gqlMock.done();
             vpmCall.done();
+            confirmCall.done();
         });
     });
 
@@ -574,12 +582,14 @@ describe('vault cases', () => {
             }));
 
             const vpmCall = getValidatePaymentMethodApiMock().expectCalls();
+            const confirmCall = getConfirmOrderApiMock().expectCalls();
 
             window.xprops.onApprove = mockAsyncProp(expect('onApprove', async (data) => {
                 if (data.orderID !== orderID) {
                     throw new Error(`Expected orderID to be ${ orderID }, got ${ data.orderID }`);
                 }
 
+                confirmCall.done();
                 vpmCall.done();
             }));
 
@@ -655,6 +665,7 @@ describe('vault cases', () => {
             }));
 
             const vpmCall = getValidatePaymentMethodApiMock().expectCalls();
+            const confirmCall = getConfirmOrderApiMock().expectCalls();
 
             window.xprops.onApprove = mockAsyncProp(expect('onApprove', async (data) => {
                 if (data.orderID !== orderID) {
@@ -662,6 +673,7 @@ describe('vault cases', () => {
                 }
 
                 vpmCall.done();
+                confirmCall.done();
             }));
 
             const fundingEligibility = {


### PR DESCRIPTION
### Description
Currently, when using the vault-capture flow, after we apply the payment (by calling the `validate-payment-method` endpoint), we have not actually approved the order. For some of our merchants, they validate that the order is approved before they will attempt to capture the order.

This PR adds in an additional call to the Orders API to `confirm-payment-method` that will set the order to `APPROVED` based on the user action

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
PPPLMER-104024

### Reproduction Steps (if applicable)
* Visit https://www.te-cibns.qa.paypal.com/xo-integrations/vaulting/client-token
* Set a breakpoint in the `onApprove` method prior to calling capture on the order
* Populate the customer_id of `test-1654613061212`
* Upon Setting the customer ID and waiting for the buttons to re-render, you should see the one-click buttons
* Click the one-click button
* When the breakpoint is hit, grab the order id that was created and look it up via the orders api
* You should see that the result is that the order has a status of `CREATED`. It should be `APPROVED`

```bash
curl --request GET \
  --url https://msmaster.qa.paypal.com:12326/v2/checkout/orders/2X1050494V836180N \
  --header 'Authorization: Bearer A21_A.AAcEhfq4h5VrKjkAZ_tbG7S_XD50-ncSKCkri27He_e2tLuJVgLJf74cduHbNhAPpVTQy-5A_n50dmAf-7T4XIr0l4ROGg' \
  --header 'Content-Type: application/json' \
```
### Screenshots (if applicable)

### Dependent Changes (if applicable)

❤️  Thank you!
