### PR TITLE
Update vault flow to use client token instead of merchant token

### DIFF
--- a/src/payment-flows/vault-capture.js
+++ b/src/payment-flows/vault-capture.js
@@ -174,7 +174,7 @@ function initVaultCapture({ props, components, payment, serviceData, config } : 
 
             const { status, body } = validate;
             return handleValidateResponse({ ThreeDomainSecure, status, body, createOrder, getParent }).then(() => {
-                return confirmOrderAPI(orderID, { payment_source: buildPaymentSource(paymentMethodID) }, { facilitatorAccessToken, partnerAttributionID })
+                return confirmOrderAPI(orderID, { payment_source: buildPaymentSource(paymentMethodID) }, { facilitatorAccessToken: accessToken, partnerAttributionID })
                 .then(() => {
                   return onApprove({}, { restart });
                 });


### PR DESCRIPTION
### Description
When calling the `confirm-payment-source` endpoint we previously used the facilitator access token. This works for most use cases, but for partner scenarios (CP4 in particular) it can cause the `confirm-payment-source` request to fail. 

This build has been verified by the PPCP team using CP3, CP4, and other integrations.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
PPPLMER-113816

### Reproduction Steps (if applicable)
Pass in client-token generated using a CP4 scenario with a vaulted user account. When clicking on the one-click button in the returning buyer scenario, you should see a request to `v2/orders/confirm-payment-source`. This previously would fail but should now succeed.

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->
### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
