### PR TITLE
DTCHKINT-1039 removed data property

### DIFF
--- a/src/api/order.js
+++ b/src/api/order.js
@@ -121,7 +121,7 @@ export function getOrder(orderID : string, { facilitatorAccessToken, buyerAccess
 
 export function isProcessorDeclineError(err : mixed) : boolean {
     // $FlowFixMe
-    return Boolean(err?.response?.body?.data?.details?.some(detail => {
+    return Boolean(err?.response?.body?.details?.some(detail => {
         return detail.issue === ORDER_API_ERROR.INSTRUMENT_DECLINED || detail.issue === ORDER_API_ERROR.PAYER_ACTION_REQUIRED;
     }));
 }


### PR DESCRIPTION
### Description

The first capture API attempt to the regular merchant API endpoint then returns a 422 INSTRUMENT_DECLINED, as expected
And the format of the response is (err?.response?.body?.details?)
And details object contains INSTRUMENT_DECLINED.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
The response path and the UI path was different, so removed data property to make it same

### Reproduction Steps (if applicable)

### Screenshots (if applicable)
![Screen Shot 2022-10-03 at 9 45 32 AM](https://user-images.githubusercontent.com/108487002/194889989-4cd929d0-5811-4940-b8b7-dc743efadd33.png)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->
### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
