### PR TITLE
send xprops.buttonLocation value to fraudnetConfig

### DIFF
--- a/src/api/fraudnet.js
+++ b/src/api/fraudnet.js
@@ -27,6 +27,7 @@ type FraudnetOptions = {|
 type FraudnetConfig = {|
     f : string,
     s : string,
+    u : string,
     cb1 : string,
     sandbox? : boolean
 |};
@@ -42,6 +43,7 @@ export const loadFraudnet : Memoized<LoadFraudnet> = memoize(({ env, clientMetad
         const config : FraudnetConfig = {
             f:   clientMetadataID,
             s:   FRAUDNET_APP_NAME,
+            u:   window.xprops.buttonLocation,
             cb1: 'fnCallback'
         };
 


### PR DESCRIPTION
### Description

This PR leverages the new xprops `buttonLocation` that was introduced in https://github.com/paypal/paypal-checkout-components/pull/2028

We are making this change so that the fraudnet team can better detect fraudulent purchases depending on the domain that loaded the SDK.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

https://engineering.paypalcorp.com/jira/browse/DTCHKINT-1214

### Reproduction Steps (if applicable)

See screenshots section (help wanted 👋 )

### Screenshots (if applicable)

I am unable to test this locally.

I can see the compiled code is present: 
<img width="762" alt="Screen Shot 2022-11-08 at 11 30 42" src="https://user-images.githubusercontent.com/3824954/200635787-798ae759-f2ae-4892-8bdf-6b1eaba5cad2.png">

but the new prop is absent: 

<img width="764" alt="Screen Shot 2022-11-08 at 11 35 12" src="https://user-images.githubusercontent.com/3824954/200635856-4e026113-683c-4b23-84f3-39ee2a2d7364.png">

I tried running the standard integration that points to local csnw that loads scnw 

### Dependent Changes (if applicable)

- [x] https://github.com/paypal/paypal-checkout-components/pull/2028

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->
### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
