### PR TITLE
Refactoring of multi-card field validation

### DIFF
--- a/src/card/components/CardCVV.jsx
+++ b/src/card/components/CardCVV.jsx
@@ -4,7 +4,9 @@
 import { h } from 'preact';
 import { useState, useEffect, useRef } from 'preact/hooks';
 
-import { validateCVV, removeNonDigits, defaultNavigation, defaultInputState, navigateOnKeyDown, exportMethods } from '../lib';
+import { getPostRobot } from '../../lib';
+import { DEFAULT_CARD_TYPE } from '../constants';
+import { validateCVV, removeNonDigits, defaultNavigation, defaultInputState, navigateOnKeyDown, exportMethods, getContext } from '../lib';
 import type { CardType, CardCvvChangeEvent, CardNavigation, FieldValidity, InputState, InputEvent } from '../types';
 
 type CardCvvProps = {|
@@ -14,8 +16,6 @@ type CardCvvProps = {|
     state? : InputState,
     placeholder : string,
     style : Object,
-    maxLength : string,
-    cardType : CardType,
     navigation : CardNavigation,
     onChange : (cvvEvent : CardCvvChangeEvent) => void,
     onFocus : (event : InputEvent) => void,
@@ -35,22 +35,36 @@ export function CardCVV(
         type,
         placeholder,
         style,
-        maxLength,
         onChange,
         onFocus,
         onBlur,
-        onValidityChange,
-        cardType
+        onValidityChange
     } : CardCvvProps
 ) : mixed {
+    const [ attributes, setAttributes ] : [ Object, (Object) => Object ] = useState({ placeholder });
     const [ inputState, setInputState ] : [ InputState, (InputState | InputState => InputState) => InputState ] = useState({ ...defaultInputState, ...state });
+    const [ cardType, setCardType ] : [ CardType, (CardType) => CardType ] = useState(DEFAULT_CARD_TYPE);
+    const [ touched, setTouched ] = useState(false);
     const { inputValue, keyStrokeCount, isValid, isPotentiallyValid } = inputState;
 
     const cvvRef = useRef()
 
     useEffect(() => {
         if (!allowNavigation) {
-            exportMethods(cvvRef);
+            exportMethods(cvvRef, setAttributes);
+        }
+        // listen for card type changes
+        const postRobot = getPostRobot();
+        if (postRobot) {
+            const context = getContext(window);
+            postRobot.on('cardTypeChange', {
+                domain: window.location.origin
+             }, (event) => {
+                const messageContext = getContext(event.source);
+                if (messageContext === context) {
+                    setCardType(event.data);
+                }
+            });
         }
     }, []);
 
@@ -58,6 +72,14 @@ export function CardCVV(
         const validity = validateCVV(inputValue, cardType);
         setInputState(newState => ({ ...newState, ...validity }));
     }, [ inputValue ]);
+
+    useEffect(() => {
+        const validity = validateCVV(inputValue, cardType);
+        if (touched) {
+            validity.isPotentiallyValid = false;
+        }
+        setInputState(newState => ({ ...newState, ...validity }));
+    }, [ cardType ]);
 
     useEffect(() => {
         if (typeof onValidityChange === 'function') {
@@ -89,6 +111,9 @@ export function CardCVV(
     };
 
     const onFocusEvent : (InputEvent) => void = (event : InputEvent) : void => {
+        if (!touched) {
+            setTouched(true);
+        }
         if (typeof onFocus === 'function') {
             onFocus(event);
         }
@@ -114,14 +139,15 @@ export function CardCVV(
             ref={ cvvRef }
             type={ type }
             className='card-field-cvv'
-            placeholder={ placeholder }
             value={ inputValue }
             style={ style }
-            maxLength={ maxLength }
+            maxLength={ cardType.code.size }
             onKeyDown={ onKeyDownEvent }
             onInput={ setCvvValue }
             onFocus={ onFocusEvent }
             onBlur={ onBlurEvent }
+            { ...attributes }
+            placeholder={ attributes.placeholder ?? cardType.code.name }
         />
     );
 }

--- a/src/card/components/CardCVV.jsx
+++ b/src/card/components/CardCVV.jsx
@@ -3,10 +3,11 @@
 
 import { h } from 'preact';
 import { useState, useEffect, useRef } from 'preact/hooks';
+import cardValidator from 'card-validator';
 
 import { getPostRobot } from '../../lib';
 import { DEFAULT_CARD_TYPE } from '../constants';
-import { validateCVV, removeNonDigits, defaultNavigation, defaultInputState, navigateOnKeyDown, exportMethods, getContext } from '../lib';
+import { removeNonDigits, defaultNavigation, defaultInputState, navigateOnKeyDown, exportMethods, getContext } from '../lib';
 import type { CardType, CardCvvChangeEvent, CardNavigation, FieldValidity, InputState, InputEvent } from '../types';
 
 type CardCvvProps = {|
@@ -69,12 +70,12 @@ export function CardCVV(
     }, []);
 
     useEffect(() => {
-        const validity = validateCVV(inputValue, cardType);
+        const validity = cardValidator.cvv(inputValue, cardType?.code?.size);
         setInputState(newState => ({ ...newState, ...validity }));
     }, [ inputValue ]);
 
     useEffect(() => {
-        const validity = validateCVV(inputValue, cardType);
+        const validity = cardValidator.cvv(inputValue, cardType?.code?.size);
         if (touched) {
             validity.isPotentiallyValid = false;
         }

--- a/src/card/components/CardExpiry.jsx
+++ b/src/card/components/CardExpiry.jsx
@@ -51,6 +51,7 @@ export function CardExpiry(
         allowNavigation = false
     } : CardExpiryProps
 ) : mixed {
+    const [ attributes, setAttributes ] : [ Object, (Object) => Object ] = useState({ placeholder });
     const [ inputState, setInputState ] : [ InputState, (InputState | InputState => InputState) => InputState ] = useState({ ...defaultInputState, ...state });
     const { inputValue, maskedInputValue, keyStrokeCount, isValid, isPotentiallyValid, contentPasted } = inputState;
 
@@ -58,7 +59,7 @@ export function CardExpiry(
 
     useEffect(() => {
         if (!allowNavigation) {
-            exportMethods(expiryRef);
+            exportMethods(expiryRef, setAttributes);
         }
     }, []);
 
@@ -148,7 +149,6 @@ export function CardExpiry(
             ref={ expiryRef }
             type={ type }
             className='card-field-expiry'
-            placeholder={ placeholder }
             value={ maskedInputValue }
             style={ style }
             maxLength={ maxLength }
@@ -157,6 +157,7 @@ export function CardExpiry(
             onFocus={ onFocusEvent }
             onBlur={ onBlurEvent }
             onPaste={ onPasteEvent }
+            { ...attributes }
         />
     );
 }

--- a/src/card/components/CardExpiry.jsx
+++ b/src/card/components/CardExpiry.jsx
@@ -3,10 +3,10 @@
 
 import { h } from 'preact';
 import { useState, useEffect, useRef } from 'preact/hooks';
+import cardValidator from 'card-validator';
 
 import {
     formatDate,
-    validateExpiry,
     removeNonDigits,
     removeDateMask,
     defaultNavigation,
@@ -64,7 +64,7 @@ export function CardExpiry(
     }, []);
 
     useEffect(() => {
-        const validity = validateExpiry(maskedInputValue);
+        const validity = cardValidator.expirationDate(maskedInputValue);
         setInputState(newState => ({ ...newState, ...validity }));
     }, [ inputValue, maskedInputValue ]);
 

--- a/src/card/components/CardName.jsx
+++ b/src/card/components/CardName.jsx
@@ -3,8 +3,9 @@
 
 import { h } from 'preact';
 import { useState, useEffect, useRef } from 'preact/hooks';
+import cardValidator from 'card-validator';
 
-import { validateCardName, defaultNavigation, defaultInputState, navigateOnKeyDown, exportMethods } from '../lib';
+import { defaultNavigation, defaultInputState, navigateOnKeyDown, exportMethods } from '../lib';
 import type { CardNameChangeEvent, CardNavigation, FieldValidity, InputState, InputEvent } from '../types';
 
 type CardNameProps = {|
@@ -50,7 +51,7 @@ export function CardName(
     }, []);
 
     useEffect(() => {
-        const validity = validateCardName(inputValue);
+        const validity = cardValidator.cardholderName(inputValue);
         setInputState(newState => ({ ...newState, ...validity }));
     }, [ inputValue ]);
 

--- a/src/card/components/CardName.jsx
+++ b/src/card/components/CardName.jsx
@@ -39,13 +39,14 @@ export function CardName(
         onValidityChange
     } : CardNameProps
 ) : mixed {
+    const [ attributes, setAttributes ] : [ Object, (Object) => Object ] = useState({ placeholder });
     const [ inputState, setInputState ] : [ InputState, (InputState | InputState => InputState) => InputState ] = useState({ ...defaultInputState, ...state });
     const { inputValue, keyStrokeCount, isValid, isPotentiallyValid } = inputState;
 
     const nameRef = useRef()
 
     useEffect(() => {
-        exportMethods(nameRef);
+        exportMethods(nameRef, setAttributes);
     }, []);
 
     useEffect(() => {
@@ -106,7 +107,6 @@ export function CardName(
             ref={ nameRef }
             type={ type }
             className="card-field-name"
-            placeholder={ placeholder }
             value={ inputValue }
             style={ style }
             maxLength={ maxLength }
@@ -114,6 +114,7 @@ export function CardName(
             onInput={ setNameValue }
             onFocus={ onFocusEvent }
             onBlur={ onBlurEvent }
+            { ...attributes }
         />
     );
 }

--- a/src/card/components/CardNumber.jsx
+++ b/src/card/components/CardNumber.jsx
@@ -7,7 +7,7 @@ import cardValidator from 'card-validator';
 
 import { getPostRobot } from '../../lib';
 import {
-    maskCardNumber,
+    addGapsToCardNumber,
     checkForNonDigits,
     removeNonDigits,
     detectCardType,
@@ -140,7 +140,7 @@ export function CardNumber(
         const { value: rawValue, selectionStart, selectionEnd } = event.target;
         const value = removeNonDigits(rawValue);
         const detectedCardType = detectCardType(value);
-        const maskedValue = maskCardNumber(value);
+        const maskedValue = addGapsToCardNumber(value);
 
         let startCursorPosition = selectionStart;
         let endCursorPosition = selectionEnd;
@@ -184,7 +184,7 @@ export function CardNumber(
             element.classList.add('display-icon');
         }
 
-        const maskedValue = maskCardNumber(inputValue);
+        const maskedValue = addGapsToCardNumber(inputValue);
         const updatedState = { ...inputState, maskedInputValue: maskedValue, displayCardIcon: true };
         if (!isValid) {
             updatedState.isPotentiallyValid = true;

--- a/src/card/components/CardNumber.jsx
+++ b/src/card/components/CardNumber.jsx
@@ -3,6 +3,7 @@
 
 import { h, Fragment } from 'preact';
 import { useState, useEffect, useRef } from 'preact/hooks';
+import cardValidator from 'card-validator';
 
 import { getPostRobot } from '../../lib';
 import {
@@ -11,7 +12,6 @@ import {
     removeNonDigits,
     detectCardType,
     checkCardEligibility,
-    validateCardNumber,
     moveCursor,
     defaultNavigation,
     defaultInputState,
@@ -94,7 +94,7 @@ export function CardNumber(
     }, []);
 
     useEffect(() => {
-        const validity = validateCardNumber(inputValue);
+        const validity = cardValidator.number(inputValue);
         setInputState(newState => ({ ...newState, ...validity }));
     }, [ inputValue, maskedInputValue ]);
 

--- a/src/card/components/CardPostalCode.jsx
+++ b/src/card/components/CardPostalCode.jsx
@@ -40,13 +40,14 @@ export function CardPostalCode(
         minLength
     } : CardPostalCodeProps
 ) : mixed {
+    const [ attributes, setAttributes ] : [ Object, (Object) => Object ] = useState({ placeholder });
     const [ inputState, setInputState ] : [ InputState, (InputState | InputState => InputState) => InputState ] = useState({ ...defaultInputState, ...state });
     const { inputValue, keyStrokeCount, isValid, isPotentiallyValid } = inputState;
 
     const postalCodeRef = useRef();
 
     useEffect(() => {
-        exportMethods(postalCodeRef);
+        exportMethods(postalCodeRef, setAttributes);
     }, []);
 
     useEffect(() => {
@@ -107,7 +108,6 @@ export function CardPostalCode(
             ref={ postalCodeRef }
             type={ type }
             className='card-field-postal-code'
-            placeholder={ placeholder }
             value={ inputValue }
             style={ style }
             maxLength={ maxLength }
@@ -116,6 +116,7 @@ export function CardPostalCode(
             onFocus={ onFocusEvent }
             onBlur={ onBlurEvent }
             minLength={ minLength }
+            { ...attributes }
         />
     )
 }

--- a/src/card/components/CardPostalCode.jsx
+++ b/src/card/components/CardPostalCode.jsx
@@ -3,8 +3,9 @@
 
 import { h } from 'preact';
 import { useState, useEffect, useRef } from 'preact/hooks';
+import cardValidator from 'card-validator';
 
-import { validatePostalCode, defaultNavigation, defaultInputState, navigateOnKeyDown, exportMethods } from '../lib';
+import { defaultNavigation, defaultInputState, navigateOnKeyDown, exportMethods } from '../lib';
 import type { CardPostalCodeChangeEvent, CardNavigation, FieldValidity, InputState, InputEvent } from '../types';
 
 type CardPostalCodeProps = {|
@@ -51,7 +52,7 @@ export function CardPostalCode(
     }, []);
 
     useEffect(() => {
-        const validity = validatePostalCode(inputValue, minLength);
+        const validity = cardValidator.postalCode(inputValue, { minLength });
         setInputState(newState => ({ ...newState, ...validity }));
     }, [ inputValue ]);
 

--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -7,7 +7,6 @@ import { useState, useEffect, useRef } from 'preact/hooks';
 
 import {
     setErrors,
-    getCvvLength,
     initFieldValidity,
     goToNextField,
     goToPreviousField,
@@ -25,14 +24,12 @@ import type {
     CardNameChangeEvent,
     CardPostalCodeChangeEvent,
     FieldValidity,
-    CardNavigation,
-    CardType
+    CardNavigation
 } from '../types';
 import {
     CARD_ERRORS,
     DEFAULT_STYLE_MULTI_CARD,
     DEFAULT_STYLE_SINGLE_CARD,
-    DEFAULT_CARD_TYPE,
     DEFAULT_PLACEHOLDERS,
     CARD_FIELD_TYPE
 } from '../constants';
@@ -55,6 +52,7 @@ type CardFieldProps = {|
 |};
 
 export function CardField({ cspNonce, onChange, styleObject = {}, placeholder = {}, gqlErrorsObject = {}, autoFocusRef, autocomplete } : CardFieldProps) : mixed {
+    const [ attributes, setAttributes ] : [ Object, (Object) => Object ] = useState({});
     const [ cssText, setCSSText ] : [ string, (string) => string ] = useState('');
     const [ number, setNumber ] : [ string, (string) => string ] = useState('');
     const [ cvv, setCvv ] : [ string, (string) => string ] = useState('');
@@ -65,7 +63,6 @@ export function CardField({ cspNonce, onChange, styleObject = {}, placeholder = 
     const [ numberValidity, setNumberValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
     const [ expiryValidity, setExpiryValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
     const [ cvvValidity, setCvvValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
-    const [ cardType, setCardType ] : [ CardType, (CardType) => CardType ] = useState(DEFAULT_CARD_TYPE);
     const [ hasFocus, setHasFocus ] : [ boolean, (boolean) => boolean ] = useState(false);
     const numberRef = useRef();
     const expiryRef = useRef();
@@ -94,7 +91,7 @@ export function CardField({ cspNonce, onChange, styleObject = {}, placeholder = 
 
     useEffect(() => {
         autoFocusRef(numberRef);
-        exportMethods(cardFieldRef);
+        exportMethods(cardFieldRef, setAttributes);
     }, []);
 
     useEffect(() => {
@@ -158,8 +155,7 @@ export function CardField({ cspNonce, onChange, styleObject = {}, placeholder = 
         numberValidity,
         isCardEligible,
         cvvValidity,
-        expiryValidity,
-        cardType
+        expiryValidity
     ]);
 
     useEffect(() => {
@@ -178,9 +174,8 @@ export function CardField({ cspNonce, onChange, styleObject = {}, placeholder = 
         }
     }, [ hasFocus, validationMessage ]);
 
-    const onChangeNumber : (CardNumberChangeEvent) => void = ({ cardNumber, cardType : type } : CardNumberChangeEvent) : void => {
+    const onChangeNumber : (CardNumberChangeEvent) => void = ({ cardNumber } : CardNumberChangeEvent) : void => {
         setNumber(cardNumber);
-        setCardType({ ...type });
     };
 
     return (
@@ -189,7 +184,7 @@ export function CardField({ cspNonce, onChange, styleObject = {}, placeholder = 
                 { cssText }
             </style>
             <Icons />
-            <fieldset ref={ cardFieldRef } className='card-field'>
+            <fieldset ref={ cardFieldRef } className='card-field' { ...attributes }>
                 <CardNumber
                     ref={ numberRef }
                     autocomplete={ autocomplete }
@@ -197,7 +192,6 @@ export function CardField({ cspNonce, onChange, styleObject = {}, placeholder = 
                     type='text'
                     allowNavigation={ true }
                     placeholder={ placeholder.number ?? DEFAULT_PLACEHOLDERS.number }
-                    maxLength='24'
                     onChange={ onChangeNumber }
                     onEligibilityChange={ (eligibility : boolean) => setIsCardEligible(eligibility) }
                     onValidityChange={ (validity : FieldValidity) => setNumberValidity({ ...validity }) }
@@ -222,10 +216,8 @@ export function CardField({ cspNonce, onChange, styleObject = {}, placeholder = 
                     autocomplete={ autocomplete }
                     navigation={ cardCvvNavivation }
                     type='text'
-                    cardType={ cardType }
                     allowNavigation={ true }
-                    placeholder={ placeholder.cvv ?? DEFAULT_PLACEHOLDERS.cvv }
-                    maxLength={ getCvvLength(cardType) }
+                    placeholder={ placeholder.cvv }
                     onChange={ ({ cardCvv } : CardCvvChangeEvent) => setCvv(cardCvv) }
                     onValidityChange={ (validity : FieldValidity) => setCvvValidity({ ...validity }) }
                     onFocus={ () => setHasFocus(true) }
@@ -250,13 +242,13 @@ type CardNumberFieldProps = {|
     cspNonce : string,
     onChange : ({| value : string, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
-    placeholder : {| number? : string, expiry? : string, cvv? : string, name? : string  |},
+    placeholder : string,
     autoFocusRef : (mixed) => void,
     autocomplete? : string,
     gqlErrors : []
 |};
 
-export function CardNumberField({ cspNonce, onChange, styleObject = {}, placeholder = {}, autoFocusRef, autocomplete, gqlErrors = [] } : CardNumberFieldProps) : mixed {
+export function CardNumberField({ cspNonce, onChange, styleObject = {}, placeholder, autoFocusRef, autocomplete, gqlErrors = [] } : CardNumberFieldProps) : mixed {
     const [ cssText, setCSSText ] : [ string, (string) => string ] = useState('');
     const [ number, setNumber ] : [ string, (string) => string ] = useState('');
     const [ isCardEligible, setIsCardEligible ] : [ boolean, (boolean) => boolean ] = useState(true);
@@ -304,8 +296,7 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
                 ref={ numberRef }
                 type='text'
                 autocomplete={ autocomplete }
-                placeholder={ placeholder.number ?? DEFAULT_PLACEHOLDERS.number }
-                maxLength='24'
+                placeholder={ placeholder ?? DEFAULT_PLACEHOLDERS.number }
                 onChange={ ({ cardNumber } : CardNumberChangeEvent) => setNumber(cardNumber) }
                 onEligibilityChange={ (eligibility : boolean) => setIsCardEligible(eligibility) }
                 onValidityChange={ (validity : FieldValidity) => setNumberValidity(validity) }
@@ -318,13 +309,13 @@ type CardExpiryFieldProps = {|
     cspNonce : string,
     onChange : ({| value : string, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
-    placeholder : {| number? : string, expiry? : string, cvv? : string, name? : string  |},
+    placeholder : string,
     autoFocusRef : (mixed) => void,
     autocomplete? : string,
     gqlErrors : []
 |};
 
-export function CardExpiryField({ cspNonce, onChange, styleObject = {}, placeholder = {}, autoFocusRef, autocomplete, gqlErrors = [] } : CardExpiryFieldProps) : mixed {
+export function CardExpiryField({ cspNonce, onChange, styleObject = {}, placeholder, autoFocusRef, autocomplete, gqlErrors = [] } : CardExpiryFieldProps) : mixed {
     const [ cssText, setCSSText ] : [ string, (string) => string ] = useState('');
     const [ expiry, setExpiry ] : [ string, (string) => string ] = useState('');
     const [ expiryValidity, setExpiryValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
@@ -362,7 +353,7 @@ export function CardExpiryField({ cspNonce, onChange, styleObject = {}, placehol
                 ref={ expiryRef }
                 type='text'
                 autocomplete={ autocomplete }
-                placeholder={ placeholder.expiry ?? DEFAULT_PLACEHOLDERS.expiry }
+                placeholder={ placeholder ?? DEFAULT_PLACEHOLDERS.expiry }
                 maxLength='7'
                 onChange={ ({ maskedDate } : CardExpiryChangeEvent) => setExpiry(convertDateFormat(maskedDate)) }
                 onValidityChange={ (validity : FieldValidity) => setExpiryValidity(validity) }
@@ -374,13 +365,13 @@ type CardCvvFieldProps = {|
     cspNonce : string,
     onChange : ({| value : string, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
-    placeholder : {| number? : string, expiry? : string, cvv? : string, name? : string  |},
+    placeholder : string,
     autoFocusRef : (mixed) => void,
     autocomplete? : string,
     gqlErrors : []
 |};
 
-export function CardCVVField({ cspNonce, onChange, styleObject = {}, placeholder = {}, autoFocusRef, autocomplete, gqlErrors = [] } : CardCvvFieldProps) : mixed {
+export function CardCVVField({ cspNonce, onChange, styleObject = {}, placeholder, autoFocusRef, autocomplete, gqlErrors = [] } : CardCvvFieldProps) : mixed {
     const [ cssText, setCSSText ] : [ string, (string) => string ] = useState('');
     const [ cvv, setCvv ] : [ string, (string) => string ] = useState('');
     const [ cvvValidity, setCvvValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
@@ -418,8 +409,7 @@ export function CardCVVField({ cspNonce, onChange, styleObject = {}, placeholder
                 ref={ cvvRef }
                 type='text'
                 autocomplete={ autocomplete }
-                placeholder={ placeholder.cvv ?? DEFAULT_PLACEHOLDERS.cvv }
-                maxLength='4'
+                placeholder={ placeholder }
                 onChange={ ({ cardCvv } : CardCvvChangeEvent) => setCvv(cardCvv) }
                 onValidityChange={ (validity : FieldValidity) => setCvvValidity(validity) }
             />
@@ -431,12 +421,12 @@ type CardNameFieldProps = {|
     cspNonce : string,
     onChange : ({| value : string, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
-    placeholder : {| number? : string, expiry? : string, cvv? : string, name? : string  |},
+    placeholder : string,
     autoFocusRef : (mixed) => void,
     gqlErrors : []
 |};
 
-export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholder = {}, autoFocusRef, gqlErrors = [] } : CardNameFieldProps) : mixed {
+export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholder, autoFocusRef, gqlErrors = [] } : CardNameFieldProps) : mixed {
     const [ cssText, setCSSText ] : [ string, (string) => string ] = useState('');
     const [ name, setName ] : [ string, (string) => string ] = useState('');
     const [ nameValidity, setNameValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
@@ -473,7 +463,7 @@ export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholde
             <CardName
                 ref={ nameRef }
                 type='text'
-                placeholder={ placeholder.name ?? DEFAULT_PLACEHOLDERS.name }
+                placeholder={ placeholder ?? DEFAULT_PLACEHOLDERS.name }
                 maxLength='255'
                 onChange={ ({ cardName } : CardNameChangeEvent) => setName(cardName) }
                 onValidityChange={ (validity : FieldValidity) => setNameValidity(validity) }
@@ -486,7 +476,7 @@ type CardPostalFieldProps = {|
     cspNonce : string,
     onChange : ({| value : string, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
-    placeholder : {| number? : string, expiry? : string, cvv? : string, name? : string |},
+    placeholder : string,
     minLength : number,
     maxLength: number,
     autoFocusRef : (mixed) => void,
@@ -494,7 +484,7 @@ type CardPostalFieldProps = {|
     gqlErrors : []
 |};
 
-export function CardPostalCodeField({ cspNonce, onChange, styleObject = {}, placeholder = {}, minLength, maxLength, autoFocusRef, autocomplete, gqlErrors = [] } : CardPostalFieldProps) : mixed {
+export function CardPostalCodeField({ cspNonce, onChange, styleObject = {}, placeholder, minLength, maxLength, autoFocusRef, autocomplete, gqlErrors = [] } : CardPostalFieldProps) : mixed {
     const [ cssText, setCSSText ] : [ string, (string) => string ] = useState('');
     const [ postalCode, setPostalCode ] : [ string, (string) => string ] = useState('');
     const [ postalCodeValidity, setPostalCodeValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
@@ -532,7 +522,7 @@ export function CardPostalCodeField({ cspNonce, onChange, styleObject = {}, plac
                 ref={ postalRef }
                 type='text'
                 autocomplete={ autocomplete }
-                placeholder={ placeholder.name ?? DEFAULT_PLACEHOLDERS.postal }
+                placeholder={ placeholder ?? DEFAULT_PLACEHOLDERS.postal }
                 minLength={ minLength }
                 maxLength={ maxLength }
                 onChange={ ({ cardPostalCode } : CardPostalCodeChangeEvent) => setPostalCode(cardPostalCode) }

--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -5,7 +5,7 @@ import { h, render, Fragment } from 'preact';
 import { useState, useEffect } from 'preact/hooks';
 
 import { getBody } from '../../lib';
-import { setupExports, formatFieldValue, autoFocusOnFirstInput, filterExtraFields } from '../lib';
+import { setupExports, autoFocusOnFirstInput, filterExtraFields } from '../lib';
 import { CARD_FIELD_TYPE_TO_FRAME_NAME, CARD_FIELD_TYPE } from '../constants';
 import { submitCardFields } from '../interface';
 import { getCardProps, type CardProps } from '../props';
@@ -107,9 +107,7 @@ function Page({ cspNonce, props } : PageProps) : mixed {
     }, [ fieldValid, fieldValue ]);
 
     const onFieldChange = ({ value, valid, errors }) => {
-        const newFieldValue = formatFieldValue(value);
-        
-        setFieldValue(newFieldValue);
+        setFieldValue(value);
         setFieldErrors([ ...errors ]);
         setFieldValid(valid);
         resetGQLErrors();

--- a/src/card/constants.js
+++ b/src/card/constants.js
@@ -135,7 +135,7 @@ export const DEFAULT_CARD_TYPE : CardType = {
     niceType: 'Unknown',
     code:     {
         name: 'CVV',
-        size: 3
+        size: 4
     }
 };
 

--- a/src/card/lib/card-checks.js
+++ b/src/card/lib/card-checks.js
@@ -91,22 +91,6 @@ export function maskCardNumber(cardNumber : string, cardType? : CardType) : stri
     return cardNumber;
 }
 
-export function getCvvLength(cardType? : CardType) : number {
-    if (cardType && typeof cardType === 'object') {
-        const { code } = cardType;
-
-        if (typeof code === 'object') {
-            const { size } = code;
-
-            if (typeof size === 'number') {
-                return size;
-            }
-        }
-    }
-
-    return 3;
-}
-
 export function checkCardEligibility(value : string, cardType : CardType) : boolean  {
     // check if the card type is eligible
     const fundingEligibility = window.xprops.fundingEligibility;
@@ -123,37 +107,19 @@ export function checkCardEligibility(value : string, cardType : CardType) : bool
 }
 
 export function validateCardNumber(value : string) : {| isValid : boolean, isPotentiallyValid : boolean |} {
-    const { number } = cardValidator;
-
-    const {isValid, isPotentiallyValid} = number(value);
-
-    return {
-        isValid,
-        isPotentiallyValid
-    }
+    return cardValidator.number(value);
 }
 
 export function validateCVV(value : string, cardType : CardType) : {| isValid : boolean, isPotentiallyValid : boolean |} {
-    let isValid = false;
-    if (value.length === getCvvLength(cardType)) {
-        isValid = true;
-    }
-    return {
-        isValid,
-        isPotentiallyValid: true
-    };
+    return cardValidator.cvv(value, cardType?.code?.size);
 }
 
 export function validateCardName(value : string) : {| isValid : boolean, isPotentiallyValid : boolean |} {
-    const { cardholderName } = cardValidator
-
-    return cardholderName(value)
+    return cardValidator.cardholderName(value);
 }
 
 export function validateExpiry(value : string) : {| isValid : boolean, isPotentiallyValid : boolean |} {
-    const { expirationDate } = cardValidator;
-    const { isValid } = expirationDate(value);
-
+    const { isValid } = cardValidator.expirationDate(value);
     return {
         isValid,
         isPotentiallyValid: true
@@ -161,8 +127,7 @@ export function validateExpiry(value : string) : {| isValid : boolean, isPotenti
 }
 
 export function validatePostalCode(value : string, minLength? : number) : {| isValid : boolean, isPotentiallyValid : boolean |} {
-    const { postalCode } = cardValidator;
-    const { isValid } = postalCode(value, {minLength})
+    const { isValid } = cardValidator.postalCode(value, { minLength });
     return {
         isValid,
         isPotentiallyValid: true

--- a/src/card/lib/card-checks.js
+++ b/src/card/lib/card-checks.js
@@ -105,31 +105,3 @@ export function checkCardEligibility(value : string, cardType : CardType) : bool
     // otherwise default to be eligible
     return true;
 }
-
-export function validateCardNumber(value : string) : {| isValid : boolean, isPotentiallyValid : boolean |} {
-    return cardValidator.number(value);
-}
-
-export function validateCVV(value : string, cardType : CardType) : {| isValid : boolean, isPotentiallyValid : boolean |} {
-    return cardValidator.cvv(value, cardType?.code?.size);
-}
-
-export function validateCardName(value : string) : {| isValid : boolean, isPotentiallyValid : boolean |} {
-    return cardValidator.cardholderName(value);
-}
-
-export function validateExpiry(value : string) : {| isValid : boolean, isPotentiallyValid : boolean |} {
-    const { isValid } = cardValidator.expirationDate(value);
-    return {
-        isValid,
-        isPotentiallyValid: true
-    };
-}
-
-export function validatePostalCode(value : string, minLength? : number) : {| isValid : boolean, isPotentiallyValid : boolean |} {
-    const { isValid } = cardValidator.postalCode(value, { minLength });
-    return {
-        isValid,
-        isPotentiallyValid: true
-    };
-}

--- a/src/card/lib/card-checks.js
+++ b/src/card/lib/card-checks.js
@@ -67,9 +67,9 @@ export function detectCardType(cardNumber : string) : CardType {
     return DEFAULT_CARD_TYPE;
 }
 
-// Mask a card number for display given a card type. If a card type is
-// not provided, attempt to detect it and mask based on that type.
-export function maskCardNumber(cardNumber : string, cardType? : CardType) : string {
+// Add gaps to a card number for display given a card type. If a card type is
+// not provided, attempt to detect it and add gaps based on that type.
+export function addGapsToCardNumber(cardNumber : string, cardType? : CardType) : string {
     assertString(cardNumber);
     // Remove all non-digits and all whitespaces
     cardNumber = cardNumber.trim().replace(/[^0-9]/g, '').replace(/\s/g, '');
@@ -95,11 +95,17 @@ export function checkCardEligibility(value : string, cardType : CardType) : bool
     // check if the card type is eligible
     const fundingEligibility = window.xprops.fundingEligibility;
     const type = VALIDATOR_TO_TYPE_MAP[cardType.type];
-    // only mark as ineligible if the card vendor is explicitly set to not be eligible
-    if (type && fundingEligibility?.card?.eligible) {
-        const vendor = fundingEligibility.card.vendors?.[type];
-        if (vendor && !vendor.eligible) {
+    if (fundingEligibility && fundingEligibility.card) {
+        // mark as ineligible if card payments are explicitly set to not be eligible
+        if (!fundingEligibility.card.eligible) {
             return false;
+        }
+        // mark as ineligible if the card vendor is explicitly set to not be eligible
+        if (type && fundingEligibility.card.vendors) {
+            const vendor = fundingEligibility.card.vendors[type];
+            if (vendor && !vendor.eligible) {
+                return false;
+            }
         }
     }
     // otherwise default to be eligible

--- a/src/card/lib/card-checks.test.js
+++ b/src/card/lib/card-checks.test.js
@@ -2,90 +2,9 @@
 
 import { DEFAULT_CARD_TYPE } from "../constants";
 
-import {
-  validateCardNumber,
-  validateCardName,
-  validatePostalCode,
-  detectCardType,
-} from "./card-checks";
+import { detectCardType } from "./card-checks";
 
 describe("card-checks", () => {
-  describe("validateCardNumber", () => {
-    it("returns true for isValid if card number passes luhn validation", () => {
-      const cardNumber = "4111 1111 1111 1111";
-
-      expect(validateCardNumber(cardNumber).isValid).toBe(true);
-    });
-
-    it("returns false for isValid if card number does not pass luhn validation", () => {
-      const cardNumber = "4111 1111";
-
-      expect(validateCardNumber(cardNumber).isValid).toBe(false);
-    });
-
-    it("returns false for isPotentiallyValid is a non-numeric character is entered", () => {
-      const cardNumber = "411x";
-
-      expect(validateCardNumber(cardNumber).isPotentiallyValid).toBe(false);
-    });
-  });
-
-  describe("validateCardName", () => {
-    it("returns true for isValid for a name less than 255 characters and is not comprised of only numbers, hyphens and spaces", () => {
-      const name = "Test Name";
-
-      expect(validateCardName(name).isValid).toBe(true);
-    });
-
-    it("returns false for isValid, and isPotentiallyValid for a name longer than 255 characters", () => {
-      const name =
-        "Ekjgfsekldjghdsfkghdksgdfkgksafghefsgkvshdbbfkshdfkbdsfgkbdskfbndfskljbndfakljvbnadflkvbadlkfvnsljkdfvhnkldsfzvnlkdsfvnladkfjvnldkfsjvnsdlkjfvnakljdfvaasdkfjgvbefskldjvblsjkdfvnbaljkdfnvkdadfjvnklsdjfnvdksdjfvnksdfvnfdjdavnkddsafvnkadljfvwertydhfjdksjdddas";
-
-      const validity = validateCardName(name);
-
-      expect(validity.isValid).toBe(false);
-      expect(validity.isPotentiallyValid).toBe(false);
-    });
-
-    it("returns false for isValid for a name comprised of only numbers", () => {
-      const name = "4111111111111111";
-
-      expect(validateCardName(name).isValid).toBe(false);
-    });
-
-    it("returns false for isValid for a name comprised of only hyphens", () => {
-      const name = "-----";
-
-      expect(validateCardName(name).isValid).toBe(false);
-    });
-
-    it("returns false for isValid for a name comprised of only spaces", () => {
-      const name = "   ";
-
-      expect(validateCardName(name).isValid).toBe(false);
-    });
-  });
-
-  describe("validatePostalCode", () => {
-    it("returns true for isValid for a 5-digit postal code", () => {
-      const postalCode = "12345";
-
-      expect(validatePostalCode(postalCode).isValid).toBe(true);
-    });
-
-    it("returns false for isValid for a postal code < 5 digits", () => {
-      const postalCode = "1234";
-
-      expect(validatePostalCode(postalCode, 5).isValid).toBe(false);
-    });
-
-    it("retusn false for isValid for a postal code that is not a string", () => {
-      const postalCode = 12345;
-
-      // $FlowFixMe
-      expect(validatePostalCode(postalCode).isValid).toBe(false);
-    });
-  });
 
   describe("detectCardType", () => {
     it("returns the default card type if the number length is 0", () => {

--- a/src/card/lib/card-checks.test.js
+++ b/src/card/lib/card-checks.test.js
@@ -2,11 +2,12 @@
 
 import { DEFAULT_CARD_TYPE } from "../constants";
 
-import { detectCardType } from "./card-checks";
+import { detectCardType, addGapsToCardNumber, checkCardEligibility } from "./card-checks";
 
 describe("card-checks", () => {
 
   describe("detectCardType", () => {
+
     it("returns the default card type if the number length is 0", () => {
       const number = "";
 
@@ -42,5 +43,80 @@ describe("card-checks", () => {
         },
       });
     });
+
   });
+
+  describe("addGapsToCardNumber", () => {
+
+    it("should add gaps (spaces) to the card number", () => {
+      const cardNumber = '4111111111111111';
+      const newCardNumber = addGapsToCardNumber(cardNumber);
+      expect(newCardNumber).toBe("4111 1111 1111 1111");
+    });
+
+    it("should handle card numbers with spaces and letters", () => {
+      const cardNumber = ' 4111a11 11b11 11c1111 ';
+      const newCardNumber = addGapsToCardNumber(cardNumber);
+      expect(newCardNumber).toBe("4111 1111 1111 1111");
+    });
+
+  });
+
+  describe("checkCardEligibility", () => {
+
+    beforeEach(() => {
+      window.xprops = {};
+    });
+
+    it("should find the card eligible", () => {
+      window.xprops.fundingEligibility = {
+        card: {
+          eligible: true,
+          vendors: {
+            visa: {
+              eligible: true
+            }
+          }
+        }
+      };
+      const cardNumber = "4111111111111111";
+      const cardType = detectCardType(cardNumber);
+      expect(checkCardEligibility(cardNumber, cardType)).toBe(true);
+    });
+
+    it("should find the card not eligible", () => {
+      window.xprops.fundingEligibility = {
+        card: {
+          eligible: true,
+          vendors: {
+            visa: {
+              eligible: false
+            }
+          }
+        }
+      };
+      const cardNumber = "4111111111111111";
+      const cardType = detectCardType(cardNumber);
+      expect(checkCardEligibility(cardNumber, cardType)).toBe(false);
+    });
+
+    it("should find card payments not eligible", () => {
+      window.xprops.fundingEligibility = {
+        card: {
+          eligible: false
+        }
+      };
+      const cardNumber = "4111111111111111";
+      const cardType = detectCardType(cardNumber);
+      expect(checkCardEligibility(cardNumber, cardType)).toBe(false);
+    });
+
+    it("should default to eligible if there is no funding eligibility specified", () => {
+      const cardNumber = "4111111111111111";
+      const cardType = detectCardType(cardNumber);
+      expect(checkCardEligibility(cardNumber, cardType)).toBe(true);
+    });
+
+  });
+
 });

--- a/src/card/lib/card-focus.test.js
+++ b/src/card/lib/card-focus.test.js
@@ -1,6 +1,6 @@
 /* @flow */
 
-import { autoFocusOnFirstInput } from "./card-focus";
+import { autoFocusOnFirstInput, goToNextField, goToPreviousField } from "./card-focus";
 
 function triggerFocusListener(input) {
 
@@ -100,3 +100,43 @@ describe("autoFocusOnFirstInput", () => {
     expect(spy).toBeCalledWith("");
   });
 });
+
+describe("goToNextField", () => {
+  it('puts the cursor at the start of the next field', () => {
+    jest.useFakeTimers();
+    const element = document.createElement('input');
+    const ref = {
+      current: {
+        base: element
+      }
+    };
+
+    goToNextField(ref)();
+    const spy = jest.spyOn(element, 'focus')
+    jest.runAllTimers()
+
+    expect(element.selectionStart).toBe(0);
+    expect(spy).toHaveBeenCalled()
+  })
+})
+
+describe("goToPreviousField", () => {
+  it('puts the cursor at the end of the previous field', () => {
+    jest.useFakeTimers();
+
+    const element = document.createElement('input');
+    element.value = 'foo'
+    const ref = {
+      current: {
+        base: element
+      }
+    };
+
+    goToPreviousField(ref)();
+    const spy = jest.spyOn(element, 'focus')
+    jest.runAllTimers()
+
+    expect(element.selectionStart).toBe(3);
+    expect(spy).toHaveBeenCalled()
+  })
+})

--- a/src/card/lib/card-utils.js
+++ b/src/card/lib/card-utils.js
@@ -2,7 +2,7 @@
 
 import { values } from '@krakenjs/belter';
 
-import type { InputState, FieldValidity, Card, ExtraFields } from '../types';
+import type { InputState, FieldValidity, ExtraFields } from '../types';
 import {
     CARD_ERRORS,
     CARD_FIELD_TYPE,
@@ -267,19 +267,6 @@ export function convertDateFormat(date : string) : string {
     }
 
     return formattedDate;
-}
-
-// Function that returns the field value in the correct format
-export function formatFieldValue(value : string | Card) : string | Card {
-    let newValue;
-    // Single card field case
-    if (typeof value === 'object') {
-        newValue = { ...value };
-    // Individual field case
-    } else {
-        newValue = value;
-    }
-    return newValue;
 }
 
 // Parse errors from ProcessPayment GQL mutation

--- a/src/card/lib/card-utils.js
+++ b/src/card/lib/card-utils.js
@@ -341,3 +341,7 @@ export function filterExtraFields(extraData : Object) : ExtraFields | Object {
         return acc;
     }, {});
 }
+
+export function getContext(win : Object) : string {
+    return win.xprops?.parent?.uid || win.xprops?.uid;
+}

--- a/src/card/lib/card-utils.test.js
+++ b/src/card/lib/card-utils.test.js
@@ -437,7 +437,7 @@ describe('card utils', () => {
 
     });
 
-    describe.only('markValidity', () => {
+    describe('markValidity', () => {
 
         it('marks the refs HTMLelement as valid when isValid is true', () => {
 
@@ -450,7 +450,8 @@ describe('card utils', () => {
             };
 
             const validity = {
-                isValid: true
+                isValid: true,
+                isPotentiallyValid: true
             };
 
             markValidity(ref, validity)
@@ -469,7 +470,8 @@ describe('card utils', () => {
             };
 
             const validity = {
-                isValid: false
+                isValid: false,
+                isPotentiallyValid: false
             };
 
             markValidity(ref, validity)
@@ -477,5 +479,5 @@ describe('card utils', () => {
             expect(element.classList.contains('invalid')).toBe(true)
             expect(element.classList.contains('valid')).toBe(false)
         })
-    })
+    });
 });

--- a/src/card/lib/card-utils.test.js
+++ b/src/card/lib/card-utils.test.js
@@ -13,7 +13,8 @@ import {
     removeNonDigits,
     checkForNonDigits,
     convertDateFormat,
-    getContext
+    getContext,
+    markValidity
 } from './card-utils';
 
 
@@ -436,4 +437,45 @@ describe('card utils', () => {
 
     });
 
+    describe.only('markValidity', () => {
+
+        it('marks the refs HTMLelement as valid when isValid is true', () => {
+
+            const element = document.createElement('div')
+
+            const ref = {
+                current: {
+                    base: element
+                }
+            };
+
+            const validity = {
+                isValid: true
+            };
+
+            markValidity(ref, validity)
+
+            expect(element.classList.contains('valid')).toBe(true)
+        })
+
+        it('marks the refs HTMLelement as invalid when isValid is false', () => {
+
+            const element = document.createElement('div')
+
+            const ref = {
+                current: {
+                    base: element
+                }
+            };
+
+            const validity = {
+                isValid: false
+            };
+
+            markValidity(ref, validity)
+
+            expect(element.classList.contains('invalid')).toBe(true)
+            expect(element.classList.contains('valid')).toBe(false)
+        })
+    })
 });

--- a/src/card/lib/card-utils.test.js
+++ b/src/card/lib/card-utils.test.js
@@ -9,8 +9,13 @@ import {
     filterStyle,
     styleToString,
     filterExtraFields,
-    isValidAttribute
+    isValidAttribute,
+    removeNonDigits,
+    checkForNonDigits,
+    convertDateFormat,
+    getContext
 } from './card-utils';
+
 
 jest.mock('../../lib/dom');
 
@@ -379,6 +384,54 @@ describe('card utils', () => {
             expect(isValidAttribute('invalid')).toBe(false);
             expect(getLogger().warn).toHaveBeenCalledWith('attribute_warning', { warn: 'HTML Attribute "invalid" was ignored. See allowed attribute list.' });
             getLogger().warn = originalLoggerWarn;
+        });
+
+    });
+
+    describe('removeNonDigits', () => {
+
+        it('should remove non-digits', () => {
+            expect(removeNonDigits('abc123')).toBe('123');
+        });
+
+    });
+
+    describe('checkForNonDigits', () => {
+
+        it('should check for non-digits', () => {
+            expect(checkForNonDigits('abc123')).toBe(true);
+            expect(checkForNonDigits('123123')).toBe(false);
+        });
+
+    });
+
+    describe('convertDateFormat', () => {
+
+        it('should format the date as MM/YYYY', () => {
+            expect(convertDateFormat('11/23')).toBe('11/2023');
+            expect(convertDateFormat('11 / 23')).toBe('11/2023');
+            expect(convertDateFormat('11 / 2023')).toBe('11/2023');
+        });
+
+    });
+
+    describe('getContext', () => {
+
+        beforeEach(() => {
+            window.xprops = {};
+        });
+
+        it('should return the UID of the component', () => {
+            window.xprops.uid = 'abc123';
+            expect(getContext(window)).toBe('abc123');
+        });
+
+        it('should return the UID of the parent of the component', () => {
+            window.xprops.uid = 'abc123';
+            window.xprops.parent = {
+                uid: 'xyz789'
+            };
+            expect(getContext(window)).toBe('xyz789');
         });
 
     });

--- a/src/card/lib/methods.js
+++ b/src/card/lib/methods.js
@@ -2,16 +2,26 @@
 
 import { isValidAttribute } from './card-utils';
 
-export function exportMethods(ref : Object) : void {
+export function exportMethods(ref : Object, setAttributes : Function) : void {
     window.xprops.export({
         setAttribute: (name, value) => {
             if (isValidAttribute(name)) {
-                ref?.current?.setAttribute(name, value);
+                setAttributes((currentAttributes) => {
+                    return {
+                        ...currentAttributes,
+                        [name]: value
+                    }
+                });
             }
         },
         removeAttribute: (name) => {
             if (isValidAttribute(name)) {
-                ref?.current?.removeAttribute(name);
+                setAttributes((currentAttributes) => {
+                    return {
+                        ...currentAttributes,
+                        [name]: ''
+                    }
+                });
             }
         },
         addClass: (name) => {

--- a/src/card/types.js
+++ b/src/card/types.js
@@ -81,8 +81,7 @@ export type InputEvent = {|
 export type CardNumberChangeEvent = {|
     event : InputEvent,
     cardNumber : string,
-    cardMaskedNumber : string,
-    cardType : CardType
+    cardMaskedNumber : string
 |};
 
 export type CardExpiryChangeEvent = {|


### PR DESCRIPTION
### Description

Multi Card Fields pulls in the `card-validator` module, but only used it to verify the expiry date. This refactors how validations are done for the CardName, CardNumber, CardCVV, and CardPostalCode fields to use this module. This also adds communication between the CardNumber field and the CardCVV field, so as the card number changes the security code placeholder and max length will update based on the determined card type.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

- [DTNOR-558](https://engineering.paypalcorp.com/jira/browse/DTNOR-558)

### Screenshots (if applicable)
Screenshots showing the CVV placeholder text changing depending on the card type:
![Screen Shot 2022-08-25 at 3 35 41 PM](https://user-images.githubusercontent.com/106204781/186780834-7db4637d-c0ea-448f-80b5-abc4906585f8.png)
![Screen Shot 2022-08-25 at 3 36 42 PM](https://user-images.githubusercontent.com/106204781/186780836-517a236b-5852-46cf-8112-cdf8c3e1ec3b.png)
![Screen Shot 2022-08-25 at 3 37 18 PM](https://user-images.githubusercontent.com/106204781/186780838-40f1303c-19ed-48c7-b1d4-8d4f96070bf0.png)

Co-Authored By:
- @bywood
- @jplukarski
- @nidhinarendra

❤️  Thank you!
