### PR TITLE
Update onComplete data and actions

### DIFF
--- a/src/button/button.js
+++ b/src/button/button.js
@@ -7,7 +7,7 @@ import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 import type { ContentType, Wallet, PersonalizationType } from '../types';
 import { getLogger, getSmartFieldsByFundingSource } from '../lib';
 import { type FirebaseConfig } from '../api';
-import { DATA_ATTRIBUTES, BUYER_INTENT } from '../constants';
+import { DATA_ATTRIBUTES, BUYER_INTENT, FPTI_CONTEXT_TYPE, AMPLITUDE_KEY } from '../constants';
 import { type Payment } from '../payment-flows';
 
 import { getButtonProps, getConfig, getComponents, getServiceData, type ButtonProps } from './props';
@@ -85,7 +85,11 @@ export function setupButton(opts : ButtonOpts) : ZalgoPromise<void> {
     getLogger()
         .info(`cross_site_tracking_enabled_${ String(isCrossSiteTrackingEnabled('enforce_policy')) }`)
         .track({
-            [FPTI_KEY.TRANSITION]: `cross_site_tracking_enabled_${ String(isCrossSiteTrackingEnabled('enforce_policy')) }`
+            [FPTI_KEY.TRANSITION]: `cross_site_tracking_enabled_${ String(isCrossSiteTrackingEnabled('enforce_policy')) }`,
+            [FPTI_KEY.CONTEXT_TYPE]:       FPTI_CONTEXT_TYPE.BUTTON_SESSION_ID,
+            [FPTI_KEY.CONTEXT_ID]:         buttonSessionID,
+            [FPTI_KEY.BUTTON_SESSION_UID]: buttonSessionID,
+            [AMPLITUDE_KEY.USER_ID]:       buttonSessionID,
         }).flush();
 
     function initiatePayment({ payment, props: paymentProps } : {| props : ButtonProps, payment : Payment |}) : ZalgoPromise<void> {

--- a/src/button/button.js
+++ b/src/button/button.js
@@ -1,13 +1,13 @@
 /* @flow */
 
-import { onClick as onElementClick, querySelectorAll, noop, stringifyErrorMessage, stringifyError, preventClickFocus, isCrossSiteTrackingEnabled } from '@krakenjs/belter/src';
+import { onClick as onElementClick, querySelectorAll, noop, stringifyErrorMessage, stringifyError, preventClickFocus } from '@krakenjs/belter/src';
 import { COUNTRY, FPTI_KEY, type FundingEligibilityType } from '@paypal/sdk-constants/src';
 import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 
 import type { ContentType, Wallet, PersonalizationType } from '../types';
 import { getLogger, getSmartFieldsByFundingSource } from '../lib';
 import { type FirebaseConfig } from '../api';
-import { DATA_ATTRIBUTES, BUYER_INTENT, FPTI_CONTEXT_TYPE, AMPLITUDE_KEY } from '../constants';
+import { DATA_ATTRIBUTES, BUYER_INTENT } from '../constants';
 import { type Payment } from '../payment-flows';
 
 import { getButtonProps, getConfig, getComponents, getServiceData, type ButtonProps } from './props';
@@ -81,16 +81,6 @@ export function setupButton(opts : ButtonOpts) : ZalgoPromise<void> {
     const { initPromise, isEnabled } = onInit({ correlationID: buttonCorrelationID });
 
     let paymentProcessing = false;
-    
-    getLogger()
-        .info(`cross_site_tracking_enabled_${ String(isCrossSiteTrackingEnabled('enforce_policy')) }`)
-        .track({
-            [FPTI_KEY.TRANSITION]: `cross_site_tracking_enabled_${ String(isCrossSiteTrackingEnabled('enforce_policy')) }`,
-            [FPTI_KEY.CONTEXT_TYPE]:       FPTI_CONTEXT_TYPE.BUTTON_SESSION_ID,
-            [FPTI_KEY.CONTEXT_ID]:         buttonSessionID,
-            [FPTI_KEY.BUTTON_SESSION_UID]: buttonSessionID,
-            [AMPLITUDE_KEY.USER_ID]:       buttonSessionID,
-        }).flush();
 
     function initiatePayment({ payment, props: paymentProps } : {| props : ButtonProps, payment : Payment |}) : ZalgoPromise<void> {
         return ZalgoPromise.try(() => {

--- a/src/button/button.js
+++ b/src/button/button.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { onClick as onElementClick, querySelectorAll, noop, stringifyErrorMessage, stringifyError, preventClickFocus } from '@krakenjs/belter/src';
+import { onClick as onElementClick, querySelectorAll, noop, stringifyErrorMessage, stringifyError, preventClickFocus, isCrossSiteTrackingEnabled } from '@krakenjs/belter/src';
 import { COUNTRY, FPTI_KEY, type FundingEligibilityType } from '@paypal/sdk-constants/src';
 import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 
@@ -81,6 +81,12 @@ export function setupButton(opts : ButtonOpts) : ZalgoPromise<void> {
     const { initPromise, isEnabled } = onInit({ correlationID: buttonCorrelationID });
 
     let paymentProcessing = false;
+    
+    getLogger()
+        .info(`cross_site_tracking_enabled_${ String(isCrossSiteTrackingEnabled('enforce_policy')) }`)
+        .track({
+            [FPTI_KEY.TRANSITION]: `cross_site_tracking_enabled_${ String(isCrossSiteTrackingEnabled('enforce_policy')) }`
+        }).flush();
 
     function initiatePayment({ payment, props: paymentProps } : {| props : ButtonProps, payment : Payment |}) : ZalgoPromise<void> {
         return ZalgoPromise.try(() => {

--- a/src/button/pay.js
+++ b/src/button/pay.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { noop, stringifyError } from '@krakenjs/belter/src';
+import { noop, stringifyError, isCrossSiteTrackingEnabled } from '@krakenjs/belter/src';
 import { EXPERIENCE } from '@paypal/checkout-components/src/constants/button';
 import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 import { FPTI_KEY } from '@paypal/sdk-constants/src';
@@ -109,7 +109,13 @@ export function initiatePaymentFlow({ payment, serviceData, config, components, 
                 [FPTI_KEY.IS_VAULT]:          instrumentType ? '1' : '0',
                 [FPTI_CUSTOM_KEY.INFO_MSG]:   enableNativeCheckout ? 'tester' : '',
                 [FPTI_CUSTOM_KEY.EXPERIENCE]: experience === EXPERIENCE.INLINE ? 'inline' : ''
-            }).flush();
+            });
+
+            getLogger()
+                .info(`cross_site_tracking_enabled_${ String(isCrossSiteTrackingEnabled('enforce_policy')) }`)
+                .track({
+                    [FPTI_KEY.TRANSITION]: `cross_site_tracking_enabled_${ String(isCrossSiteTrackingEnabled('enforce_policy')) }`
+                }).flush();
 
         const loggingPromise =  ZalgoPromise.try(() => {
             return window.xprops.sessionState.get(`__confirm_${ fundingSource }_payload__`).then(confirmPayload => {

--- a/src/button/pay.js
+++ b/src/button/pay.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { noop, stringifyError, isCrossSiteTrackingEnabled } from '@krakenjs/belter/src';
+import { noop, stringifyError } from '@krakenjs/belter/src';
 import { EXPERIENCE } from '@paypal/checkout-components/src/constants/button';
 import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 import { FPTI_KEY } from '@paypal/sdk-constants/src';
@@ -83,13 +83,6 @@ export function initiatePaymentFlow({ payment, serviceData, config, components, 
 
         const { name, init, inline, spinner, updateFlowClientConfig } = getPaymentFlow({ props, payment, config, components, serviceData });
         const { click, start, close } = init({ props, config, serviceData, components, payment, restart });
-        
-        let derivedExperience = '';
-        if (isCrossSiteTrackingEnabled('enforce_policy') && experience === EXPERIENCE.INLINE) {
-            derivedExperience = 'inline_tracking_enabled';
-        } else if (!isCrossSiteTrackingEnabled('enforce_policy') && experience === EXPERIENCE.INLINE) {
-            derivedExperience = 'inline_tracking_disabled';
-        }
 
         getLogger()
             .addPayloadBuilder(() => {
@@ -115,7 +108,7 @@ export function initiatePaymentFlow({ payment, serviceData, config, components, 
                 [FPTI_KEY.PAYMENT_FLOW]:      name,
                 [FPTI_KEY.IS_VAULT]:          instrumentType ? '1' : '0',
                 [FPTI_CUSTOM_KEY.INFO_MSG]:   enableNativeCheckout ? 'tester' : '',
-                [FPTI_CUSTOM_KEY.EXPERIENCE]: derivedExperience
+                [FPTI_CUSTOM_KEY.EXPERIENCE]: experience === EXPERIENCE.INLINE ? 'inline' : ''
             }).flush();
 
         const loggingPromise =  ZalgoPromise.try(() => {

--- a/src/payment-flows/card-form.js
+++ b/src/payment-flows/card-form.js
@@ -19,7 +19,7 @@ function setupCardForm() {
 let cardFormOpen = false;
 
 function isCardFormEligible({ props, serviceData } : IsEligibleOptions) : boolean {
-    const { vault, onShippingChange, onShippingAddressChange, onShippingOptionsChange, experience } = props;
+    const { vault, onShippingChange, experience } = props;
     const { eligibility } = serviceData;
 
     if (experience === EXPERIENCE.INLINE && !isCrossSiteTrackingEnabled('enforce_policy')) {
@@ -32,7 +32,7 @@ function isCardFormEligible({ props, serviceData } : IsEligibleOptions) : boolea
                 [FPTI_KEY.EXPERIMENT_NAME]: 'inlinexo',
                 [FPTI_KEY.TREATMENT_NAME]:  treatment
             }).flush();
-            
+
         return inlinexoExperiment.isEnabled() ? false : true;
     }
 
@@ -40,7 +40,7 @@ function isCardFormEligible({ props, serviceData } : IsEligibleOptions) : boolea
         return false;
     }
 
-    if (onShippingChange || onShippingAddressChange || onShippingOptionsChange) {
+    if (onShippingChange) {
         return false;
     }
 

--- a/src/payment-flows/card-form.js
+++ b/src/payment-flows/card-form.js
@@ -1,12 +1,13 @@
 /* @flow */
 
 import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
-import { FUNDING, CARD } from '@paypal/sdk-constants/src';
+import { FUNDING, CARD, FPTI_KEY } from '@paypal/sdk-constants/src';
+import { createExperiment } from '@paypal/sdk-client/src';
 import { memoize, querySelectorAll, debounce, noop, isCrossSiteTrackingEnabled } from '@krakenjs/belter/src';
 import { EXPERIENCE } from '@paypal/checkout-components/src/constants/button';
 
 import { DATA_ATTRIBUTES } from '../constants';
-import { unresolvedPromise, promiseNoop } from '../lib';
+import { unresolvedPromise, promiseNoop, getLogger } from '../lib';
 
 import type { PaymentFlow, PaymentFlowInstance, IsEligibleOptions, IsPaymentEligibleOptions, InitOptions } from './types';
 import { checkout } from './checkout';
@@ -22,6 +23,15 @@ function isCardFormEligible({ props, serviceData } : IsEligibleOptions) : boolea
     const { eligibility } = serviceData;
 
     if (experience === EXPERIENCE.INLINE && !isCrossSiteTrackingEnabled('enforce_policy')) {
+        const inlinexoExperiment = createExperiment('inlinexo', 50, getLogger());
+        const treatment = inlinexoExperiment.getTreatment();
+
+        getLogger()
+            .info(treatment)
+            .track({
+                [FPTI_KEY.EXPERIMENT_NAME]: 'inlinexo',
+                [FPTI_KEY.TREATMENT_NAME]:  treatment
+            }).flush();
         return false;
     }
 

--- a/src/payment-flows/card-form.js
+++ b/src/payment-flows/card-form.js
@@ -32,7 +32,8 @@ function isCardFormEligible({ props, serviceData } : IsEligibleOptions) : boolea
                 [FPTI_KEY.EXPERIMENT_NAME]: 'inlinexo',
                 [FPTI_KEY.TREATMENT_NAME]:  treatment
             }).flush();
-        return false;
+            
+        return inlinexoExperiment.isEnabled() ? false : true;
     }
 
     if (vault) {

--- a/src/payment-flows/checkout.js
+++ b/src/payment-flows/checkout.js
@@ -241,7 +241,12 @@ function initCheckout({ props, components, serviceData, payment, config, restart
             },
 
             onComplete: () => {
-                return onComplete()
+                getLogger().info(`spb_oncomplete_access_token_${ buyerAccessToken ? 'present' : 'not_present' }`).flush();
+
+                setBuyerAccessToken(buyerAccessToken);
+
+                // eslint-disable-next-line no-use-before-define
+                return onComplete({ buyerAccessToken }, { restart })
                     // eslint-disable-next-line no-use-before-define
                     .finally(() => close().then(noop))
                     .catch(noop);

--- a/src/props/onComplete.js
+++ b/src/props/onComplete.js
@@ -2,24 +2,63 @@
 
 import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 import { memoize, redirect as redir } from '@krakenjs/belter/src';
-import { FPTI_KEY } from '@paypal/sdk-constants/src';
+import { INTENT, FPTI_KEY } from '@paypal/sdk-constants/src';
 
-import { getLogger, promiseNoop } from '../lib';
-import { FPTI_TRANSITION, FPTI_CONTEXT_TYPE } from '../constants';
+import { getLogger, promiseNoop, unresolvedPromise } from '../lib';
+import { FPTI_TRANSITION, FPTI_CONTEXT_TYPE, LSAT_UPGRADE_EXCLUDED_MERCHANTS } from '../constants';
+import { getOrder, captureOrder, isProcessorDeclineError, isUnprocessableEntityError, type OrderResponse } from '../api';
 
 import type { CreateOrder } from './createOrder';
 import type { OnError } from './onError';
 
 
-export type OnComplete = () => ZalgoPromise<void>;
+export type OnCompleteData = {|
+    payerID? : ?string,
+    paymentID? : ?string,
+    billingToken? : ?string,
+    subscriptionID? : ?string,
+    buyerAccessToken? : ?string,
+    authCode? : ?string,
+    forceRestAPI? : boolean,
+    paymentMethodToken? : string
+|};
+
+export type OnCompleteActions = {|
+    restart : () => ZalgoPromise<void>
+|};
+
+export type OnComplete = (OnCompleteData, OnCompleteActions) => ZalgoPromise<void>;
 
 export type XOnCompleteData = {|
-    orderID : string
+    orderID : string,
+    intent : $Values<typeof INTENT>
 |};
 export type XOnCompleteActions = {|
+    capture : () => ZalgoPromise<OrderResponse>,
+    get : () => ZalgoPromise<OrderResponse>,
     redirect : (string) => ZalgoPromise<void>
 |};
 export type XOnComplete = (XOnCompleteData, XOnCompleteActions) => ZalgoPromise<void>;
+
+type OnCompleteActionOptions = {|
+    orderID : string,
+    restart : () => ZalgoPromise<void>,
+    facilitatorAccessToken : string,
+    buyerAccessToken : ?string,
+    partnerAttributionID : ?string,
+    forceRestAPI : boolean,
+    onError : OnError
+|};
+
+type GetOnCompleteOptions = {|
+    intent : $Values<typeof INTENT>,
+    onComplete : ?XOnComplete,
+    partnerAttributionID : ?string,
+    onError : OnError,
+    clientID : string,
+    facilitatorAccessToken : string,
+    createOrder : CreateOrder,
+|};
 
 const redirect = (url) => {
     if (!url) {
@@ -36,12 +75,48 @@ const redirect = (url) => {
     return redir(url, window.top);
 };
 
-export function getOnComplete({ createOrder, onComplete, onError } : {| createOrder : CreateOrder, onComplete : ?XOnComplete, onError : OnError |}) : OnComplete {
+const handleProcessorError = <T>(err : mixed, restart : () => ZalgoPromise<void>, onError : OnError) : ZalgoPromise<T> => {
+
+    if (isUnprocessableEntityError(err)) {
+        if (err && err.response) {
+            // $FlowFixMe
+            err.message = JSON.stringify(err.response) || err.message;
+        }
+        return onError(err).then(unresolvedPromise);
+    }
+
+    if (isProcessorDeclineError(err)) {
+        return restart().then(unresolvedPromise);
+    }
+
+    throw err;
+};
+
+const buildOnCompleteActions = ({ orderID, restart, facilitatorAccessToken, buyerAccessToken, partnerAttributionID, forceRestAPI, onError } : OnCompleteActionOptions) : XOnCompleteActions => {
+    const get = memoize(() => {
+        return getOrder(orderID, { facilitatorAccessToken, buyerAccessToken, partnerAttributionID, forceRestAPI });
+    });
+
+    const capture = memoize(() => {
+        return captureOrder(orderID, { facilitatorAccessToken, buyerAccessToken, partnerAttributionID, forceRestAPI })
+            .finally(get.reset)
+            .finally(capture.reset)
+            .catch(err => {
+                return handleProcessorError<OrderResponse>(err, restart, onError);
+            });
+    });
+
+    return { capture, get, redirect };
+};
+
+export function getOnComplete({ intent, onComplete, partnerAttributionID, onError, clientID, facilitatorAccessToken, createOrder } : GetOnCompleteOptions) : OnComplete {
     if (!onComplete) {
         return promiseNoop;
     }
 
-    return memoize(() => {
+    const upgradeLSAT = LSAT_UPGRADE_EXCLUDED_MERCHANTS.indexOf(clientID) === -1;
+
+    return memoize(({ buyerAccessToken, forceRestAPI = upgradeLSAT } : OnCompleteData, { restart } : OnCompleteActions) => {
         return createOrder().then(orderID => {
             getLogger()
                 .info('button_complete')
@@ -51,7 +126,9 @@ export function getOnComplete({ createOrder, onComplete, onError } : {| createOr
                     [FPTI_KEY.TOKEN]:        orderID,
                     [FPTI_KEY.CONTEXT_ID]:   orderID
                 }).flush();
-            return onComplete({ orderID }, { redirect }).catch(err => {
+            const actions = buildOnCompleteActions({ orderID, restart, facilitatorAccessToken, buyerAccessToken, partnerAttributionID, forceRestAPI, onError });
+
+            return onComplete({ orderID, intent }, actions).catch(err => {
                 return ZalgoPromise.try(() => {
                     return onError(err);
                 }).then(() => {

--- a/src/props/props.js
+++ b/src/props/props.js
@@ -252,7 +252,7 @@ export function getProps({ facilitatorAccessToken, branded, paymentSource } : {|
 
     const onError = getOnError({ onError: xprops.onError });
     const onApprove = getOnApprove({ onApprove: xprops.onApprove, createBillingAgreement, createSubscription, intent, onError, partnerAttributionID, clientAccessToken, vault, clientID, facilitatorAccessToken, branded, createOrder, paymentSource });
-    const onComplete = getOnComplete({ createOrder, onComplete: xprops.onComplete, onError: xprops.onError });
+    const onComplete = getOnComplete({ intent, onComplete: xprops.onComplete, partnerAttributionID, onError, clientID, facilitatorAccessToken, createOrder });
     const onCancel = getOnCancel({ onCancel: xprops.onCancel, onError }, { createOrder });
     const onShippingChange = getOnShippingChange({ onShippingChange: xprops.onShippingChange, partnerAttributionID, clientID }, { facilitatorAccessToken, createOrder });
     const onShippingAddressChange = getOnShippingAddressChange({ onShippingAddressChange: xprops.onShippingAddressChange, partnerAttributionID, clientID }, { facilitatorAccessToken, createOrder });

--- a/test/client/inlinexo.js
+++ b/test/client/inlinexo.js
@@ -177,7 +177,9 @@ describe('Inline XO cases', () => {
                     })
                 });
                 captureOrderMock.expectCalls();
-                await actions.capture();
+                if (data.intent === 'authorize') {
+                    await actions.capture();
+                }
                 captureOrderMock.done();
             });
 

--- a/test/client/inlinexo.js
+++ b/test/client/inlinexo.js
@@ -1,11 +1,18 @@
 /* @flow */
 /* eslint require-await: off, max-lines: off, max-nested-callbacks: off */
 
-import { wrapPromise } from '@krakenjs/belter/src';
+import { uniqueID, wrapPromise } from '@krakenjs/belter/src';
 import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 import { FUNDING, CARD } from '@paypal/sdk-constants/src';
 
-import { mockSetupButton, generateOrderID, mockAsyncProp, createButtonHTML, mockFunction, clickButton } from './mocks';
+import {
+    mockSetupButton,
+    generateOrderID,
+    mockAsyncProp,
+    createButtonHTML,
+    mockFunction,
+    clickButton,
+    getRestfulCaptureOrderApiMock, getGraphQLApiMock } from './mocks';
 
 describe('Inline XO cases', () => {
     
@@ -94,6 +101,128 @@ describe('Inline XO cases', () => {
             createButtonHTML({ fundingEligibility });
             await mockSetupButton({ experience: 'inline', merchantID: [ 'XYZ12345' ], fundingEligibility });
             await clickButton(FUNDING.CARD);
+        });
+    });
+
+    it('should call onComplete if experience is inline and capture if intent is authorize', async () => {
+        return await wrapPromise(async ({ expect, avoid }) => {
+
+            const orderID = generateOrderID();
+            const facilitatorAccessToken = uniqueID();
+
+            window.xprops.experience = 'inline';
+            window.xprops.intent = 'authorize';
+
+            const getOrderDetailsMock = getGraphQLApiMock({
+                extraHandler: expect('orderDetailsCall', ({ data }) => {
+
+                    if (data.query.includes('query GetCheckoutDetails')) {
+                        return {
+                            data: {
+                                checkoutSession: {
+                                    cart: {
+                                        intent:  'authorize',
+                                        amounts: {
+                                            total: {
+                                                currencyCode: 'USD'
+                                            }
+                                        }
+                                    },
+                                    payees: [
+                                        {
+                                            merchantId: 'XYZ12345',
+                                            email:       {
+                                                stringValue: 'xyz-us-b1@paypal.com'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        };
+                    }
+                })
+            }).expectCalls();
+
+            window.xprops.createOrder = mockAsyncProp(expect('createOrder', async () => {
+                return ZalgoPromise.try(() => {
+                    return orderID;
+                });
+            }));
+
+            window.xprops.onCancel = avoid('onCancel');
+            window.xprops.onApprove = avoid('onApprove');
+            window.xprops.onError = avoid('onError');
+
+            window.xprops.onComplete = expect('onComplete', async (data, actions) => {
+                if (data.orderID !== orderID) {
+                    throw new Error(`Expected orderID to be ${ orderID }, got ${ data.orderID }`);
+                }
+
+                if (!actions.redirect) {
+                    throw new Error(`Expected actions.redirect() to be available.`);
+                }
+
+                const captureOrderMock = getRestfulCaptureOrderApiMock({
+                    handler: expect('captureOrder', ({ headers }) => {
+                        if (headers.authorization !== `Bearer ${ facilitatorAccessToken }`) {
+                            throw new Error(`Expected call to come with correct facilitator access token`);
+                        }
+
+                        return {
+                            id: orderID
+                        };
+                    })
+                });
+                captureOrderMock.expectCalls();
+                await actions.capture();
+                captureOrderMock.done();
+            });
+
+            mockFunction(window.paypal, 'Checkout', expect('Checkout', ({ original: CheckoutOriginal, args: [ props ] }) => {
+
+                mockFunction(props, 'onComplete', expect('onComplete', ({ original: onCompleteOriginal, args: [ data, actions ] }) => {
+                    return onCompleteOriginal({ ...data }, actions);
+                }));
+
+                const checkoutInstance = CheckoutOriginal(props);
+
+                mockFunction(checkoutInstance, 'renderTo', expect('renderTo', async ({ original: renderToOriginal, args }) => {
+                    const [ win, element, context ] = args;
+
+                    if (!win) {
+                        throw new Error(`Expected window to be passed to renderTo`);
+                    }
+
+                    if (!element || typeof element !== 'string') {
+                        throw new Error(`Expected string element to be passed to renderTo`);
+                    }
+
+                    if (context !== 'iframe') {
+                        throw new Error(`Expected context to be iframe, got ${ context }`);
+                    }
+
+                    return props.createOrder().then(id => {
+                        if (id !== orderID) {
+                            throw new Error(`Expected orderID to be ${ orderID }, got ${ id }`);
+                        }
+
+                        return renderToOriginal(...args);
+                    });
+                }));
+
+                return checkoutInstance;
+            }));
+
+            createButtonHTML({ fundingEligibility });
+            await mockSetupButton({
+                experience: 'inline',
+                merchantID: [ 'XYZ12345' ],
+                fundingEligibility,
+                facilitatorAccessToken
+            });
+            await clickButton(FUNDING.CARD);
+
+            getOrderDetailsMock.done();
         });
     });
 

--- a/test/client/inlinexo.js
+++ b/test/client/inlinexo.js
@@ -12,7 +12,10 @@ import {
     createButtonHTML,
     mockFunction,
     clickButton,
-    getRestfulCaptureOrderApiMock, getGraphQLApiMock } from './mocks';
+    getRestfulCaptureOrderApiMock,
+    getRestfulGetOrderApiMock,
+    getGraphQLApiMock
+} from './mocks';
 
 describe('Inline XO cases', () => {
     
@@ -253,7 +256,7 @@ describe('Inline XO cases', () => {
                     throw new Error(`Expected actions.redirect() to be available.`);
                 }
 
-                const getOrderMock = getRestfulCaptureOrderApiMock({
+                const getOrderMock = getRestfulGetOrderApiMock({
                     handler: expect('getOrder', ({ headers }) => {
                         if (headers.authorization !== `Bearer ${ facilitatorAccessToken }`) {
                             throw new Error(`Expected call to come with correct facilitator access token`);

--- a/test/client/inlinexo.js
+++ b/test/client/inlinexo.js
@@ -231,6 +231,257 @@ describe('Inline XO cases', () => {
         });
     });
 
+    it('should call onComplete if experience is inline and capture if intent is authorize and catch isProcessorDeclineError from capture', async () => {
+        return await wrapPromise(async ({ expect, avoid }) => {
+
+            const orderID = generateOrderID();
+            const facilitatorAccessToken = uniqueID();
+
+            window.xprops.experience = 'inline';
+            window.xprops.intent = 'authorize';
+
+            const getOrderDetailsMock = getGraphQLApiMock({
+                extraHandler: expect('orderDetailsCall', ({ data }) => {
+
+                    if (data.query.includes('query GetCheckoutDetails')) {
+                        return {
+                            data: {
+                                checkoutSession: {
+                                    cart: {
+                                        intent:  'authorize',
+                                        amounts: {
+                                            total: {
+                                                currencyCode: 'USD'
+                                            }
+                                        }
+                                    },
+                                    payees: [
+                                        {
+                                            merchantId: 'XYZ12345',
+                                            email:       {
+                                                stringValue: 'xyz-us-b1@paypal.com'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        };
+                    }
+                })
+            }).expectCalls();
+
+            window.xprops.createOrder = mockAsyncProp(expect('createOrder', async () => {
+                return ZalgoPromise.try(() => {
+                    return orderID;
+                });
+            }));
+
+            window.xprops.onCancel = avoid('onCancel');
+            window.xprops.onApprove = avoid('onApprove');
+            window.xprops.onError = avoid('onError');
+
+            let onComplete = expect('onComplete', async (data, actions) => {
+
+                if (data.orderID !== orderID) {
+                    throw new Error(`Expected orderID to be ${ orderID }, got ${ data.orderID }`);
+                }
+
+                const captureOrderRESTMock = getRestfulCaptureOrderApiMock({
+                    status: 400,
+                    data:   {
+                        ack:         'contingency',
+                        contingency: 'UNPROCESSABLE_ENTITY',
+                        data:        {
+                            details: [
+                                {
+                                    issue: 'INSTRUMENT_DECLINED'
+                                }
+                            ]
+                        }
+                    }
+                });
+                captureOrderRESTMock.expectCalls();
+                actions.capture();
+                captureOrderRESTMock.done();
+
+                onComplete = expect('onComplete2');
+            });
+
+            window.xprops.onComplete = mockAsyncProp(expect('onComplete', (data, actions) => onComplete(data, actions)));
+
+            mockFunction(window.paypal, 'Checkout', expect('Checkout', ({ original: CheckoutOriginal, args: [ props ] }) => {
+                mockFunction(props, 'onComplete', expect('onComplete', ({ original: onCompleteOriginal, args: [ data, actions ] }) => {
+                    return onCompleteOriginal({ ...data }, actions);
+                }));
+
+                const checkoutInstance = CheckoutOriginal(props);
+
+                mockFunction(checkoutInstance, 'renderTo', expect('renderTo', async ({ original: renderToOriginal, args }) => {
+                    const [ win, element, context ] = args;
+
+                    if (!win) {
+                        throw new Error(`Expected window to be passed to renderTo`);
+                    }
+
+                    if (!element || typeof element !== 'string') {
+                        throw new Error(`Expected string element to be passed to renderTo`);
+                    }
+
+                    if (context !== 'iframe') {
+                        throw new Error(`Expected context to be iframe, got ${ context }`);
+                    }
+
+                    return props.createOrder().then(id => {
+                        if (id !== orderID) {
+                            throw new Error(`Expected orderID to be ${ orderID }, got ${ id }`);
+                        }
+
+                        return renderToOriginal(...args);
+                    });
+                }));
+
+                return checkoutInstance;
+            }));
+
+            createButtonHTML({ fundingEligibility });
+            await mockSetupButton({
+                experience: 'inline',
+                merchantID: [ 'XYZ12345' ],
+                fundingEligibility,
+                facilitatorAccessToken
+            });
+            await clickButton(FUNDING.CARD);
+
+            getOrderDetailsMock.done();
+        });
+    });
+
+    it('should call onComplete if experience is inline and capture if intent is authorize and catch isUnprocessableEntityError from capture', async () => {
+        return await wrapPromise(async ({ expect, avoid }) => {
+
+            const orderID = generateOrderID();
+            const facilitatorAccessToken = uniqueID();
+
+            window.xprops.experience = 'inline';
+            window.xprops.intent = 'authorize';
+
+            const getOrderDetailsMock = getGraphQLApiMock({
+                extraHandler: expect('orderDetailsCall', ({ data }) => {
+
+                    if (data.query.includes('query GetCheckoutDetails')) {
+                        return {
+                            data: {
+                                checkoutSession: {
+                                    cart: {
+                                        intent:  'authorize',
+                                        amounts: {
+                                            total: {
+                                                currencyCode: 'USD'
+                                            }
+                                        }
+                                    },
+                                    payees: [
+                                        {
+                                            merchantId: 'XYZ12345',
+                                            email:       {
+                                                stringValue: 'xyz-us-b1@paypal.com'
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        };
+                    }
+                })
+            }).expectCalls();
+
+            window.xprops.createOrder = mockAsyncProp(expect('createOrder', async () => {
+                return ZalgoPromise.try(() => {
+                    return orderID;
+                });
+            }));
+
+            window.xprops.onCancel = avoid('onCancel');
+            window.xprops.onApprove = avoid('onApprove');
+            window.xprops.onError = avoid('onError');
+
+            let onComplete = expect('onComplete', async (data, actions) => {
+
+                if (data.orderID !== orderID) {
+                    throw new Error(`Expected orderID to be ${ orderID }, got ${ data.orderID }`);
+                }
+
+                const captureOrderRESTMock = getRestfulCaptureOrderApiMock({
+                    status: 400,
+                    data:   {
+                        ack:         'contingency',
+                        contingency: 'UNPROCESSABLE_ENTITY',
+                        data:        {
+                            details: [
+                                {
+                                    issue: 'DUPLICATE_INVOICE_ID'
+                                }
+                            ]
+                        }
+                    }
+                });
+                captureOrderRESTMock.expectCalls();
+                actions.capture();
+                captureOrderRESTMock.done();
+
+                onComplete = avoid('onComplete2');
+            });
+
+            window.xprops.onComplete = mockAsyncProp(expect('onComplete', (data, actions) => onComplete(data, actions)));
+
+            mockFunction(window.paypal, 'Checkout', expect('Checkout', ({ original: CheckoutOriginal, args: [ props ] }) => {
+
+                mockFunction(props, 'onComplete', expect('onComplete', ({ original: onCompleteOriginal, args: [ data, actions ] }) => {
+                    return onCompleteOriginal({ ...data }, actions);
+                }));
+
+                const checkoutInstance = CheckoutOriginal(props);
+
+                mockFunction(checkoutInstance, 'renderTo', expect('renderTo', async ({ original: renderToOriginal, args }) => {
+                    const [ win, element, context ] = args;
+
+                    if (!win) {
+                        throw new Error(`Expected window to be passed to renderTo`);
+                    }
+
+                    if (!element || typeof element !== 'string') {
+                        throw new Error(`Expected string element to be passed to renderTo`);
+                    }
+
+                    if (context !== 'iframe') {
+                        throw new Error(`Expected context to be iframe, got ${ context }`);
+                    }
+
+                    return props.createOrder().then(id => {
+                        if (id !== orderID) {
+                            throw new Error(`Expected orderID to be ${ orderID }, got ${ id }`);
+                        }
+
+                        return renderToOriginal(...args);
+                    });
+                }));
+
+                return checkoutInstance;
+            }));
+
+            createButtonHTML({ fundingEligibility });
+            await mockSetupButton({
+                experience: 'inline',
+                merchantID: [ 'XYZ12345' ],
+                fundingEligibility,
+                facilitatorAccessToken
+            });
+            await clickButton(FUNDING.CARD);
+
+            getOrderDetailsMock.done();
+        });
+    });
+
     it('should call onComplete if experience is inline and get order when captured', async () => {
         return await wrapPromise(async ({ expect, avoid }) => {
 

--- a/test/client/inlinexo.js
+++ b/test/client/inlinexo.js
@@ -226,6 +226,95 @@ describe('Inline XO cases', () => {
         });
     });
 
+    it('should call onComplete if experience is inline and get order when captured', async () => {
+        return await wrapPromise(async ({ expect, avoid }) => {
+
+            const orderID = generateOrderID();
+            const facilitatorAccessToken = uniqueID();
+
+            window.xprops.experience = 'inline';
+
+            window.xprops.createOrder = mockAsyncProp(expect('createOrder', async () => {
+                return ZalgoPromise.try(() => {
+                    return orderID;
+                });
+            }));
+
+            window.xprops.onCancel = avoid('onCancel');
+            window.xprops.onApprove = avoid('onApprove');
+            window.xprops.onError = avoid('onError');
+
+            window.xprops.onComplete = expect('onComplete', async (data, actions) => {
+                if (data.orderID !== orderID) {
+                    throw new Error(`Expected orderID to be ${ orderID }, got ${ data.orderID }`);
+                }
+
+                if (!actions.redirect) {
+                    throw new Error(`Expected actions.redirect() to be available.`);
+                }
+
+                const getOrderMock = getRestfulCaptureOrderApiMock({
+                    handler: expect('getOrder', ({ headers }) => {
+                        if (headers.authorization !== `Bearer ${ facilitatorAccessToken }`) {
+                            throw new Error(`Expected call to come with correct facilitator access token`);
+                        }
+
+                        return {
+                            id: orderID
+                        };
+                    })
+                });
+                getOrderMock.expectCalls();
+                await actions.get();
+                getOrderMock.done();
+            });
+
+            mockFunction(window.paypal, 'Checkout', expect('Checkout', ({ original: CheckoutOriginal, args: [ props ] }) => {
+
+                mockFunction(props, 'onComplete', expect('onComplete', ({ original: onCompleteOriginal, args: [ data, actions ] }) => {
+                    return onCompleteOriginal({ ...data }, actions);
+                }));
+
+                const checkoutInstance = CheckoutOriginal(props);
+
+                mockFunction(checkoutInstance, 'renderTo', expect('renderTo', async ({ original: renderToOriginal, args }) => {
+                    const [ win, element, context ] = args;
+
+                    if (!win) {
+                        throw new Error(`Expected window to be passed to renderTo`);
+                    }
+
+                    if (!element || typeof element !== 'string') {
+                        throw new Error(`Expected string element to be passed to renderTo`);
+                    }
+
+                    if (context !== 'iframe') {
+                        throw new Error(`Expected context to be iframe, got ${ context }`);
+                    }
+
+                    return props.createOrder().then(id => {
+                        if (id !== orderID) {
+                            throw new Error(`Expected orderID to be ${ orderID }, got ${ id }`);
+                        }
+
+                        return renderToOriginal(...args);
+                    });
+                }));
+
+                return checkoutInstance;
+            }));
+
+            createButtonHTML({ fundingEligibility });
+            await mockSetupButton({
+                experience: 'inline',
+                merchantID: [ 'XYZ12345' ],
+                fundingEligibility,
+                facilitatorAccessToken
+            });
+            await clickButton(FUNDING.CARD);
+        });
+    });
+
     it('should not fail when calling onComplete if experience is inline and onComplete callback is not provided', async () => {
         return await wrapPromise(async ({ expect, avoid }) => {
 


### PR DESCRIPTION
### Description
Adds `capture` and `get` to actions for `onComplete` callback and also `intent` to the data attribute.  This allows merchants to capture the order if `intent=authorize` and authorization is done in the app.
