### PR TITLE
chore: set fraudnet id to order id for applepay

### DIFF
--- a/src/api/fraudnet.js
+++ b/src/api/fraudnet.js
@@ -64,6 +64,12 @@ export const loadFraudnet : Memoized<LoadFraudnet> = memoize(({ env, clientMetad
         window.fnCallback = resolve;
         setTimeout(resolve, timeout);
 
+        // replace existing script to update cmid
+        const fconfigElement = document.getElementById('fconfig');
+        if (fconfigElement) {
+            fconfigElement.remove();
+        }
+
         const body = getBody();
         body.appendChild(configScript);
         body.appendChild(fraudnetScript);

--- a/src/payment-flows/applepay/applepay.js
+++ b/src/payment-flows/applepay/applepay.js
@@ -348,7 +348,7 @@ function initApplePay({ props, payment, serviceData } : InitOptions) : PaymentFl
                         logApplePayEvent('validatemerchant', { validationURL });
 
                         orderPromise.then(orderID => {   
-                            loadFraudnet({ env, clientMetadataID: orderID }).catch(noop);        
+                            loadFraudnet({ env, clientMetadataID: orderID }).catch(noop);
                             getDetailedOrderInfo(orderID, locale.country).then(order => {
                                 const {
                                     merchant,


### PR DESCRIPTION
### Description

Merchant will be directed to include paypal-client-metadata-id (CMID) in the header of their capture call. Because Applepay flow doesn't follow the same process as when the PayPal pop-up is opened (and instead uses its own sheets), the CMID is never set to the Order ID, making it difficult for Fraudnet to track the Applepay order when it comes time to do order capture.
This fix is to set the Fraudnet ID to the Order ID when the buyer has clicked the Applepay button and the Order ID is created.

Updated PR: Removes initial fraudnet script element and replaces it with new element with Order ID. This guarantees the P1 and P2 network calls made after button click use the Order ID as the correlationID. 

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
[DTALTPAY-986](https://engineering.paypalcorp.com/jira/browse/DTALTPAY-986)
DTAPMWALL-321

### Reproduction Steps (if applicable)
Visit https://stage-applepay-paypal-js-sdk.herokuapp.com/advanced.html
Click Applepay button
Check Network tab for the Fraudnet call (P1, P2...)
Check the CorrelationID value to see the Fraudnet ID is set to the Order ID.

### Screenshots (if applicable)
<img width="1792" alt="Applepay Order Created - Fraudnet" src="https://user-images.githubusercontent.com/29203245/181115339-02c23415-b014-45d7-93e0-3c79ea8ad219.png">
<img width="1792" alt="Applepay P1 - Fraudnet" src="https://user-images.githubusercontent.com/29203245/181115340-18082771-3c43-419f-882d-1fca6385d286.png">
<img width="1792" alt="Applepay P2 - Fraudnet" src="https://user-images.githubusercontent.com/29203245/181115331-7882c557-bf84-4670-9cff-116e283e4ac2.png">
-----
Before:
<img width="1246" alt="Two elements with fconfig id" src="https://user-images.githubusercontent.com/29203245/182460303-290b5425-e8bf-456f-91f2-8251a96eb251.png">
After:
<img width="1256" alt="Applepay Fraudnet Updated 4" src="https://user-images.githubusercontent.com/29203245/182460229-b1fe673d-3dbb-4e91-bd88-8db92fdf0a52.png">
<img width="1244" alt="Applepay Fraudnet Updated 3" src="https://user-images.githubusercontent.com/29203245/182460233-108e04ee-a355-4018-a838-1c60d10cf1fb.png">
<img width="1238" alt="Applepay Fraudnet Updated 2" src="https://user-images.githubusercontent.com/29203245/182460236-ce558e3e-d15b-4e36-a9e2-4abf4134af1f.png">
<img width="1243" alt="Applepay Fraudnet Updated 1" src="https://user-images.githubusercontent.com/29203245/182460238-d0947df7-fdc6-4366-963b-c54898feb5b7.png">


### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->
### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
