### PR TITLE
feat(getState()): add getState Method to Unbranded Multi-Card Fields 

### DIFF
--- a/src/api/order.js
+++ b/src/api/order.js
@@ -958,12 +958,12 @@ export function updateButtonClientConfig({ orderID, productFlow, fundingSource, 
 }
 
 type TokenizeCardOptions = {|
-    card : {|
-        number : string,
+    card : {
+        number? : string,
         cvv? : string,
         expiry? : string,
         name? : string
-    |}
+    }
 |};
 
 type TokenizeCardResult = {|

--- a/src/api/order.js
+++ b/src/api/order.js
@@ -1,5 +1,6 @@
 /* @flow */
 /* eslint max-lines: 0 */
+/* eslint-disable flowtype/require-exact-type */
 
 import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 import { CURRENCY, FPTI_KEY, FUNDING, WALLET_INSTRUMENT, INTENT } from '@paypal/sdk-constants/src';
@@ -957,14 +958,14 @@ export function updateButtonClientConfig({ orderID, productFlow, fundingSource, 
     });
 }
 
-type TokenizeCardOptions = {|
+type TokenizeCardOptions = {
     card : {
-        number? : string,
-        cvv? : string,
-        expiry? : string,
-        name? : string
+        number : ?string,
+        cvv : ?string,
+        expiry : ?string,
+        name? : ?string
     }
-|};
+};
 
 type TokenizeCardResult = {|
     paymentMethodToken : string
@@ -1023,3 +1024,5 @@ export function approveCardPayment({ card, orderID, clientID, branded } : Approv
         return gqlResult;
     });
 }
+
+/* eslint-enable flowtype/require-exact-type */

--- a/src/card/components/CardCVV.jsx
+++ b/src/card/components/CardCVV.jsx
@@ -122,7 +122,7 @@ export function CardCVV(
             onFocus(event);
         }
         if (!isValid) {
-            setInputState(newState => ({ ...newState, isPotentiallyValid: true }));
+            setInputState(newState => ({ ...newState }));
         }
     };
 
@@ -131,7 +131,7 @@ export function CardCVV(
             onBlur(event);
         }
         if (!isValid) {
-            setInputState(newState => ({ ...newState, isPotentiallyValid: false }));
+            setInputState(newState => ({ ...newState }));
         }
     };
 

--- a/src/card/components/CardCVV.jsx
+++ b/src/card/components/CardCVV.jsx
@@ -121,17 +121,11 @@ export function CardCVV(
         if (typeof onFocus === 'function') {
             onFocus(event);
         }
-        if (!isValid) {
-            setInputState(newState => ({ ...newState }));
-        }
     };
 
     const onBlurEvent : (InputEvent) => void = (event : InputEvent) : void => {
         if (typeof onBlur === 'function') {
             onBlur(event);
-        }
-        if (!isValid) {
-            setInputState(newState => ({ ...newState }));
         }
     };
 

--- a/src/card/components/CardExpiry.jsx
+++ b/src/card/components/CardExpiry.jsx
@@ -116,17 +116,11 @@ export function CardExpiry(
         if (typeof onFocus === 'function') {
             onFocus(event);
         }
-        if (!isValid) {
-            setInputState((newState) => ({ ...newState }));
-        }
     };
 
     const onBlurEvent : (InputEvent) => void = (event : InputEvent) : void => {
         if (typeof onBlur === 'function') {
             onBlur(event);
-        }
-        if (!isValid) {
-            setInputState((newState) => ({ ...newState, contentPasted: false }));
         }
     };
 

--- a/src/card/components/CardExpiry.jsx
+++ b/src/card/components/CardExpiry.jsx
@@ -117,7 +117,7 @@ export function CardExpiry(
             onFocus(event);
         }
         if (!isValid) {
-            setInputState((newState) => ({ ...newState, isPotentiallyValid: true }));
+            setInputState((newState) => ({ ...newState }));
         }
     };
 
@@ -126,7 +126,7 @@ export function CardExpiry(
             onBlur(event);
         }
         if (!isValid) {
-            setInputState((newState) => ({ ...newState, isPotentiallyValid: false, contentPasted: false }));
+            setInputState((newState) => ({ ...newState, contentPasted: false }));
         }
     };
 

--- a/src/card/components/CardName.jsx
+++ b/src/card/components/CardName.jsx
@@ -91,7 +91,7 @@ export function CardName(
             onFocus(event);
         }
         if (!isValid) {
-            setInputState(newState => ({ ...newState, isPotentiallyValid: true }));
+            setInputState(newState => ({ ...newState }));
         }
     };
 
@@ -100,7 +100,7 @@ export function CardName(
             onBlur(event);
         }
         if (!isValid) {
-            setInputState(newState => ({ ...newState, isPotentiallyValid: false }));
+            setInputState(newState => ({ ...newState }));
         }
     };
 

--- a/src/card/components/CardName.jsx
+++ b/src/card/components/CardName.jsx
@@ -22,8 +22,7 @@ type CardNameProps = {|
     onFocus : (event : InputEvent) => void,
     onBlur : (event : InputEvent) => void,
     allowNavigation : boolean,
-    onValidityChange? : (numberValidity : FieldValidity) => void,
-    innerInnerRef : object
+    onValidityChange? : (numberValidity : FieldValidity) => void
 |};
 
 
@@ -40,7 +39,6 @@ export function CardName(
         onChange,
         onFocus,
         onBlur,
-        innerInnerRef,
         onValidityChange
     } : CardNameProps
 ) : mixed {

--- a/src/card/components/CardName.jsx
+++ b/src/card/components/CardName.jsx
@@ -90,17 +90,11 @@ export function CardName(
         if (typeof onFocus === 'function') {
             onFocus(event);
         }
-        if (!isValid) {
-            setInputState(newState => ({ ...newState }));
-        }
     };
 
     const onBlurEvent : (InputEvent) => void = (event : InputEvent) : void => {
         if (typeof onBlur === 'function') {
             onBlur(event);
-        }
-        if (!isValid) {
-            setInputState(newState => ({ ...newState }));
         }
     };
 

--- a/src/card/components/CardName.jsx
+++ b/src/card/components/CardName.jsx
@@ -22,7 +22,8 @@ type CardNameProps = {|
     onFocus : (event : InputEvent) => void,
     onBlur : (event : InputEvent) => void,
     allowNavigation : boolean,
-    onValidityChange? : (numberValidity : FieldValidity) => void
+    onValidityChange? : (numberValidity : FieldValidity) => void,
+    innerInnerRef : object
 |};
 
 
@@ -39,6 +40,7 @@ export function CardName(
         onChange,
         onFocus,
         onBlur,
+        innerInnerRef,
         onValidityChange
     } : CardNameProps
 ) : mixed {

--- a/src/card/components/CardNumber.jsx
+++ b/src/card/components/CardNumber.jsx
@@ -83,7 +83,7 @@ export function CardNumber(
     } : CardNumberProps
 ) : mixed {
     const [ attributes, setAttributes ] : [ Object, (Object) => Object ] = useState({ placeholder });
-    const [ cardTypes, setCardTypes ] : [ CardType, (CardType) => CardType ] = useState([DEFAULT_CARD_TYPE]);
+    const [ cardTypes, setCardTypes ] : [ CardType, ($ReadOnlyArray<CardType>) => $ReadOnlyArray<CardType> ] = useState([DEFAULT_CARD_TYPE]);
     const [ maxLength, setMaxLength ] : [ number, (number) => number ] = useState(24);
     const [ inputState, setInputState ] : [ InputState, (InputState | InputState => InputState) => InputState ] = useState({ ...defaultInputState, ...state });
     const { inputValue, maskedInputValue, cursorStart, cursorEnd, keyStrokeCount, isValid, isPotentiallyValid, contentPasted } = inputState;

--- a/src/card/components/CardNumber.jsx
+++ b/src/card/components/CardNumber.jsx
@@ -111,6 +111,11 @@ export function CardNumber(
         if (typeof onEligibilityChange === 'function') {
             onEligibilityChange(checkCardEligibility(inputValue, cardType));
         }
+        
+        if (typeof onPotentialCardTypesChange === 'function') {
+            onPotentialCardTypesChange(cardTypes);
+        }
+
         if (cardType && cardType.lengths) {
             // get the maximum card length for the given card type
             const cardMaxLength = cardType.lengths.reduce((previousValue, currentValue) => {
@@ -149,7 +154,6 @@ export function CardNumber(
         const { value: rawValue, selectionStart, selectionEnd } = event.target;
         const value = removeNonDigits(rawValue);
         const detectedCardType = detectCardType(value);
-        // console.log('setValueAndCursor value: ', value)
         const maskedValue = addGapsToCardNumber(value);
 
         let startCursorPosition = selectionStart;
@@ -193,7 +197,6 @@ export function CardNumber(
         if (element) {
             element.classList.add('display-icon');
         }
-        // console.log('inputValue in onFocusEvent: ', inputValue)
         const maskedValue = addGapsToCardNumber(inputValue);
         const updatedState = { ...inputState, maskedInputValue: maskedValue, displayCardIcon: true };
         if (!isValid) {

--- a/src/card/components/CardNumber.jsx
+++ b/src/card/components/CardNumber.jsx
@@ -61,7 +61,7 @@ type CardNumberProps = {|
     onBlur? : (event : InputEvent) => void,
     onValidityChange? : (numberValidity : FieldValidity) => void,
     onEligibilityChange? : (isCardEligible : boolean) => void,
-    onPotentialCardTypesChange? : (cardTypes : array) => void
+    onPotentialCardTypesChange? : (cardTypes : CardType) => void
 |};
 
 export function CardNumber(

--- a/src/card/components/CardNumber.jsx
+++ b/src/card/components/CardNumber.jsx
@@ -199,9 +199,6 @@ export function CardNumber(
         }
         const maskedValue = addGapsToCardNumber(inputValue);
         const updatedState = { ...inputState, maskedInputValue: maskedValue, displayCardIcon: true };
-        if (!isValid) {
-            updatedState.isPotentiallyValid = true;
-        }
 
         setInputState((newState) => ({ ...newState, ...updatedState }));
     };
@@ -220,8 +217,6 @@ export function CardNumber(
 
         if (isValid) {
             updatedState.maskedInputValue = maskValidCard(maskedInputValue);
-        } else {
-            updatedState.isPotentiallyValid = false;
         }
 
         if (typeof onBlur === 'function') {

--- a/src/card/components/CardNumber.jsx
+++ b/src/card/components/CardNumber.jsx
@@ -60,7 +60,8 @@ type CardNumberProps = {|
     onFocus? : (event : InputEvent) => void,
     onBlur? : (event : InputEvent) => void,
     onValidityChange? : (numberValidity : FieldValidity) => void,
-    onEligibilityChange? : (isCardEligible : boolean) => void
+    onEligibilityChange? : (isCardEligible : boolean) => void,
+    onPotentialCardTypesChange? : (cardTypes : array) => void
 |};
 
 export function CardNumber(
@@ -77,14 +78,16 @@ export function CardNumber(
         onFocus,
         onBlur,
         onValidityChange,
-        onEligibilityChange
+        onEligibilityChange,
+        onPotentialCardTypesChange
     } : CardNumberProps
 ) : mixed {
     const [ attributes, setAttributes ] : [ Object, (Object) => Object ] = useState({ placeholder });
-    const [ cardType, setCardType ] : [ CardType, (CardType) => CardType ] = useState(DEFAULT_CARD_TYPE);
+    const [ cardTypes, setCardTypes ] : [ CardType, (CardType) => CardType ] = useState([DEFAULT_CARD_TYPE]);
     const [ maxLength, setMaxLength ] : [ number, (number) => number ] = useState(24);
     const [ inputState, setInputState ] : [ InputState, (InputState | InputState => InputState) => InputState ] = useState({ ...defaultInputState, ...state });
     const { inputValue, maskedInputValue, cursorStart, cursorEnd, keyStrokeCount, isValid, isPotentiallyValid, contentPasted } = inputState;
+    const [ cardType, setCardType ] : [ CardType, (CardType) => CardType ] = useState(DEFAULT_CARD_TYPE);
 
     const numberRef = useRef()
     const ariaMessageRef = useRef()
@@ -94,6 +97,10 @@ export function CardNumber(
             exportMethods(numberRef, setAttributes, setInputState, ariaMessageRef);
         }
     }, []);
+
+    useEffect(() => {
+        setCardType(cardTypes[0])
+    }, [cardTypes])
 
     useEffect(() => {
         const validity = cardValidator.number(inputValue);
@@ -142,6 +149,7 @@ export function CardNumber(
         const { value: rawValue, selectionStart, selectionEnd } = event.target;
         const value = removeNonDigits(rawValue);
         const detectedCardType = detectCardType(value);
+        // console.log('setValueAndCursor value: ', value)
         const maskedValue = addGapsToCardNumber(value);
 
         let startCursorPosition = selectionStart;
@@ -162,7 +170,7 @@ export function CardNumber(
 
         moveCursor(event.target, startCursorPosition, endCursorPosition);
 
-        setCardType(detectedCardType);
+        setCardTypes(detectedCardType);
         setInputState({
             ...inputState,
             inputValue:       value,
@@ -185,7 +193,7 @@ export function CardNumber(
         if (element) {
             element.classList.add('display-icon');
         }
-
+        // console.log('inputValue in onFocusEvent: ', inputValue)
         const maskedValue = addGapsToCardNumber(inputValue);
         const updatedState = { ...inputState, maskedInputValue: maskedValue, displayCardIcon: true };
         if (!isValid) {

--- a/src/card/components/CardPostalCode.jsx
+++ b/src/card/components/CardPostalCode.jsx
@@ -91,17 +91,11 @@ export function CardPostalCode(
         if (typeof onFocus === 'function') {
             onFocus(event);
         }
-        if (!isValid) {
-            setInputState((newState) => ({ ...newState }));
-        }
     };
 
     const onBlurEvent : (InputEvent) => void = (event : InputEvent) : void => {
         if (typeof onBlur === 'function') {
             onBlur(event);
-        }
-        if (!isValid) {
-            setInputState((newState) => ({ ...newState, contentPasted: false }));
         }
     };
 

--- a/src/card/components/CardPostalCode.jsx
+++ b/src/card/components/CardPostalCode.jsx
@@ -92,7 +92,7 @@ export function CardPostalCode(
             onFocus(event);
         }
         if (!isValid) {
-            setInputState((newState) => ({ ...newState, isPotentiallyValid: true }));
+            setInputState((newState) => ({ ...newState }));
         }
     };
 
@@ -101,7 +101,7 @@ export function CardPostalCode(
             onBlur(event);
         }
         if (!isValid) {
-            setInputState((newState) => ({ ...newState, isPotentiallyValid: false, contentPasted: false }));
+            setInputState((newState) => ({ ...newState, contentPasted: false }));
         }
     };
 

--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -1,5 +1,6 @@
 /* @flow */
 /** @jsx h */
+/* eslint-disable flowtype/require-exact-type */
 
 import { h, Fragment } from 'preact';
 import { noop } from '@krakenjs/belter';
@@ -549,3 +550,5 @@ export function CardPostalCodeField({ cspNonce, onChange, styleObject = {}, plac
         </Fragment>
     )
 }
+
+/* eslint-enable flowtype/require-exact-type */

--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -140,10 +140,10 @@ export function CardField({ cspNonce, onChange, styleObject = {}, placeholder = 
                 element.classList.remove('valid');
             }
         } else {
-            // markValidity(numberRef, numberValidity);
+            markValidity(numberRef, numberValidity);
         }
-        // markValidity(expiryRef, expiryValidity);
-        // markValidity(cvvRef, cvvValidity);
+        markValidity(expiryRef, expiryValidity);
+        markValidity(cvvRef, cvvValidity);
 
         onChange({ value: { number, cvv, expiry }, valid, errors });
 
@@ -282,7 +282,7 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
                 element.classList.remove('valid');
             }
         } else {
-            // markValidity(numberRef, numberValidity);
+            markValidity(numberRef, numberValidity);
         }
         onChange({ value: number, valid: numberValidity.isValid, isFocused: hasFocus, potentiallyValid: numberValidity.isPotentiallyValid, errors });
     }, [ number, isCardEligible, isValid, hasFocus, isPotentiallyValid ]);
@@ -344,7 +344,7 @@ export function CardExpiryField({ cspNonce, onChange, styleObject = {}, placehol
     
     useEffect(() => {
         const errors = setErrors({ isExpiryValid: expiryValidity.isValid });
-        // markValidity(expiryRef, expiryValidity);
+        markValidity(expiryRef, expiryValidity);
         onChange({ value: expiry, valid: expiryValidity.isValid, isFocused: hasFocus, potentiallyValid: expiryValidity.isPotentiallyValid, errors });
     }, [ expiry, isValid, hasFocus, isPotentiallyValid ]);
 
@@ -403,7 +403,7 @@ export function CardCVVField({ cspNonce, onChange, styleObject = {}, placeholder
 
     useEffect(() => {
         const errors = setErrors({ isCvvValid: cvvValidity.isValid });
-        // markValidity(cvvRef, cvvValidity);
+        markValidity(cvvRef, cvvValidity);
         onChange({ value: cvv, valid: cvvValidity.isValid, isFocused: hasFocus, potentiallyValid: cvvValidity.isPotentiallyValid, errors });
     }, [ cvv, isValid, hasFocus, isPotentiallyValid  ]);
 
@@ -431,23 +431,22 @@ type CardNameFieldProps = {|
     onChange : ({| value : string, valid : boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
-    // autoFocusRef : (mixed) => void,
-    innerRef: object,
+    autoFocusRef : (mixed) => void,
     gqlErrors : []
 |};
 
-export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholder, innerRef, gqlErrors = [] } : CardNameFieldProps) : mixed {
+export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholder, autoFocusRef, gqlErrors = [] } : CardNameFieldProps) : mixed {
     const [ cssText, setCSSText ] : [ string, (string) => string ] = useState('');
     const [ name, setName ] : [ string, (string) => string ] = useState('');
     const [ nameValidity, setNameValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
-    // const nameRef = useRef();
+    const nameRef = useRef();
     const [ hasFocus, setHasFocus ] : [ boolean, (boolean) => boolean ] = useState(false);
     
     const { isValid, isPotentiallyValid } = nameValidity;
 
-    // useEffect(() => {
-    //     autoFocusRef(nameRef);
-    // }, []);
+    useEffect(() => {
+        autoFocusRef(nameRef);
+    }, []);
 
     useEffect(() => {
         setCSSText(getCSSText(DEFAULT_STYLE_MULTI_CARD, styleObject));
@@ -462,8 +461,7 @@ export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholde
 
     useEffect(() => {
         const errors = setErrors({ isNameValid: nameValidity.isValid });
-        console.log('What is the innerref?', innerRef)
-        markValidity(innerRef, nameValidity);
+        markValidity(nameRef, nameValidity);
         onChange({ value: name, valid: nameValidity.isValid, isFocused: hasFocus, potentiallyValid: nameValidity.isPotentiallyValid, errors });
     }, [ name, isValid, hasFocus, isPotentiallyValid  ]);
 
@@ -473,7 +471,7 @@ export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholde
                 { cssText }
             </style>
             <CardName
-                innerInnerRef={ innerRef }
+                ref={ nameRef }
                 type='text'
                 placeholder={ placeholder ?? DEFAULT_PLACEHOLDERS.name }
                 maxLength='255'
@@ -524,7 +522,7 @@ export function CardPostalCodeField({ cspNonce, onChange, styleObject = {}, plac
 
     useEffect(() => {
         const errors = setErrors({ isPostalCodeValid: postalCodeValidity.isValid });
-        // markValidity(postalRef, postalCodeValidity);
+        markValidity(postalRef, postalCodeValidity);
         onChange({ value: postalCode, valid: postalCodeValidity.isValid, isFocused: hasFocus, potentiallyValid: postalCodeValidity.isPotentiallyValid, errors });
     }, [ postalCode, isValid, hasFocus, isPotentiallyValid  ]);
 

--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -140,10 +140,10 @@ export function CardField({ cspNonce, onChange, styleObject = {}, placeholder = 
                 element.classList.remove('valid');
             }
         } else {
-            markValidity(numberRef, numberValidity);
+            // markValidity(numberRef, numberValidity);
         }
-        markValidity(expiryRef, expiryValidity);
-        markValidity(cvvRef, cvvValidity);
+        // markValidity(expiryRef, expiryValidity);
+        // markValidity(cvvRef, cvvValidity);
 
         onChange({ value: { number, cvv, expiry }, valid, errors });
 
@@ -282,7 +282,7 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
                 element.classList.remove('valid');
             }
         } else {
-            markValidity(numberRef, numberValidity);
+            // markValidity(numberRef, numberValidity);
         }
         onChange({ value: number, valid: numberValidity.isValid, isFocused: hasFocus, potentiallyValid: numberValidity.isPotentiallyValid, errors });
     }, [ number, isCardEligible, isValid, hasFocus, isPotentiallyValid ]);
@@ -344,7 +344,7 @@ export function CardExpiryField({ cspNonce, onChange, styleObject = {}, placehol
     
     useEffect(() => {
         const errors = setErrors({ isExpiryValid: expiryValidity.isValid });
-        markValidity(expiryRef, expiryValidity);
+        // markValidity(expiryRef, expiryValidity);
         onChange({ value: expiry, valid: expiryValidity.isValid, isFocused: hasFocus, potentiallyValid: expiryValidity.isPotentiallyValid, errors });
     }, [ expiry, isValid, hasFocus, isPotentiallyValid ]);
 
@@ -403,7 +403,7 @@ export function CardCVVField({ cspNonce, onChange, styleObject = {}, placeholder
 
     useEffect(() => {
         const errors = setErrors({ isCvvValid: cvvValidity.isValid });
-        markValidity(cvvRef, cvvValidity);
+        // markValidity(cvvRef, cvvValidity);
         onChange({ value: cvv, valid: cvvValidity.isValid, isFocused: hasFocus, potentiallyValid: cvvValidity.isPotentiallyValid, errors });
     }, [ cvv, isValid, hasFocus, isPotentiallyValid  ]);
 
@@ -431,22 +431,23 @@ type CardNameFieldProps = {|
     onChange : ({| value : string, valid : boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
-    autoFocusRef : (mixed) => void,
+    // autoFocusRef : (mixed) => void,
+    innerRef: object,
     gqlErrors : []
 |};
 
-export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholder, autoFocusRef, gqlErrors = [] } : CardNameFieldProps) : mixed {
+export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholder, innerRef, gqlErrors = [] } : CardNameFieldProps) : mixed {
     const [ cssText, setCSSText ] : [ string, (string) => string ] = useState('');
     const [ name, setName ] : [ string, (string) => string ] = useState('');
     const [ nameValidity, setNameValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
-    const nameRef = useRef();
+    // const nameRef = useRef();
     const [ hasFocus, setHasFocus ] : [ boolean, (boolean) => boolean ] = useState(false);
     
     const { isValid, isPotentiallyValid } = nameValidity;
 
-    useEffect(() => {
-        autoFocusRef(nameRef);
-    }, []);
+    // useEffect(() => {
+    //     autoFocusRef(nameRef);
+    // }, []);
 
     useEffect(() => {
         setCSSText(getCSSText(DEFAULT_STYLE_MULTI_CARD, styleObject));
@@ -461,7 +462,8 @@ export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholde
 
     useEffect(() => {
         const errors = setErrors({ isNameValid: nameValidity.isValid });
-        markValidity(nameRef, nameValidity);
+        console.log('What is the innerref?', innerRef)
+        markValidity(innerRef, nameValidity);
         onChange({ value: name, valid: nameValidity.isValid, isFocused: hasFocus, potentiallyValid: nameValidity.isPotentiallyValid, errors });
     }, [ name, isValid, hasFocus, isPotentiallyValid  ]);
 
@@ -471,7 +473,7 @@ export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholde
                 { cssText }
             </style>
             <CardName
-                ref={ nameRef }
+                innerInnerRef={ innerRef }
                 type='text'
                 placeholder={ placeholder ?? DEFAULT_PLACEHOLDERS.name }
                 maxLength='255'
@@ -522,7 +524,7 @@ export function CardPostalCodeField({ cspNonce, onChange, styleObject = {}, plac
 
     useEffect(() => {
         const errors = setErrors({ isPostalCodeValid: postalCodeValidity.isValid });
-        markValidity(postalRef, postalCodeValidity);
+        // markValidity(postalRef, postalCodeValidity);
         onChange({ value: postalCode, valid: postalCodeValidity.isValid, isFocused: hasFocus, potentiallyValid: postalCodeValidity.isPotentiallyValid, errors });
     }, [ postalCode, isValid, hasFocus, isPotentiallyValid  ]);
 

--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -240,7 +240,7 @@ export function ValidationMessage({ message } : Object) : mixed {
 
 type CardNumberFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : string, valid : boolean, isFocused: boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}, cardTypes: array) => void,
+    onChange : ({| value : string, valid : boolean, isFocused: boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>], potentialCardTypes: array | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
     autoFocusRef : (mixed) => void,
@@ -285,7 +285,7 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
         } else {
             markValidity(numberRef, numberValidity);
         }
-        onChange({ value: number, valid: numberValidity.isValid, isFocused: hasFocus, potentiallyValid: numberValidity.isPotentiallyValid, errors, cardTypes: cards });
+        onChange({ value: number, valid: numberValidity.isValid, isFocused: hasFocus, potentiallyValid: numberValidity.isPotentiallyValid, errors, potentialCardTypes: cards });
     }, [ number, isCardEligible, isValid, hasFocus, isPotentiallyValid, cards ]);
 
     return (

--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -24,7 +24,8 @@ import type {
     CardNameChangeEvent,
     CardPostalCodeChangeEvent,
     FieldValidity,
-    CardNavigation
+    CardNavigation,
+    CardType
 } from '../types';
 import {
     CARD_ERRORS,
@@ -240,7 +241,7 @@ export function ValidationMessage({ message } : Object) : mixed {
 
 type CardNumberFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : string, valid : boolean, isFocused: boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>], potentialCardTypes: array | [] |}) => void,
+    onChange : ({| value : string, valid : boolean, isFocused: boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>], potentialCardTypes: CardType | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
     autoFocusRef : (mixed) => void,
@@ -253,7 +254,7 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
     const [ number, setNumber ] : [ string, (string) => string ] = useState('');
     const [ isCardEligible, setIsCardEligible ] : [ boolean, (boolean) => boolean ] = useState(true);
     const [ numberValidity, setNumberValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
-    const [cards, setCards] : [array, (array) => array] = useState([])
+    const [cards, setCards] : [$ReadOnlyArray<CardType>, (CardType) => $ReadOnlyArray<CardType>] = useState([])
     const [ hasFocus, setHasFocus ] : [ boolean, (boolean) => boolean ] = useState(false);
     const numberRef = useRef();
 
@@ -302,7 +303,7 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
                 onChange={ ({ cardNumber } : CardNumberChangeEvent) => setNumber(cardNumber) }
                 onEligibilityChange={ (eligibility : boolean) => setIsCardEligible(eligibility) }
                 onValidityChange={ (validity : FieldValidity) => setNumberValidity(validity) }
-                onPotentialCardTypesChange={(cardTypes : Array<strings>) => setCards(cardTypes)}
+                onPotentialCardTypesChange={(cardTypes : CardType) => setCards(cardTypes)}
                 onFocus={ () => setHasFocus(true) }
                 onBlur={ () => setHasFocus(false) }
             />

--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -241,7 +241,7 @@ export function ValidationMessage({ message } : Object) : mixed {
 
 type CardNumberFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : string, valid : boolean, isFocused: boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>], potentialCardTypes: CardType | [] |}) => void,
+    onChange : ({| value : string, valid : boolean, isFocused: boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] |[], potentialCardTypes: $ReadOnlyArray<CardType> | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
     autoFocusRef : (mixed) => void,
@@ -313,7 +313,7 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
 
 type CardExpiryFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : string, valid : boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
+    onChange : ({| value : string, valid : boolean, isFocused: boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
     autoFocusRef : (mixed) => void,
@@ -372,7 +372,7 @@ export function CardExpiryField({ cspNonce, onChange, styleObject = {}, placehol
 }
 type CardCvvFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : string, valid : boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
+    onChange : ({| value : string, valid : boolean, isFocused: boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
     autoFocusRef : (mixed) => void,
@@ -431,7 +431,7 @@ export function CardCVVField({ cspNonce, onChange, styleObject = {}, placeholder
 
 type CardNameFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : string, valid : boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
+    onChange : ({| value : string, valid : boolean, isFocused: boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
     autoFocusRef : (mixed) => void,
@@ -489,7 +489,7 @@ export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholde
 
 type CardPostalFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : string, valid : boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
+    onChange : ({| value : string, valid : boolean, isFocused: boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
     minLength : number,

--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -240,7 +240,7 @@ export function ValidationMessage({ message } : Object) : mixed {
 
 type CardNumberFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : string, valid : boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
+    onChange : ({| value : string, valid : boolean, isFocused: boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
     autoFocusRef : (mixed) => void,
@@ -253,6 +253,7 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
     const [ number, setNumber ] : [ string, (string) => string ] = useState('');
     const [ isCardEligible, setIsCardEligible ] : [ boolean, (boolean) => boolean ] = useState(true);
     const [ numberValidity, setNumberValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
+    const [ hasFocus, setHasFocus ] : [ boolean, (boolean) => boolean ] = useState(false);
     const numberRef = useRef();
 
     const { isValid, isPotentiallyValid } = numberValidity;
@@ -283,8 +284,8 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
         } else {
             markValidity(numberRef, numberValidity);
         }
-        onChange({ value: number, valid: numberValidity.isValid, potentiallyValid: numberValidity.isPotentiallyValid, errors });
-    }, [ number, isCardEligible, isValid, isPotentiallyValid ]);
+        onChange({ value: number, valid: numberValidity.isValid, isFocused: hasFocus, potentiallyValid: numberValidity.isPotentiallyValid, errors });
+    }, [ number, isCardEligible, isValid, hasFocus, isPotentiallyValid ]);
 
     return (
         <Fragment>
@@ -300,6 +301,8 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
                 onChange={ ({ cardNumber } : CardNumberChangeEvent) => setNumber(cardNumber) }
                 onEligibilityChange={ (eligibility : boolean) => setIsCardEligible(eligibility) }
                 onValidityChange={ (validity : FieldValidity) => setNumberValidity(validity) }
+                onFocus={ () => setHasFocus(true) }
+                onBlur={ () => setHasFocus(false) }
             />
         </Fragment>
     );
@@ -320,6 +323,7 @@ export function CardExpiryField({ cspNonce, onChange, styleObject = {}, placehol
     const [ expiry, setExpiry ] : [ string, (string) => string ] = useState('');
     const [ expiryValidity, setExpiryValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
     const expiryRef = useRef();
+    const [ hasFocus, setHasFocus ] : [ boolean, (boolean) => boolean ] = useState(false);
 
     const { isValid, isPotentiallyValid } = expiryValidity;
 
@@ -341,8 +345,8 @@ export function CardExpiryField({ cspNonce, onChange, styleObject = {}, placehol
     useEffect(() => {
         const errors = setErrors({ isExpiryValid: expiryValidity.isValid });
         markValidity(expiryRef, expiryValidity);
-        onChange({ value: expiry, valid: expiryValidity.isValid, potentiallyValid: expiryValidity.isPotentiallyValid, errors });
-    }, [ expiry, isValid, isPotentiallyValid ]);
+        onChange({ value: expiry, valid: expiryValidity.isValid, isFocused: hasFocus, potentiallyValid: expiryValidity.isPotentiallyValid, errors });
+    }, [ expiry, isValid, hasFocus, isPotentiallyValid ]);
 
     return (
         <Fragment>
@@ -357,6 +361,8 @@ export function CardExpiryField({ cspNonce, onChange, styleObject = {}, placehol
                 maxLength='7'
                 onChange={ ({ maskedDate } : CardExpiryChangeEvent) => setExpiry(convertDateFormat(maskedDate)) }
                 onValidityChange={ (validity : FieldValidity) => setExpiryValidity(validity) }
+                onFocus={ () => setHasFocus(true) }
+                onBlur={ () => setHasFocus(false) }
             />
         </Fragment>
     );
@@ -376,6 +382,7 @@ export function CardCVVField({ cspNonce, onChange, styleObject = {}, placeholder
     const [ cvv, setCvv ] : [ string, (string) => string ] = useState('');
     const [ cvvValidity, setCvvValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
     const cvvRef = useRef();
+    const [ hasFocus, setHasFocus ] : [ boolean, (boolean) => boolean ] = useState(false);
     
     const { isValid, isPotentiallyValid } = cvvValidity;
 
@@ -397,8 +404,8 @@ export function CardCVVField({ cspNonce, onChange, styleObject = {}, placeholder
     useEffect(() => {
         const errors = setErrors({ isCvvValid: cvvValidity.isValid });
         markValidity(cvvRef, cvvValidity);
-        onChange({ value: cvv, valid: cvvValidity.isValid, potentiallyValid: cvvValidity.isPotentiallyValid, errors });
-    }, [ cvv, isValid, isPotentiallyValid  ]);
+        onChange({ value: cvv, valid: cvvValidity.isValid, isFocused: hasFocus, potentiallyValid: cvvValidity.isPotentiallyValid, errors });
+    }, [ cvv, isValid, hasFocus, isPotentiallyValid  ]);
 
     return (
         <Fragment>
@@ -412,6 +419,8 @@ export function CardCVVField({ cspNonce, onChange, styleObject = {}, placeholder
                 placeholder={ placeholder }
                 onChange={ ({ cardCvv } : CardCvvChangeEvent) => setCvv(cardCvv) }
                 onValidityChange={ (validity : FieldValidity) => setCvvValidity(validity) }
+                onFocus={ () => setHasFocus(true) }
+                onBlur={ () => setHasFocus(false) }
             />
         </Fragment>
     );
@@ -431,6 +440,7 @@ export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholde
     const [ name, setName ] : [ string, (string) => string ] = useState('');
     const [ nameValidity, setNameValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
     const nameRef = useRef();
+    const [ hasFocus, setHasFocus ] : [ boolean, (boolean) => boolean ] = useState(false);
     
     const { isValid, isPotentiallyValid } = nameValidity;
 
@@ -452,8 +462,8 @@ export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholde
     useEffect(() => {
         const errors = setErrors({ isNameValid: nameValidity.isValid });
         markValidity(nameRef, nameValidity);
-        onChange({ value: name, valid: nameValidity.isValid, potentiallyValid: nameValidity.isPotentiallyValid, errors });
-    }, [ name, isValid, isPotentiallyValid  ]);
+        onChange({ value: name, valid: nameValidity.isValid, isFocused: hasFocus, potentiallyValid: nameValidity.isPotentiallyValid, errors });
+    }, [ name, isValid, hasFocus, isPotentiallyValid  ]);
 
     return (
         <Fragment>
@@ -467,6 +477,8 @@ export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholde
                 maxLength='255'
                 onChange={ ({ cardName } : CardNameChangeEvent) => setName(cardName) }
                 onValidityChange={ (validity : FieldValidity) => setNameValidity(validity) }
+                onFocus={ () => setHasFocus(true) }
+                onBlur={ () => setHasFocus(false) }
             />
         </Fragment>
     );
@@ -489,6 +501,7 @@ export function CardPostalCodeField({ cspNonce, onChange, styleObject = {}, plac
     const [ postalCode, setPostalCode ] : [ string, (string) => string ] = useState('');
     const [ postalCodeValidity, setPostalCodeValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
     const postalRef = useRef();
+    const [ hasFocus, setHasFocus ] : [ boolean, (boolean) => boolean ] = useState(false);
 
     const { isValid, isPotentiallyValid } = postalCodeValidity;
 
@@ -510,8 +523,8 @@ export function CardPostalCodeField({ cspNonce, onChange, styleObject = {}, plac
     useEffect(() => {
         const errors = setErrors({ isPostalCodeValid: postalCodeValidity.isValid });
         markValidity(postalRef, postalCodeValidity);
-        onChange({ value: postalCode, valid: postalCodeValidity.isValid, potentiallyValid: postalCodeValidity.isPotentiallyValid, errors });
-    }, [ postalCode, isValid, isPotentiallyValid  ]);
+        onChange({ value: postalCode, valid: postalCodeValidity.isValid, isFocused: hasFocus, potentiallyValid: postalCodeValidity.isPotentiallyValid, errors });
+    }, [ postalCode, isValid, hasFocus, isPotentiallyValid  ]);
 
     return (
         <Fragment>
@@ -527,6 +540,8 @@ export function CardPostalCodeField({ cspNonce, onChange, styleObject = {}, plac
                 maxLength={ maxLength }
                 onChange={ ({ cardPostalCode } : CardPostalCodeChangeEvent) => setPostalCode(cardPostalCode) }
                 onValidityChange={ (validity : FieldValidity) => setPostalCodeValidity(validity) }
+                onFocus={ () => setHasFocus(true) }
+                onBlur={ () => setHasFocus(false) }
             />
         </Fragment>
     )

--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -240,7 +240,7 @@ export function ValidationMessage({ message } : Object) : mixed {
 
 type CardNumberFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : string, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
+    onChange : ({| value : string, valid : boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
     autoFocusRef : (mixed) => void,
@@ -283,7 +283,7 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
         } else {
             markValidity(numberRef, numberValidity);
         }
-        onChange({ value: number, valid: numberValidity.isValid, errors });
+        onChange({ value: number, valid: numberValidity.isValid, potentiallyValid: numberValidity.isPotentiallyValid, errors });
     }, [ number, isCardEligible, isValid, isPotentiallyValid ]);
 
     return (
@@ -307,7 +307,7 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
 
 type CardExpiryFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : string, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
+    onChange : ({| value : string, valid : boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
     autoFocusRef : (mixed) => void,
@@ -341,7 +341,7 @@ export function CardExpiryField({ cspNonce, onChange, styleObject = {}, placehol
     useEffect(() => {
         const errors = setErrors({ isExpiryValid: expiryValidity.isValid });
         markValidity(expiryRef, expiryValidity);
-        onChange({ value: expiry, valid: expiryValidity.isValid, errors });
+        onChange({ value: expiry, valid: expiryValidity.isValid, potentiallyValid: expiryValidity.isPotentiallyValid, errors });
     }, [ expiry, isValid, isPotentiallyValid ]);
 
     return (
@@ -363,7 +363,7 @@ export function CardExpiryField({ cspNonce, onChange, styleObject = {}, placehol
 }
 type CardCvvFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : string, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
+    onChange : ({| value : string, valid : boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
     autoFocusRef : (mixed) => void,
@@ -397,7 +397,7 @@ export function CardCVVField({ cspNonce, onChange, styleObject = {}, placeholder
     useEffect(() => {
         const errors = setErrors({ isCvvValid: cvvValidity.isValid });
         markValidity(cvvRef, cvvValidity);
-        onChange({ value: cvv, valid: cvvValidity.isValid, errors });
+        onChange({ value: cvv, valid: cvvValidity.isValid, potentiallyValid: cvvValidity.isPotentiallyValid, errors });
     }, [ cvv, isValid, isPotentiallyValid  ]);
 
     return (
@@ -419,7 +419,7 @@ export function CardCVVField({ cspNonce, onChange, styleObject = {}, placeholder
 
 type CardNameFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : string, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
+    onChange : ({| value : string, valid : boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
     autoFocusRef : (mixed) => void,
@@ -452,7 +452,7 @@ export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholde
     useEffect(() => {
         const errors = setErrors({ isNameValid: nameValidity.isValid });
         markValidity(nameRef, nameValidity);
-        onChange({ value: name, valid: nameValidity.isValid, errors });
+        onChange({ value: name, valid: nameValidity.isValid, potentiallyValid: nameValidity.isPotentiallyValid, errors });
     }, [ name, isValid, isPotentiallyValid  ]);
 
     return (
@@ -474,7 +474,7 @@ export function CardNameField({ cspNonce, onChange, styleObject = {}, placeholde
 
 type CardPostalFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : string, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
+    onChange : ({| value : string, valid : boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
     styleObject : CardStyle,
     placeholder : string,
     minLength : number,
@@ -510,7 +510,7 @@ export function CardPostalCodeField({ cspNonce, onChange, styleObject = {}, plac
     useEffect(() => {
         const errors = setErrors({ isPostalCodeValid: postalCodeValidity.isValid });
         markValidity(postalRef, postalCodeValidity);
-        onChange({ value: postalCode, valid: postalCodeValidity.isValid, errors });
+        onChange({ value: postalCode, valid: postalCodeValidity.isValid, potentiallyValid: postalCodeValidity.isPotentiallyValid, errors });
     }, [ postalCode, isValid, isPotentiallyValid  ]);
 
     return (

--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -44,7 +44,7 @@ import { Icons, Icon } from './Icons';
 
 type CardFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : Card, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
+    onChange : ({ value : Card, valid : boolean, errors : [$Values<typeof CARD_ERRORS>] | [] }) => void,
     styleObject : CardStyle,
     placeholder : {| number? : string, expiry? : string, cvv? : string  |},
     autoFocusRef : (mixed) => void,

--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -240,7 +240,7 @@ export function ValidationMessage({ message } : Object) : mixed {
 
 type CardNumberFieldProps = {|
     cspNonce : string,
-    onChange : ({| value : string, valid : boolean, isFocused: boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}) => void,
+    onChange : ({| value : string, valid : boolean, isFocused: boolean, potentiallyValid: boolean, errors : [$Values<typeof CARD_ERRORS>] | [] |}, cardTypes: array) => void,
     styleObject : CardStyle,
     placeholder : string,
     autoFocusRef : (mixed) => void,
@@ -253,6 +253,7 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
     const [ number, setNumber ] : [ string, (string) => string ] = useState('');
     const [ isCardEligible, setIsCardEligible ] : [ boolean, (boolean) => boolean ] = useState(true);
     const [ numberValidity, setNumberValidity ] : [ FieldValidity, (FieldValidity) => FieldValidity ] = useState(initFieldValidity);
+    const [cards, setCards] : [array, (array) => array] = useState([])
     const [ hasFocus, setHasFocus ] : [ boolean, (boolean) => boolean ] = useState(false);
     const numberRef = useRef();
 
@@ -284,8 +285,8 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
         } else {
             markValidity(numberRef, numberValidity);
         }
-        onChange({ value: number, valid: numberValidity.isValid, isFocused: hasFocus, potentiallyValid: numberValidity.isPotentiallyValid, errors });
-    }, [ number, isCardEligible, isValid, hasFocus, isPotentiallyValid ]);
+        onChange({ value: number, valid: numberValidity.isValid, isFocused: hasFocus, potentiallyValid: numberValidity.isPotentiallyValid, errors, cardTypes: cards });
+    }, [ number, isCardEligible, isValid, hasFocus, isPotentiallyValid, cards ]);
 
     return (
         <Fragment>
@@ -301,6 +302,7 @@ export function CardNumberField({ cspNonce, onChange, styleObject = {}, placehol
                 onChange={ ({ cardNumber } : CardNumberChangeEvent) => setNumber(cardNumber) }
                 onEligibilityChange={ (eligibility : boolean) => setIsCardEligible(eligibility) }
                 onValidityChange={ (validity : FieldValidity) => setNumberValidity(validity) }
+                onPotentialCardTypesChange={(cardTypes : Array<strings>) => setCards(cardTypes)}
                 onFocus={ () => setHasFocus(true) }
                 onBlur={ () => setHasFocus(false) }
             />

--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -21,7 +21,7 @@ type PageProps = {|
 |};
 
 function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
-    const { facilitatorAccessToken, style, disableAutocomplete, placeholder, type, onChange, export: xport } = props;
+    const { facilitatorAccessToken, style, disableAutocomplete, placeholder, type, onChange, export: xport, minLength, maxLength } = props;
 
     const [ fieldValue, setFieldValue ] = useState();
     const [ fieldValid, setFieldValid ] = useState(false);

--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -7,7 +7,7 @@ import { useState, useEffect, useRef } from 'preact/hooks';
 import { getBody } from '../../lib';
 import { setupExports, autoFocusOnFirstInput, filterExtraFields } from '../lib';
 import { CARD_FIELD_TYPE_TO_FRAME_NAME, CARD_FIELD_TYPE } from '../constants';
-import { submitCardFields } from '../interface';
+import { submitCardFields, getCardFieldState } from '../interface';
 import { getCardProps, type CardProps } from '../props';
 import type { SetupCardOptions} from '../types';
 import type {FeatureFlags } from '../../types'
@@ -25,6 +25,7 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
 
     const [ fieldValue, setFieldValue ] = useState();
     const [ fieldValid, setFieldValid ] = useState(false);
+    const [ fieldPotentiallyValid, setFieldPotentiallyValid] = useState(true)
     const [ fieldErrors, setFieldErrors ] = useState([]);
     const [ mainRef, setRef ] = useState();
     const [ fieldGQLErrors, setFieldGQLErrors ] = useState({ singleField: {}, numberField: [], expiryField: [], cvvField: [], nameField: [], postalCodeField: [] });
@@ -42,6 +43,10 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
     const isFieldValid = () => {
         return fieldValid;
     };
+
+    const isFieldPotentiallyValid = () => {
+        return fieldPotentiallyValid
+    }
 
     const setGqlErrors = (errorData : {| field : string, errors : [] |}) => {
         const { errors } = errorData;
@@ -106,6 +111,7 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
     useEffect(() => {
         setupExports({
             name: CARD_FIELD_TYPE_TO_FRAME_NAME[type],
+            isFieldPotentiallyValid,
             isFieldValid,
             getFieldValue,
             setGqlErrors,
@@ -116,14 +122,18 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
             submit: (extraData) => {
                 const extraFields = filterExtraFields(extraData);
                 return submitCardFields({ facilitatorAccessToken, extraFields, featureFlags });
+            },
+            getState: () => {
+                console.log(getCardFieldState())
             }
         });
-    }, [ fieldValid, fieldValue ]);
+    }, [ fieldValid, fieldValue, fieldPotentiallyValid ]);
 
-    const onFieldChange = ({ value, valid, errors }) => {
+    const onFieldChange = ({ value, valid, potentiallyValid, errors }) => {
         setFieldValue(value);
         setFieldErrors([ ...errors ]);
         setFieldValid(valid);
+        setFieldPotentiallyValid(potentiallyValid)
         resetGQLErrors();
     };
 

--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -31,7 +31,6 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
     const [ mainRef, setRef ] = useState();
     const [ fieldGQLErrors, setFieldGQLErrors ] = useState({ singleField: {}, numberField: [], expiryField: [], cvvField: [], nameField: [], postalCodeField: [] });
     const initialRender = useRef(true)
-    const fieldRef = useRef()
 
     let autocomplete;
     if (disableAutocomplete) {
@@ -52,12 +51,6 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
 
     const isFieldFocused = () => {
         return fieldFocus;
-    }
-
-    const getContainer = () => {
-        console.log('Field Ref: ', fieldRef)
-        return fieldRef.current;
-        // return 'returning the dom node'
     }
 
     const setGqlErrors = (errorData : {| field : string, errors : [] |}) => {
@@ -126,7 +119,6 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
             isFieldPotentiallyValid,
             isFieldValid,
             isFieldFocused,
-            getContainer,
             getFieldValue,
             setGqlErrors,
             resetGQLErrors
@@ -138,8 +130,7 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
                 return submitCardFields({ facilitatorAccessToken, extraFields, featureFlags });
             },
             getState: () => {
-                // console.log('from sdk',getCardFieldState())
-                return getCardFieldState()
+                console.log(getCardFieldState())
             }
         });
     }, [ fieldValid, fieldValue, fieldFocus, fieldPotentiallyValid ]);
@@ -213,13 +204,13 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
             {
                 (type === CARD_FIELD_TYPE.NAME)
                     ? <CardNameField
-                            innerRef={ fieldRef }
+                            ref={ mainRef }
                             gqlErrors={ fieldGQLErrors.nameField }
                             cspNonce={ cspNonce }
                             onChange={ onFieldChange }
                             styleObject={ style }
                             placeholder={ placeholder }
-                            // autoFocusRef={ (ref) => setRef(ref.current.base) }
+                            autoFocusRef={ (ref) => setRef(ref.current.base) }
                     /> : null
             }
 

--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -26,6 +26,7 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
     const [ fieldValue, setFieldValue ] = useState();
     const [ fieldValid, setFieldValid ] = useState(false);
     const [ fieldPotentiallyValid, setFieldPotentiallyValid] = useState(true);
+    const [cardTypes, setCardTypes] = useState([]);
     const [fieldFocus, setFieldFocus ] = useState(false);
     const [ fieldErrors, setFieldErrors ] = useState([]);
     const [ mainRef, setRef ] = useState();
@@ -51,6 +52,10 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
 
     const isFieldFocused = () => {
         return fieldFocus;
+    }
+
+    const getPotentialCardTypes = () => {
+        return cardTypes
     }
 
     const setGqlErrors = (errorData : {| field : string, errors : [] |}) => {
@@ -130,18 +135,19 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
                 return submitCardFields({ facilitatorAccessToken, extraFields, featureFlags });
             },
             getState: () => {
-                console.log(getCardFieldState())
+                return getCardFieldState()
             }
         });
     }, [ fieldValid, fieldValue, fieldFocus, fieldPotentiallyValid ]);
 
-    const onFieldChange = ({ value, valid, isFocused, potentiallyValid, errors }) => {
+    const onFieldChange = ({ value, valid, isFocused, potentiallyValid, errors, cardTypes }) => {
         setFieldValue(value);
         setFieldErrors([ ...errors ]);
         setFieldFocus(isFocused)
         setFieldValid(valid);
-        setFieldPotentiallyValid(potentiallyValid)
+        setFieldPotentiallyValid(potentiallyValid);
         resetGQLErrors();
+        setCardTypes(cardTypes)
     };
 
     return (

--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -122,6 +122,7 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
         setupExports({
             name: CARD_FIELD_TYPE_TO_FRAME_NAME[type],
             isFieldPotentiallyValid,
+            getPotentialCardTypes,
             isFieldValid,
             isFieldFocused,
             getFieldValue,
@@ -138,16 +139,16 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
                 return getCardFieldState()
             }
         });
-    }, [ fieldValid, fieldValue, fieldFocus, fieldPotentiallyValid ]);
+    }, [ fieldValid, fieldValue, fieldFocus, fieldPotentiallyValid, cardTypes ]);
 
-    const onFieldChange = ({ value, valid, isFocused, potentiallyValid, errors, cardTypes }) => {
+    const onFieldChange = ({ value, valid, isFocused, potentiallyValid, errors, potentialCardTypes }) => {
         setFieldValue(value);
         setFieldErrors([ ...errors ]);
         setFieldFocus(isFocused)
         setFieldValid(valid);
         setFieldPotentiallyValid(potentiallyValid);
         resetGQLErrors();
-        setCardTypes(cardTypes)
+        setCardTypes(potentialCardTypes);
     };
 
     return (

--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -25,7 +25,8 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
 
     const [ fieldValue, setFieldValue ] = useState();
     const [ fieldValid, setFieldValid ] = useState(false);
-    const [ fieldPotentiallyValid, setFieldPotentiallyValid] = useState(true)
+    const [ fieldPotentiallyValid, setFieldPotentiallyValid] = useState(true);
+    const [fieldFocus, setFieldFocus ] = useState(false);
     const [ fieldErrors, setFieldErrors ] = useState([]);
     const [ mainRef, setRef ] = useState();
     const [ fieldGQLErrors, setFieldGQLErrors ] = useState({ singleField: {}, numberField: [], expiryField: [], cvvField: [], nameField: [], postalCodeField: [] });
@@ -46,6 +47,10 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
 
     const isFieldPotentiallyValid = () => {
         return fieldPotentiallyValid
+    }
+
+    const isFieldFocused = () => {
+        return fieldFocus;
     }
 
     const setGqlErrors = (errorData : {| field : string, errors : [] |}) => {
@@ -113,6 +118,7 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
             name: CARD_FIELD_TYPE_TO_FRAME_NAME[type],
             isFieldPotentiallyValid,
             isFieldValid,
+            isFieldFocused,
             getFieldValue,
             setGqlErrors,
             resetGQLErrors
@@ -127,11 +133,12 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
                 console.log(getCardFieldState())
             }
         });
-    }, [ fieldValid, fieldValue, fieldPotentiallyValid ]);
+    }, [ fieldValid, fieldValue, fieldFocus, fieldPotentiallyValid ]);
 
-    const onFieldChange = ({ value, valid, potentiallyValid, errors }) => {
+    const onFieldChange = ({ value, valid, isFocused, potentiallyValid, errors }) => {
         setFieldValue(value);
         setFieldErrors([ ...errors ]);
+        setFieldFocus(isFocused)
         setFieldValid(valid);
         setFieldPotentiallyValid(potentiallyValid)
         resetGQLErrors();

--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -31,6 +31,7 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
     const [ mainRef, setRef ] = useState();
     const [ fieldGQLErrors, setFieldGQLErrors ] = useState({ singleField: {}, numberField: [], expiryField: [], cvvField: [], nameField: [], postalCodeField: [] });
     const initialRender = useRef(true)
+    const fieldRef = useRef()
 
     let autocomplete;
     if (disableAutocomplete) {
@@ -51,6 +52,12 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
 
     const isFieldFocused = () => {
         return fieldFocus;
+    }
+
+    const getContainer = () => {
+        console.log('Field Ref: ', fieldRef)
+        return fieldRef.current;
+        // return 'returning the dom node'
     }
 
     const setGqlErrors = (errorData : {| field : string, errors : [] |}) => {
@@ -119,6 +126,7 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
             isFieldPotentiallyValid,
             isFieldValid,
             isFieldFocused,
+            getContainer,
             getFieldValue,
             setGqlErrors,
             resetGQLErrors
@@ -130,7 +138,8 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
                 return submitCardFields({ facilitatorAccessToken, extraFields, featureFlags });
             },
             getState: () => {
-                console.log(getCardFieldState())
+                // console.log('from sdk',getCardFieldState())
+                return getCardFieldState()
             }
         });
     }, [ fieldValid, fieldValue, fieldFocus, fieldPotentiallyValid ]);
@@ -204,13 +213,13 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
             {
                 (type === CARD_FIELD_TYPE.NAME)
                     ? <CardNameField
-                            ref={ mainRef }
+                            innerRef={ fieldRef }
                             gqlErrors={ fieldGQLErrors.nameField }
                             cspNonce={ cspNonce }
                             onChange={ onFieldChange }
                             styleObject={ style }
                             placeholder={ placeholder }
-                            autoFocusRef={ (ref) => setRef(ref.current.base) }
+                            // autoFocusRef={ (ref) => setRef(ref.current.base) }
                     /> : null
             }
 

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -11,9 +11,9 @@ import { getLogger } from '../lib';
 import type {FeatureFlags} from '../types'
 
 import { getCardProps } from './props';
-import type { Card, ExtraFields } from './types';
+import type { Card, ExtraFields, CardFieldsState } from './types';
 import { type CardExports, type ExportsOptions } from './lib';
-import { parsedCardType } from './/lib/card-utils';
+import { parsedCardType } from './lib/card-utils';
 
 function getExportsByFrameName<T>(name: $Values<typeof FRAME_NAME>): ?CardExports<T> {
     try {
@@ -59,7 +59,7 @@ function isEmpty(value: string): boolean {
     return false
 }
 
-export function getCardFieldState(): object {
+export function getCardFieldState(): CardFieldsState {
     const { cardNameFrame, cardNumberFrame, cardCVVFrame, cardExpiryFrame, cardPostalFrame } = getCardFrames();
 
     const cardFieldsState = {
@@ -218,7 +218,7 @@ function reformatExpiry(expiry: ?string): ?string {
 }
 
 export function submitCardFields({ facilitatorAccessToken, extraFields, featureFlags } : SubmitCardFieldsOptions) : ZalgoPromise<void> {
-    const { intent, branded, vault, createOrder, onApprove, clientID } = getCardProps({ facilitatorAccessToken, featureFlags });
+    const { intent, createOrder, onApprove, onError } = getCardProps({ facilitatorAccessToken, featureFlags });
 
     resetGQLErrors();
 

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -306,6 +306,7 @@ export function submitCardFields({
     };
 
     if (intent === INTENT.TOKENIZE) {
+      // $FlowIgnore
       return tokenizeCard({ card }).then(({ paymentMethodToken }) => {
         return onApprove({ paymentMethodToken }, { restart });
       });

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -32,7 +32,6 @@ function getExportsByFrameName<T>(name : $Values<typeof FRAME_NAME>) : ?CardExpo
     }
 }
 
-
 function getCardFrames() : {| cardFrame : ?ExportsOptions,  cardNumberFrame : ?ExportsOptions, cardCVVFrame : ?ExportsOptions, cardExpiryFrame : ?ExportsOptions, cardNameFrame : ?ExportsOptions |} {
 
     const cardFrame = getExportsByFrameName(FRAME_NAME.CARD_FIELD);
@@ -40,18 +39,62 @@ function getCardFrames() : {| cardFrame : ?ExportsOptions,  cardNumberFrame : ?E
     const cardCVVFrame = getExportsByFrameName(FRAME_NAME.CARD_CVV_FIELD);
     const cardExpiryFrame = getExportsByFrameName(FRAME_NAME.CARD_EXPIRY_FIELD);
     const cardNameFrame = getExportsByFrameName(FRAME_NAME.CARD_NAME_FIELD);
+    const cardPostalFrame = getExportsByFrameName(FRAME_NAME.CARD_POSTAL_FIELD)
 
     return {
         cardFrame,
         cardNumberFrame,
         cardCVVFrame,
         cardExpiryFrame,
-        cardNameFrame
+        cardNameFrame,
+        cardPostalFrame
     };
 }
 
+function isEmpty(value: string) : boolean {
+    if(value.length === 0) {
+        return true
+    }
+    return false
+}
 
-export function hasCardFields() : boolean {
+export function getCardFieldState() : object {
+    const { cardFrame, cardNameFrame, cardNumberFrame, cardCVVFrame, cardExpiryFrame, cardPostalFrame } = getCardFrames();
+
+    const cardFieldsState = {
+        cards: [],
+        fields: {
+            cardName: {
+                isEmpty: isEmpty(cardNameFrame.getFieldValue()),
+                isValid: cardNameFrame.isFieldValid(),
+                isPotentiallyValid: cardNameFrame.isFieldPotentiallyValid()
+            },
+            cardNumber: {
+                isEmpty: isEmpty(cardNumberFrame.getFieldValue()),
+                isValid: cardNumberFrame.isFieldValid(),
+                isPotentiallyValid: cardNumberFrame.isFieldPotentiallyValid()
+            },
+            cardExpiry: {
+                isEmpty: isEmpty(cardExpiryFrame.getFieldValue()),
+                isValid: cardExpiryFrame.isFieldValid(),
+                isPotentiallyValid: cardExpiryFrame.isFieldPotentiallyValid()
+            },
+            cardCVV: {
+                isEmpty: isEmpty(cardCVVFrame.getFieldValue()),
+                isValid: cardCVVFrame.isFieldValid(),
+                isPotentiallyValid: cardCVVFrame.isFieldPotentiallyValid()
+            },
+            cardPostalCode: {
+                isEmpty: isEmpty(cardPostalFrame.getFieldValue()),
+                isValid: cardPostalFrame.isFieldValid(),
+                isPotentiallyValid: cardPostalFrame.isFieldPotentiallyValid()
+            }
+        }
+    }
+    return cardFieldsState
+}
+
+export function hasCaroFields() : boolean {
     const { cardFrame, cardNumberFrame, cardCVVFrame, cardExpiryFrame } = getCardFrames();
 
     if (cardFrame || (cardNumberFrame && cardCVVFrame && cardExpiryFrame)) {

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -140,7 +140,6 @@ export function hasCardFields(): boolean {
     cardNumberFrame,
     cardCVVFrame,
     cardExpiryFrame,
-    cardPostalFrame
   } = getCardFrames();
 
   if (cardFrame || (cardNumberFrame && cardCVVFrame && cardExpiryFrame)) {

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -1,280 +1,351 @@
+/* eslint-disable flowtype/require-exact-type */
 /* @flow */
 
-import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
-import { INTENT } from '@paypal/sdk-constants';
-import { getAllFramesInWindow, isSameDomain } from '@krakenjs/cross-domain-utils/src';
-import { uniqueID } from '@krakenjs/belter/src';
+import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
+import { INTENT } from "@paypal/sdk-constants";
+import {
+  getAllFramesInWindow,
+  isSameDomain
+} from "@krakenjs/cross-domain-utils/src";
+import { uniqueID } from "@krakenjs/belter/src";
 
-import { FRAME_NAME } from '../constants';
-import { tokenizeCard, confirmOrderAPI } from '../api';
-import { getLogger } from '../lib';
-import type {FeatureFlags} from '../types'
+import { FRAME_NAME } from "../constants";
+import { tokenizeCard, confirmOrderAPI } from "../api";
+import { getLogger } from "../lib";
+import type { FeatureFlags } from "../types";
 
-import { getCardProps } from './props';
-import type { Card, ExtraFields, CardFieldsState } from './types';
-import { type CardExports, type ExportsOptions } from './lib';
-import { parsedCardType } from './lib/card-utils';
+import { getCardProps } from "./props";
+import type { Card, ExtraFields, CardFieldsState } from "./types";
+import { type CardExports, type ExportsOptions } from "./lib";
+import { parsedCardType } from "./lib/card-utils";
 
-function getExportsByFrameName<T>(name: $Values<typeof FRAME_NAME>): ?CardExports<T> {
-    try {
-        for (const win of getAllFramesInWindow(window)) {
-
-            if (
-                isSameDomain(win) &&
-                // $FlowFixMe
-                win.exports &&
-                win.exports.name === name
-            ) {
-                return win.exports;
-            }
-        }
-    } catch (err) {
-        // pass
+function getExportsByFrameName<T>(
+  name: $Values<typeof FRAME_NAME>
+): ?CardExports<T> {
+  try {
+    for (const win of getAllFramesInWindow(window)) {
+      if (
+        isSameDomain(win) &&
+        // $FlowFixMe
+        win.exports &&
+        win.exports.name === name
+      ) {
+        return win.exports;
+      }
     }
+  } catch (err) {
+    // pass
+  }
 }
+/* This is a deadlock situation where CardExports<T> returned by getExportsByFrameName has to be a 'Maybe Type' (https://flow.org/en/docs/types/maybe/) for cardFrame, cardNameFrame and cardPostalCode whereas mandatory for the rest of the Frames.
+ So adding a flowIgnore to pass the typecheck failures*/
 
-function getCardFrames(): {| cardFrame : ?ExportsOptions, cardNumberFrame : ?ExportsOptions, cardCVVFrame : ?ExportsOptions, cardExpiryFrame : ?ExportsOptions, cardNameFrame : ?ExportsOptions, cardPostalFrame: ?ExportsOptions |} {
+// $FlowIgnore
+function getCardFrames(): {
+  cardFrame: ?ExportsOptions,
+  cardNumberFrame: ExportsOptions,
+  cardCVVFrame: ExportsOptions,
+  cardExpiryFrame: ExportsOptions,
+  cardNameFrame?: ?ExportsOptions,
+  cardPostalFrame?: ?ExportsOptions
+} {
+  const cardFrame = getExportsByFrameName(FRAME_NAME.CARD_FIELD);
+  const cardNumberFrame = getExportsByFrameName(FRAME_NAME.CARD_NUMBER_FIELD);
+  const cardCVVFrame = getExportsByFrameName(FRAME_NAME.CARD_CVV_FIELD);
+  const cardExpiryFrame = getExportsByFrameName(FRAME_NAME.CARD_EXPIRY_FIELD);
+  const cardNameFrame = getExportsByFrameName(FRAME_NAME.CARD_NAME_FIELD);
+  const cardPostalFrame = getExportsByFrameName(FRAME_NAME.CARD_POSTAL_FIELD);
 
-    const cardFrame = getExportsByFrameName(FRAME_NAME.CARD_FIELD);
-    const cardNumberFrame = getExportsByFrameName(FRAME_NAME.CARD_NUMBER_FIELD);
-    const cardCVVFrame = getExportsByFrameName(FRAME_NAME.CARD_CVV_FIELD);
-    const cardExpiryFrame = getExportsByFrameName(FRAME_NAME.CARD_EXPIRY_FIELD);
-    const cardNameFrame = getExportsByFrameName(FRAME_NAME.CARD_NAME_FIELD);
-    const cardPostalFrame = getExportsByFrameName(FRAME_NAME.CARD_POSTAL_FIELD)
-
-    return {
-        cardFrame,
-        cardNumberFrame,
-        cardCVVFrame,
-        cardExpiryFrame,
-        cardNameFrame,
-        cardPostalFrame
-    };
+ 
+  return {
+    cardFrame,
+     // $FlowIgnore
+    cardNumberFrame,
+     // $FlowIgnore
+    cardCVVFrame,
+     // $FlowIgnore
+    cardExpiryFrame,
+    cardNameFrame,
+    cardPostalFrame
+  };
 }
 
 function isEmpty(value: string): boolean {
-    if (value.length === 0) {
-        return true
-    }
-    return false
+  if (value.length === 0) {
+    return true;
+  }
+  return false;
 }
 
+function formatCardFrameFieldName(fieldName: string): string {
+  const res = fieldName.split("-");
+  res.pop();
+  res[1] = res[1]?.replace(/^\w/, c => c.toUpperCase());
+  return res.join("");
+}
 export function getCardFieldState(): CardFieldsState {
-    const { cardNameFrame, cardNumberFrame, cardCVVFrame, cardExpiryFrame, cardPostalFrame } = getCardFrames();
+  const {
+    cardNameFrame,
+    cardNumberFrame,
+    cardCVVFrame,
+    cardExpiryFrame,
+    cardPostalFrame
+  } = getCardFrames();
+  const optionalFields = {};
 
-    const cardFieldsState = {
-        cards: parsedCardType(cardNumberFrame.getPotentialCardTypes()),
-        fields: {
-            cardName: {
-                isEmpty: isEmpty(cardNameFrame.getFieldValue()),
-                isValid: cardNameFrame.isFieldValid(),
-                isPotentiallyValid: cardNameFrame.isFieldPotentiallyValid(),
-                isFocused: cardNameFrame.isFieldFocused()
-            },
-            cardNumber: {
-                isEmpty: isEmpty(cardNumberFrame.getFieldValue()),
-                isValid: cardNumberFrame.isFieldValid(),
-                isPotentiallyValid: cardNumberFrame.isFieldPotentiallyValid(),
-                isFocused: cardNumberFrame.isFieldFocused(),
-            },
-            cardExpiry: {
-                isEmpty: isEmpty(cardExpiryFrame.getFieldValue()),
-                isValid: cardExpiryFrame.isFieldValid(),
-                isPotentiallyValid: cardExpiryFrame.isFieldPotentiallyValid(),
-                isFocused: cardExpiryFrame.isFieldFocused()
-            },
-            cardCVV: {
-                isEmpty: isEmpty(cardCVVFrame.getFieldValue()),
-                isValid: cardCVVFrame.isFieldValid(),
-                isPotentiallyValid: cardCVVFrame.isFieldPotentiallyValid(),
-                isFocused: cardCVVFrame.isFieldFocused()
-            },
-            cardPostalCode: {
-                isEmpty: isEmpty(cardPostalFrame.getFieldValue()),
-                isValid: cardPostalFrame.isFieldValid(),
-                isPotentiallyValid: cardPostalFrame.isFieldPotentiallyValid(),
-                isFocused: cardPostalFrame.isFieldFocused()
-            }
-        }
+  // Optional frames: the idea is to keep the optional frames separate and add the field
+  // state as needed
+  const cardFrameFields = [cardNameFrame, cardPostalFrame];
+  cardFrameFields.forEach(cardFrame => {
+    if (cardFrame) {
+      optionalFields[formatCardFrameFieldName(cardFrame.name)] = {
+        isEmpty: isEmpty(cardFrame?.getFieldValue()),
+        isValid: cardFrame?.isFieldValid(),
+        isPotentiallyValid: cardFrame.isFieldPotentiallyValid(),
+        isFocused: cardFrame.isFieldFocused()
+      };
     }
-    return cardFieldsState
+  });
+
+  const cardFieldsState = {
+    cards: parsedCardType(cardNumberFrame.getPotentialCardTypes()),
+    fields: {
+      ...optionalFields,
+      cardNumber: {
+        isEmpty: isEmpty(cardNumberFrame.getFieldValue()),
+        isValid: cardNumberFrame.isFieldValid(),
+        isPotentiallyValid: cardNumberFrame.isFieldPotentiallyValid(),
+        isFocused: cardNumberFrame.isFieldFocused()
+      },
+      cardExpiry: {
+        isEmpty: isEmpty(cardExpiryFrame.getFieldValue()),
+        isValid: cardExpiryFrame.isFieldValid(),
+        isPotentiallyValid: cardExpiryFrame.isFieldPotentiallyValid(),
+        isFocused: cardExpiryFrame.isFieldFocused()
+      },
+      cardCvv: {
+        isEmpty: isEmpty(cardCVVFrame.getFieldValue()),
+        isValid: cardCVVFrame.isFieldValid(),
+        isPotentiallyValid: cardCVVFrame.isFieldPotentiallyValid(),
+        isFocused: cardCVVFrame.isFieldFocused()
+      }
+    }
+  };
+  return cardFieldsState;
 }
 
 export function hasCardFields(): boolean {
-    const { cardFrame, cardNumberFrame, cardCVVFrame, cardExpiryFrame } = getCardFrames();
+  const {
+    cardFrame,
+    cardNumberFrame,
+    cardCVVFrame,
+    cardExpiryFrame
+  } = getCardFrames();
 
-    if (cardFrame || (cardNumberFrame && cardCVVFrame && cardExpiryFrame)) {
-        return true;
-    }
+  if (cardFrame || (cardNumberFrame && cardCVVFrame && cardExpiryFrame)) {
+    return true;
+  }
 
-    return false;
+  return false;
 }
 
 export function getCardFields(): ?Card {
-    const cardFrame = getExportsByFrameName(FRAME_NAME.CARD_FIELD);
+  const cardFrame = getExportsByFrameName(FRAME_NAME.CARD_FIELD);
 
-    if (cardFrame && cardFrame.isFieldValid()) {
-        return cardFrame.getFieldValue();
-    }
+  if (cardFrame && cardFrame.isFieldValid()) {
+    return cardFrame.getFieldValue();
+  }
 
-    const { cardNumberFrame, cardCVVFrame, cardExpiryFrame, cardNameFrame } = getCardFrames();
+  const {
+    cardNumberFrame,
+    cardCVVFrame,
+    cardExpiryFrame,
+    cardNameFrame
+  } = getCardFrames();
 
-    if (
-        cardNumberFrame && cardNumberFrame.isFieldValid() &&
-        cardCVVFrame && cardCVVFrame.isFieldValid() &&
-        cardExpiryFrame && cardExpiryFrame.isFieldValid() &&
-        (cardNameFrame ? cardNameFrame.isFieldValid() : true)
-    ) {
-        return {
-            number: cardNumberFrame.getFieldValue(),
-            cvv: cardCVVFrame.getFieldValue(),
-            expiry: cardExpiryFrame.getFieldValue(),
-            name: cardNameFrame?.getFieldValue() || ''
-        };
-    }
+  if (
+    cardNumberFrame &&
+    cardNumberFrame.isFieldValid() &&
+    cardCVVFrame &&
+    cardCVVFrame.isFieldValid() &&
+    cardExpiryFrame &&
+    cardExpiryFrame.isFieldValid() &&
+    (cardNameFrame ? cardNameFrame.isFieldValid() : true)
+  ) {
+    return {
+      number: cardNumberFrame.getFieldValue(),
+      cvv: cardCVVFrame.getFieldValue(),
+      expiry: cardExpiryFrame.getFieldValue(),
+      name: cardNameFrame?.getFieldValue() || ""
+    };
+  }
 
-    throw new Error(`Card fields not available to submit`);
+  throw new Error(`Card fields not available to submit`);
 }
 
 export function emitGqlErrors(errorsMap: Object): void {
-    const { cardFrame, cardNumberFrame, cardExpiryFrame, cardCVVFrame } = getCardFrames();
+  const {
+    cardFrame,
+    cardNumberFrame,
+    cardExpiryFrame,
+    cardCVVFrame
+  } = getCardFrames();
 
-    const { number, expiry, security_code } = errorsMap;
+  const { number, expiry, security_code } = errorsMap;
 
-    if (cardFrame) {
-        let cardFieldError = { field: '', errors: [] };
+  if (cardFrame) {
+    let cardFieldError = { field: "", errors: [] };
 
-        if (number) {
-            cardFieldError = { field: 'number', errors: number };
-        }
-
-        if (expiry) {
-            cardFieldError = { field: 'expiry', errors: expiry };
-        }
-
-        if (security_code) {
-            cardFieldError = { field: 'cvv', errors: security_code };
-        }
-
-        cardFrame.setGqlErrors(cardFieldError);
+    if (number) {
+      cardFieldError = { field: "number", errors: number };
     }
 
-    if (cardNumberFrame && number) {
-        cardNumberFrame.setGqlErrors({ field: 'number', errors: number });
+    if (expiry) {
+      cardFieldError = { field: "expiry", errors: expiry };
     }
 
-    if (cardExpiryFrame && expiry) {
-        cardExpiryFrame.setGqlErrors({ field: 'expiry', errors: expiry });
+    if (security_code) {
+      cardFieldError = { field: "cvv", errors: security_code };
     }
 
-    if (cardCVVFrame && security_code) {
-        cardCVVFrame.setGqlErrors({ field: 'cvv', errors: security_code });
-    }
+    cardFrame.setGqlErrors(cardFieldError);
+  }
+
+  if (cardNumberFrame && number) {
+    cardNumberFrame.setGqlErrors({ field: "number", errors: number });
+  }
+
+  if (cardExpiryFrame && expiry) {
+    cardExpiryFrame.setGqlErrors({ field: "expiry", errors: expiry });
+  }
+
+  if (cardCVVFrame && security_code) {
+    cardCVVFrame.setGqlErrors({ field: "cvv", errors: security_code });
+  }
 }
 
 export function resetGQLErrors(): void {
-    const { cardFrame, cardNumberFrame, cardExpiryFrame, cardCVVFrame } = getCardFrames();
+  const {
+    cardFrame,
+    cardNumberFrame,
+    cardExpiryFrame,
+    cardCVVFrame
+  } = getCardFrames();
 
-    if (cardFrame) {
-        cardFrame.resetGQLErrors();
-    }
+  if (cardFrame) {
+    cardFrame.resetGQLErrors();
+  }
 
-    if (cardNumberFrame) {
-        cardNumberFrame.resetGQLErrors();
-    }
+  if (cardNumberFrame) {
+    cardNumberFrame.resetGQLErrors();
+  }
 
-    if (cardExpiryFrame) {
-        cardExpiryFrame.resetGQLErrors();
-    }
+  if (cardExpiryFrame) {
+    cardExpiryFrame.resetGQLErrors();
+  }
 
-    if (cardCVVFrame) {
-        cardCVVFrame.resetGQLErrors();
-    }
+  if (cardCVVFrame) {
+    cardCVVFrame.resetGQLErrors();
+  }
 }
 
 type SubmitCardFieldsOptions = {|
-    facilitatorAccessToken : string,
-    featureFlags: FeatureFlags,
-    extraFields? : {|
-        billingAddress? : string
-    |}
+  facilitatorAccessToken: string,
+  featureFlags: FeatureFlags,
+  extraFields?: {|
+    billingAddress?: string
+  |}
 |};
 
 type CardValues = {|
-    number : string,
-        expiry ? : ? string,
-        security_code ? : string,
-        postalCode ? : string,
-        name ? : string,
-    ...ExtraFields
-    |};
+  number: string,
+  expiry?: ?string,
+  security_code?: string,
+  postalCode?: string,
+  name?: string,
+  ...ExtraFields
+|};
 
 // Reformat MM/YYYY to YYYY-MM
 function reformatExpiry(expiry: ?string): ?string {
-    if (typeof expiry === "string") {
-        const [month, year] = expiry.split('/');
-        return `${year}-${month}`;
+  if (typeof expiry === "string") {
+    const [month, year] = expiry.split("/");
+    return `${year}-${month}`;
+  }
+}
+
+export function submitCardFields({
+  facilitatorAccessToken,
+  extraFields,
+  featureFlags
+}: SubmitCardFieldsOptions): ZalgoPromise<void> {
+  const { intent, createOrder, onApprove, onError } = getCardProps({
+    facilitatorAccessToken,
+    featureFlags
+  });
+
+  resetGQLErrors();
+
+  return ZalgoPromise.try(() => {
+    if (!hasCardFields()) {
+      throw new Error(`Card fields not available to submit`);
     }
+
+    const card = getCardFields();
+
+    if (!card) {
+      return;
+    }
+
+    const restart = () => {
+      throw new Error(`Restart not implemented for card fields flow`);
+    };
+
+    if (intent === INTENT.TOKENIZE) {
+      return tokenizeCard({ card }).then(({ paymentMethodToken }) => {
+        return onApprove({ paymentMethodToken }, { restart });
+      });
+    }
+
+    if (intent === INTENT.CAPTURE || intent === INTENT.AUTHORIZE) {
+      return createOrder()
+        .then(orderID => {
+          const cardObject: CardValues = {
+            name: card.name,
+            number: card.number,
+            expiry: reformatExpiry(card.expiry),
+            security_code: card.cvv,
+            ...extraFields
+          };
+
+          if (card.name) {
+            cardObject.name = card.name;
+          }
+
+          // eslint-disable-next-line flowtype/no-weak-types
+          const data: any = {
+            payment_source: {
+              card: cardObject
+            }
+          };
+          return confirmOrderAPI(orderID, data, {
+            facilitatorAccessToken,
+            partnerAttributionID: ""
+          }).catch(error => {
+            getLogger().info("card_fields_payment_failed");
+            if (onError) {
+              onError(error);
+            }
+            throw error;
+          });
+        })
+        .then(orderData => {
+          return onApprove(
+            { payerID: uniqueID(), buyerAccessToken: uniqueID(), ...orderData },
+            { restart }
+          );
+        });
+    }
+  });
 }
-
-export function submitCardFields({ facilitatorAccessToken, extraFields, featureFlags } : SubmitCardFieldsOptions) : ZalgoPromise<void> {
-    const { intent, createOrder, onApprove, onError } = getCardProps({ facilitatorAccessToken, featureFlags });
-
-    resetGQLErrors();
-
-    return ZalgoPromise.try(() => {
-        if (!hasCardFields()) {
-            throw new Error(`Card fields not available to submit`);
-        }
-
-        const card = getCardFields();
-
-        if (!card) {
-            return;
-        }
-
-        const restart = () => {
-            throw new Error(`Restart not implemented for card fields flow`);
-        };
-
-        if (intent === INTENT.TOKENIZE) {
-            return tokenizeCard({ card }).then(({ paymentMethodToken }) => {
-                return onApprove({ paymentMethodToken }, { restart });
-            });
-        }
-
-        if (intent === INTENT.CAPTURE || intent === INTENT.AUTHORIZE) {
-            return createOrder().then(orderID => {
-
-                const cardObject: CardValues = {
-                    name: card.name,
-                    number: card.number,
-                    expiry: reformatExpiry(card.expiry),
-                    security_code: card.cvv,
-                    ...extraFields
-                };
-
-                if (card.name) {
-                    cardObject.name = card.name;
-                }
-
-                // eslint-disable-next-line flowtype/no-weak-types
-                const data: any = {
-                    payment_source: {
-                        card: cardObject
-                    }
-                };
-                return confirmOrderAPI(orderID, data, { facilitatorAccessToken, partnerAttributionID: '' }).catch((error) => {
-                    getLogger().info('card_fields_payment_failed');
-                    if (onError) {
-                        onError(error);
-                    }
-                    throw error;
-                })
-
-            }).then((orderData) => {
-                return onApprove({ payerID: uniqueID(), buyerAccessToken: uniqueID(), ...orderData }, { restart });
-            });
-        }
-    });
-}
+/* eslint-enable flowtype/require-exact-type */

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -262,11 +262,11 @@ type SubmitCardFieldsOptions = {|
 |};
 
 type CardValues = {|
-  number: string,
+  number: ?string,
   expiry?: ?string,
-  security_code?: string,
-  postalCode?: string,
-  name?: string,
+  security_code?: ?string,
+  postalCode?: ?string,
+  name?: ?string,
   ...ExtraFields
 |};
 
@@ -306,7 +306,6 @@ export function submitCardFields({
     };
 
     if (intent === INTENT.TOKENIZE) {
-      // $FlowIgnore
       return tokenizeCard({ card }).then(({ paymentMethodToken }) => {
         return onApprove({ paymentMethodToken }, { restart });
       });

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -180,7 +180,7 @@ export function getCardFields(): ?Card {
       cvv: cardCVVFrame.getFieldValue(),
       expiry: cardExpiryFrame.getFieldValue(),
       name: cardNameFrame?.getFieldValue() || "",
-      postalCode: cardPostalFrame.getFieldValue() || ""
+      postalCode: cardPostalFrame?.getFieldValue() || ""
     };
   }
 

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -68,8 +68,7 @@ export function getCardFieldState(): object {
                 isEmpty: isEmpty(cardNameFrame.getFieldValue()),
                 isValid: cardNameFrame.isFieldValid(),
                 isPotentiallyValid: cardNameFrame.isFieldPotentiallyValid(),
-                isFocused: cardNameFrame.isFieldFocused(),
-                container: cardNameFrame.getContainer()
+                isFocused: cardNameFrame.isFieldFocused()
             },
             cardNumber: {
                 isEmpty: isEmpty(cardNumberFrame.getFieldValue()),

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -68,7 +68,8 @@ export function getCardFieldState(): object {
                 isEmpty: isEmpty(cardNameFrame.getFieldValue()),
                 isValid: cardNameFrame.isFieldValid(),
                 isPotentiallyValid: cardNameFrame.isFieldPotentiallyValid(),
-                isFocused: cardNameFrame.isFieldFocused()
+                isFocused: cardNameFrame.isFieldFocused(),
+                container: cardNameFrame.getContainer()
             },
             cardNumber: {
                 isEmpty: isEmpty(cardNumberFrame.getFieldValue()),

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -14,7 +14,7 @@ import { getCardProps } from './props';
 import type { Card, ExtraFields } from './types';
 import { type CardExports, type ExportsOptions } from './lib';
 
-function getExportsByFrameName<T>(name : $Values<typeof FRAME_NAME>) : ?CardExports<T> {
+function getExportsByFrameName<T>(name: $Values<typeof FRAME_NAME>): ?CardExports<T> {
     try {
         for (const win of getAllFramesInWindow(window)) {
 
@@ -32,7 +32,7 @@ function getExportsByFrameName<T>(name : $Values<typeof FRAME_NAME>) : ?CardExpo
     }
 }
 
-function getCardFrames() : {| cardFrame : ?ExportsOptions,  cardNumberFrame : ?ExportsOptions, cardCVVFrame : ?ExportsOptions, cardExpiryFrame : ?ExportsOptions, cardNameFrame : ?ExportsOptions |} {
+function getCardFrames(): {| cardFrame : ?ExportsOptions, cardNumberFrame : ?ExportsOptions, cardCVVFrame : ?ExportsOptions, cardExpiryFrame : ?ExportsOptions, cardNameFrame : ?ExportsOptions, cardPostalFrame: ?ExportsOptions |} {
 
     const cardFrame = getExportsByFrameName(FRAME_NAME.CARD_FIELD);
     const cardNumberFrame = getExportsByFrameName(FRAME_NAME.CARD_NUMBER_FIELD);
@@ -51,15 +51,16 @@ function getCardFrames() : {| cardFrame : ?ExportsOptions,  cardNumberFrame : ?E
     };
 }
 
-function isEmpty(value: string) : boolean {
-    if(value.length === 0) {
+function isEmpty(value: string): boolean {
+    if (value.length === 0) {
         return true
     }
     return false
 }
 
-export function getCardFieldState() : object {
-    const { cardFrame, cardNameFrame, cardNumberFrame, cardCVVFrame, cardExpiryFrame, cardPostalFrame } = getCardFrames();
+export function getCardFieldState(): object {
+    console.log("## Hey there!")
+    const { cardNameFrame, cardNumberFrame, cardCVVFrame, cardExpiryFrame, cardPostalFrame } = getCardFrames();
 
     const cardFieldsState = {
         cards: [],
@@ -67,34 +68,39 @@ export function getCardFieldState() : object {
             cardName: {
                 isEmpty: isEmpty(cardNameFrame.getFieldValue()),
                 isValid: cardNameFrame.isFieldValid(),
-                isPotentiallyValid: cardNameFrame.isFieldPotentiallyValid()
+                isPotentiallyValid: cardNameFrame.isFieldPotentiallyValid(),
+                isFocused: cardNameFrame.isFieldFocused()
             },
             cardNumber: {
                 isEmpty: isEmpty(cardNumberFrame.getFieldValue()),
                 isValid: cardNumberFrame.isFieldValid(),
-                isPotentiallyValid: cardNumberFrame.isFieldPotentiallyValid()
+                isPotentiallyValid: cardNumberFrame.isFieldPotentiallyValid(),
+                isFocused: cardNumberFrame.isFieldFocused()
             },
             cardExpiry: {
                 isEmpty: isEmpty(cardExpiryFrame.getFieldValue()),
                 isValid: cardExpiryFrame.isFieldValid(),
-                isPotentiallyValid: cardExpiryFrame.isFieldPotentiallyValid()
+                isPotentiallyValid: cardExpiryFrame.isFieldPotentiallyValid(),
+                isFocused: cardExpiryFrame.isFieldFocused()
             },
             cardCVV: {
                 isEmpty: isEmpty(cardCVVFrame.getFieldValue()),
                 isValid: cardCVVFrame.isFieldValid(),
-                isPotentiallyValid: cardCVVFrame.isFieldPotentiallyValid()
+                isPotentiallyValid: cardCVVFrame.isFieldPotentiallyValid(),
+                isFocused: cardCVVFrame.isFieldFocused()
             },
             cardPostalCode: {
                 isEmpty: isEmpty(cardPostalFrame.getFieldValue()),
                 isValid: cardPostalFrame.isFieldValid(),
-                isPotentiallyValid: cardPostalFrame.isFieldPotentiallyValid()
+                isPotentiallyValid: cardPostalFrame.isFieldPotentiallyValid(),
+                isFocused: cardPostalFrame.isFieldFocused()
             }
         }
     }
     return cardFieldsState
 }
 
-export function hasCaroFields() : boolean {
+export function hasCardFields(): boolean {
     const { cardFrame, cardNumberFrame, cardCVVFrame, cardExpiryFrame } = getCardFrames();
 
     if (cardFrame || (cardNumberFrame && cardCVVFrame && cardExpiryFrame)) {
@@ -104,7 +110,7 @@ export function hasCaroFields() : boolean {
     return false;
 }
 
-export function getCardFields() : ?Card {
+export function getCardFields(): ?Card {
     const cardFrame = getExportsByFrameName(FRAME_NAME.CARD_FIELD);
 
     if (cardFrame && cardFrame.isFieldValid()) {
@@ -121,16 +127,16 @@ export function getCardFields() : ?Card {
     ) {
         return {
             number: cardNumberFrame.getFieldValue(),
-            cvv:    cardCVVFrame.getFieldValue(),
+            cvv: cardCVVFrame.getFieldValue(),
             expiry: cardExpiryFrame.getFieldValue(),
-            name:   cardNameFrame?.getFieldValue() || ''
+            name: cardNameFrame?.getFieldValue() || ''
         };
     }
 
     throw new Error(`Card fields not available to submit`);
 }
 
-export function emitGqlErrors(errorsMap : Object) : void {
+export function emitGqlErrors(errorsMap: Object): void {
     const { cardFrame, cardNumberFrame, cardExpiryFrame, cardCVVFrame } = getCardFrames();
 
     const { number, expiry, security_code } = errorsMap;
@@ -166,7 +172,7 @@ export function emitGqlErrors(errorsMap : Object) : void {
     }
 }
 
-export function resetGQLErrors() : void {
+export function resetGQLErrors(): void {
     const { cardFrame, cardNumberFrame, cardExpiryFrame, cardCVVFrame } = getCardFrames();
 
     if (cardFrame) {
@@ -196,18 +202,18 @@ type SubmitCardFieldsOptions = {|
 
 type CardValues = {|
     number : string,
-    expiry? : ?string,
-    security_code? : string,
-    postalCode? : string,
-    name? : string,
+        expiry ? : ? string,
+        security_code ? : string,
+        postalCode ? : string,
+        name ? : string,
     ...ExtraFields
-|};
+    |};
 
 // Reformat MM/YYYY to YYYY-MM
-function reformatExpiry(expiry : ?string) : ?string {
+function reformatExpiry(expiry: ?string): ?string {
     if (typeof expiry === "string") {
-        const [ month, year ] = expiry.split('/');
-        return `${ year }-${ month }`;
+        const [month, year] = expiry.split('/');
+        return `${year}-${month}`;
     }
 }
 
@@ -230,7 +236,7 @@ export function submitCardFields({ facilitatorAccessToken, extraFields, featureF
         const restart = () => {
             throw new Error(`Restart not implemented for card fields flow`);
         };
-    
+
         if (intent === INTENT.TOKENIZE) {
             return tokenizeCard({ card }).then(({ paymentMethodToken }) => {
                 return onApprove({ paymentMethodToken }, { restart });
@@ -240,10 +246,10 @@ export function submitCardFields({ facilitatorAccessToken, extraFields, featureF
         if (intent === INTENT.CAPTURE || intent === INTENT.AUTHORIZE) {
             return createOrder().then(orderID => {
 
-                const cardObject : CardValues = {
-                    name:          card.name,
-                    number:        card.number,
-                    expiry:        reformatExpiry(card.expiry),
+                const cardObject: CardValues = {
+                    name: card.name,
+                    number: card.number,
+                    expiry: reformatExpiry(card.expiry),
                     security_code: card.cvv,
                     ...extraFields
                 };
@@ -253,7 +259,7 @@ export function submitCardFields({ facilitatorAccessToken, extraFields, featureF
                 }
 
                 // eslint-disable-next-line flowtype/no-weak-types
-                const data : any = {
+                const data: any = {
                     payment_source: {
                         card: cardObject
                     }

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -13,6 +13,7 @@ import type {FeatureFlags} from '../types'
 import { getCardProps } from './props';
 import type { Card, ExtraFields } from './types';
 import { type CardExports, type ExportsOptions } from './lib';
+import { parsedCardType } from './/lib/card-utils';
 
 function getExportsByFrameName<T>(name: $Values<typeof FRAME_NAME>): ?CardExports<T> {
     try {
@@ -62,7 +63,7 @@ export function getCardFieldState(): object {
     const { cardNameFrame, cardNumberFrame, cardCVVFrame, cardExpiryFrame, cardPostalFrame } = getCardFrames();
 
     const cardFieldsState = {
-        cards: [],
+        cards: parsedCardType(cardNumberFrame.getPotentialCardTypes()),
         fields: {
             cardName: {
                 isEmpty: isEmpty(cardNameFrame.getFieldValue()),
@@ -74,7 +75,7 @@ export function getCardFieldState(): object {
                 isEmpty: isEmpty(cardNumberFrame.getFieldValue()),
                 isValid: cardNumberFrame.isFieldValid(),
                 isPotentiallyValid: cardNumberFrame.isFieldPotentiallyValid(),
-                isFocused: cardNumberFrame.isFieldFocused()
+                isFocused: cardNumberFrame.isFieldFocused(),
             },
             cardExpiry: {
                 isEmpty: isEmpty(cardExpiryFrame.getFieldValue()),

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -59,7 +59,6 @@ function isEmpty(value: string): boolean {
 }
 
 export function getCardFieldState(): object {
-    console.log("## Hey there!")
     const { cardNameFrame, cardNumberFrame, cardCVVFrame, cardExpiryFrame, cardPostalFrame } = getCardFrames();
 
     const cardFieldsState = {

--- a/src/card/interface.js
+++ b/src/card/interface.js
@@ -139,7 +139,8 @@ export function hasCardFields(): boolean {
     cardFrame,
     cardNumberFrame,
     cardCVVFrame,
-    cardExpiryFrame
+    cardExpiryFrame,
+    cardPostalFrame
   } = getCardFrames();
 
   if (cardFrame || (cardNumberFrame && cardCVVFrame && cardExpiryFrame)) {
@@ -160,7 +161,8 @@ export function getCardFields(): ?Card {
     cardNumberFrame,
     cardCVVFrame,
     cardExpiryFrame,
-    cardNameFrame
+    cardNameFrame,
+    cardPostalFrame
   } = getCardFrames();
 
   if (
@@ -170,13 +172,16 @@ export function getCardFields(): ?Card {
     cardCVVFrame.isFieldValid() &&
     cardExpiryFrame &&
     cardExpiryFrame.isFieldValid() &&
-    (cardNameFrame ? cardNameFrame.isFieldValid() : true)
+    // cardNameFrame and cardPostalFrame are optional fields so we only want to check the validity if they are rendered.
+    (cardNameFrame ? cardNameFrame.isFieldValid() : true) &&
+    (cardPostalFrame ? cardPostalFrame.isFieldValid() : true)
   ) {
     return {
       number: cardNumberFrame.getFieldValue(),
       cvv: cardCVVFrame.getFieldValue(),
       expiry: cardExpiryFrame.getFieldValue(),
-      name: cardNameFrame?.getFieldValue() || ""
+      name: cardNameFrame?.getFieldValue() || "",
+      postalCode: cardPostalFrame.getFieldValue() || ""
     };
   }
 

--- a/src/card/lib/card-checks.js
+++ b/src/card/lib/card-checks.js
@@ -57,7 +57,7 @@ cardValidator.creditCardType.addCard({
 });
 
 // Detect the card type metadata for a card number
-export function detectCardType(cardNumber : string) : CardType {
+export function detectCardType(cardNumber : string) : $ReadOnlyArray<CardType> {
     if (cardNumber.length > 0) {
         const cardTypes = cardValidator.creditCardType.default(cardNumber);
         if (cardTypes.length > 0) {

--- a/src/card/lib/card-checks.js
+++ b/src/card/lib/card-checks.js
@@ -61,20 +61,23 @@ export function detectCardType(cardNumber : string) : CardType {
     if (cardNumber.length > 0) {
         const cardTypes = cardValidator.creditCardType.default(cardNumber);
         if (cardTypes.length > 0) {
-            return cardTypes[0];
+            return cardTypes;
         }
     }
-    return DEFAULT_CARD_TYPE;
+    return [ DEFAULT_CARD_TYPE ];
 }
 
 // Add gaps to a card number for display given a card type. If a card type is
 // not provided, attempt to detect it and add gaps based on that type.
 export function addGapsToCardNumber(cardNumber : string, cardType? : CardType) : string {
     assertString(cardNumber);
+    console.log('Card Number: ', cardNumber)
+    console.log('Card Type: ', cardType)
     // Remove all non-digits and all whitespaces
     cardNumber = cardNumber.trim().replace(/[^0-9]/g, '').replace(/\s/g, '');
     // $FlowFixMe
-    const gaps = cardType?.gaps || detectCardType(cardNumber)?.gaps;
+    const gaps = cardType?.gaps || detectCardType(cardNumber)[0]?.gaps;
+    console.log('gaps', gaps)
 
     // The gaps indicate where a space is inserted into the card number for display
     if (gaps) {

--- a/src/card/lib/card-checks.js
+++ b/src/card/lib/card-checks.js
@@ -71,13 +71,11 @@ export function detectCardType(cardNumber : string) : CardType {
 // not provided, attempt to detect it and add gaps based on that type.
 export function addGapsToCardNumber(cardNumber : string, cardType? : CardType) : string {
     assertString(cardNumber);
-    console.log('Card Number: ', cardNumber)
-    console.log('Card Type: ', cardType)
+
     // Remove all non-digits and all whitespaces
     cardNumber = cardNumber.trim().replace(/[^0-9]/g, '').replace(/\s/g, '');
     // $FlowFixMe
     const gaps = cardType?.gaps || detectCardType(cardNumber)[0]?.gaps;
-    console.log('gaps', gaps)
 
     // The gaps indicate where a space is inserted into the card number for display
     if (gaps) {

--- a/src/card/lib/card-checks.test.js
+++ b/src/card/lib/card-checks.test.js
@@ -204,4 +204,5 @@ describe("card-checks", () => {
       expect(checkCardEligibility(cardNumber, cardType)).toBe(true);
     });
   });
+
 });

--- a/src/card/lib/card-checks.test.js
+++ b/src/card/lib/card-checks.test.js
@@ -2,68 +2,137 @@
 
 import { DEFAULT_CARD_TYPE } from "../constants";
 
-import { detectCardType, addGapsToCardNumber, checkCardEligibility } from "./card-checks";
+import {
+  detectCardType,
+  addGapsToCardNumber,
+  checkCardEligibility,
+} from "./card-checks";
 
 describe("card-checks", () => {
-
   describe("detectCardType", () => {
-
-    it("returns the default card type if the number length is 0", () => {
+    it("returns an array with the default card type as the only element if the number length is 0", () => {
       const number = "";
 
       const cardType = detectCardType(number);
 
-      expect(cardType).toBe(DEFAULT_CARD_TYPE);
+      expect(cardType).toStrictEqual([DEFAULT_CARD_TYPE]);
     });
 
-    it("returns the default card type if the number length is greater than 0 but the card validator module does not return any potential card type", () => {
+    it("returns an array with the default card type as the only element if the number length is greater than 0 but the card validator module does not return any potential card type", () => {
       // the card-validator module will return an empty array for this card number
       const number = "123";
 
       const cardType = detectCardType(number);
 
-      expect(cardType).toBe(DEFAULT_CARD_TYPE);
+      expect(cardType).toStrictEqual([DEFAULT_CARD_TYPE]);
     });
 
-    it("returns a card type when the card validator module is able to detect a card type", () => {
-      const number = "411";
+    it("returns an array with the card type as the only element when the card validator module is able to detect a card type", () => {
+      const number = "41111111";
 
       const cardType = detectCardType(number);
 
-      expect(cardType).toStrictEqual([{
-        niceType: "Visa",
-        type: "visa",
-        patterns: [4],
-        matchStrength: 1,
-        gaps: [4, 8, 12],
-        lengths: [16, 18, 19],
-        code: {
-          name: "CVV",
-          size: 3,
+      expect(cardType).toStrictEqual([
+        {
+          niceType: "Visa",
+          type: "visa",
+          patterns: [4],
+          matchStrength: 1,
+          gaps: [4, 8, 12],
+          lengths: [16, 18, 19],
+          code: {
+            name: "CVV",
+            size: 3,
+          },
         },
-      }]);
+      ]);
     });
 
+    it("returns an array of possible card types when the card validator module detects more than one possible card types", () => {
+      const number = "4";
+
+      const cardType = detectCardType(number);
+
+      expect(cardType).toStrictEqual([
+        {
+          niceType: "Visa",
+          type: "visa",
+          patterns: [4],
+          gaps: [4, 8, 12],
+          lengths: [16, 18, 19],
+          code: { name: "CVV", size: 3 },
+          matchStrength: 1,
+        },
+        {
+          niceType: "Maestro",
+          type: "maestro",
+          patterns: [
+            493698,
+            [500000, 504174],
+            [504176, 506698],
+            [506779, 508999],
+            [56, 59],
+            63,
+            67,
+            6,
+          ],
+          gaps: [4, 8, 12],
+          lengths: [12, 13, 14, 15, 16, 17, 18, 19],
+          code: { name: "CVC", size: 3 },
+        },
+        {
+          niceType: "Elo",
+          type: "elo",
+          patterns: [
+            401178,
+            401179,
+            438935,
+            457631,
+            457632,
+            431274,
+            451416,
+            457393,
+            504175,
+            [506699, 506778],
+            [509000, 509999],
+            627780,
+            636297,
+            636368,
+            [650031, 650033],
+            [650035, 650051],
+            [650405, 650439],
+            [650485, 650538],
+            [650541, 650598],
+            [650700, 650718],
+            [650720, 650727],
+            [650901, 650978],
+            [651652, 651679],
+            [655000, 655019],
+            [655021, 655058],
+          ],
+          gaps: [4, 8, 12],
+          lengths: [16],
+          code: { name: "CVE", size: 3 },
+        },
+      ]);
+    });
   });
 
   describe("addGapsToCardNumber", () => {
-
     it("should add gaps (spaces) to the card number", () => {
-      const cardNumber = '4111111111111111';
+      const cardNumber = "4111111111111111";
       const newCardNumber = addGapsToCardNumber(cardNumber);
       expect(newCardNumber).toBe("4111 1111 1111 1111");
     });
 
     it("should handle card numbers with spaces and letters", () => {
-      const cardNumber = ' 4111a11 11b11 11c1111 ';
+      const cardNumber = " 4111a11 11b11 11c1111 ";
       const newCardNumber = addGapsToCardNumber(cardNumber);
       expect(newCardNumber).toBe("4111 1111 1111 1111");
     });
-
   });
 
   describe("checkCardEligibility", () => {
-
     beforeEach(() => {
       window.xprops = {};
     });
@@ -74,13 +143,13 @@ describe("card-checks", () => {
           eligible: true,
           vendors: {
             visa: {
-              eligible: true
-            }
-          }
-        }
+              eligible: true,
+            },
+          },
+        },
       };
       const cardNumber = "4111111111111111";
-      const cardType = detectCardType(cardNumber);
+      const cardType = detectCardType(cardNumber)[0];
       expect(checkCardEligibility(cardNumber, cardType)).toBe(true);
     });
 
@@ -90,51 +159,49 @@ describe("card-checks", () => {
           eligible: true,
           vendors: {
             visa: {
-              eligible: false
-            }
-          }
-        }
+              eligible: false,
+            },
+          },
+        },
       };
       const cardNumber = "4111111111111111";
-      const cardType = detectCardType(cardNumber);
+      const cardType = detectCardType(cardNumber)[0];
       expect(checkCardEligibility(cardNumber, cardType)).toBe(false);
     });
 
     it("should find card payments not eligible when the merchant is not onboarded for card payments", () => {
       window.xprops.fundingEligibility = {
         card: {
-          eligible: false
-        }
+          eligible: false,
+        },
       };
       const cardNumber = "4111111111111111";
-      const cardType = detectCardType(cardNumber);
+      const cardType = detectCardType(cardNumber)[0];
       expect(checkCardEligibility(cardNumber, cardType)).toBe(false);
     });
 
     it("should find unbranded card payments not eligible if the merchant is only eligible for branded payments", () => {
       window.xprops.fundingEligibility = {
         card: {
-          branded: true
-        }
+          branded: true,
+        },
       };
 
       const cardNumber = "4111111111111111";
-      const cardType = detectCardType(cardNumber);
+      const cardType = detectCardType(cardNumber)[0];
       expect(checkCardEligibility(cardNumber, cardType)).toBe(false);
-    })
+    });
 
     it("should default to ineligible if there is no funding eligibility specified", () => {
       const cardNumber = "4111111111111111";
-      const cardType = detectCardType(cardNumber);
+      const cardType = detectCardType(cardNumber)[0];
       expect(checkCardEligibility(cardNumber, cardType)).toBe(false);
     });
 
     it("should default to eligible if there is no card number entered", () => {
       const cardNumber = "";
-      const cardType = detectCardType(cardNumber);
+      const cardType = detectCardType(cardNumber)[0];
       expect(checkCardEligibility(cardNumber, cardType)).toBe(true);
     });
-
   });
-
 });

--- a/src/card/lib/card-checks.test.js
+++ b/src/card/lib/card-checks.test.js
@@ -30,7 +30,7 @@ describe("card-checks", () => {
 
       const cardType = detectCardType(number);
 
-      expect(cardType).toStrictEqual({
+      expect(cardType).toStrictEqual([{
         niceType: "Visa",
         type: "visa",
         patterns: [4],
@@ -41,7 +41,7 @@ describe("card-checks", () => {
           name: "CVV",
           size: 3,
         },
-      });
+      }]);
     });
 
   });

--- a/src/card/lib/card-utils.js
+++ b/src/card/lib/card-utils.js
@@ -306,13 +306,10 @@ export function filterExtraFields(extraData : Object) : ExtraFields | Object {
 
 
 export function parsedCardType(potentialCardTypes: CardType) : ParsedCardType {
-    const parsedCardTypeInfo = [];
-    potentialCardTypes.forEach((card) => {
-        const { type, niceType, code } = card;
-        parsedCardTypeInfo.push( { type, niceType, code })
-    })
-
-    return parsedCardTypeInfo;
+    
+    return potentialCardTypes.map(({ type, niceType, code }) => ({
+        type, niceType, code
+      }));
     
 }
 

--- a/src/card/lib/card-utils.js
+++ b/src/card/lib/card-utils.js
@@ -304,6 +304,18 @@ export function filterExtraFields(extraData : Object) : ExtraFields | Object {
     }, {});
 }
 
+
+export function parsedCardType(potentialCardTypes: Array<object>) : Array<object> {
+    const parsedCardTypeInfo = [];
+    potentialCardTypes.forEach((card) => {
+        const { type, niceType, code } = card;
+        parsedCardTypeInfo.push( { type, niceType, code })
+    })
+
+    return parsedCardTypeInfo;
+    
+}
+
 export function getContext(win : Object) : string {
     return win.xprops?.parent?.uid || win.xprops?.uid;
 }

--- a/src/card/lib/card-utils.js
+++ b/src/card/lib/card-utils.js
@@ -154,8 +154,7 @@ export function getCSSText(cardFieldStyle : Object, customStyle : Object) : stri
 
 // mark the ref's HTMLElement as valid or invalid
 export function markValidity(ref : Object, validity : FieldValidity) {
-    const element = ref?.current;
-    console.log('Element from mark validity: ', ref)
+    const element = ref?.current?.base;
     if (element) {
         if (validity.isPotentiallyValid || validity.isValid) {
             element.classList.add('valid');

--- a/src/card/lib/card-utils.js
+++ b/src/card/lib/card-utils.js
@@ -2,7 +2,7 @@
 
 import { values } from '@krakenjs/belter';
 
-import type { InputState, FieldValidity, ExtraFields } from '../types';
+import type { InputState, FieldValidity, ExtraFields, CardType, ParsedCardType } from '../types';
 import {
     CARD_ERRORS,
     CARD_FIELD_TYPE,
@@ -305,7 +305,7 @@ export function filterExtraFields(extraData : Object) : ExtraFields | Object {
 }
 
 
-export function parsedCardType(potentialCardTypes: Array<object>) : Array<object> {
+export function parsedCardType(potentialCardTypes: CardType) : ParsedCardType {
     const parsedCardTypeInfo = [];
     potentialCardTypes.forEach((card) => {
         const { type, niceType, code } = card;

--- a/src/card/lib/card-utils.js
+++ b/src/card/lib/card-utils.js
@@ -154,7 +154,8 @@ export function getCSSText(cardFieldStyle : Object, customStyle : Object) : stri
 
 // mark the ref's HTMLElement as valid or invalid
 export function markValidity(ref : Object, validity : FieldValidity) {
-    const element = ref?.current?.base;
+    const element = ref?.current;
+    console.log('Element from mark validity: ', ref)
     if (element) {
         if (validity.isPotentiallyValid || validity.isValid) {
             element.classList.add('valid');

--- a/src/card/lib/card-utils.js
+++ b/src/card/lib/card-utils.js
@@ -21,6 +21,7 @@ export const defaultInputState : InputState = {
     maskedInputValue:   '',
     cursorStart:        0,
     cursorEnd:          0,
+    isFocused:          false,
     keyStrokeCount:     0,
     isPotentiallyValid:  true,
     isValid:            false
@@ -305,7 +306,7 @@ export function filterExtraFields(extraData : Object) : ExtraFields | Object {
 }
 
 
-export function parsedCardType(potentialCardTypes: CardType) : ParsedCardType {
+export function parsedCardType(potentialCardTypes: $ReadOnlyArray<CardType>) : $ReadOnlyArray<ParsedCardType> {
     
     return potentialCardTypes.map(({ type, niceType, code }) => ({
         type, niceType, code

--- a/src/card/lib/card-utils.test.js
+++ b/src/card/lib/card-utils.test.js
@@ -15,7 +15,8 @@ import {
     getContext,
     markValidity,
     assertType,
-    shouldUseZeroPaddedExpiryPattern
+    shouldUseZeroPaddedExpiryPattern,
+    parsedCardType
 } from './card-utils';
 
 
@@ -492,4 +493,34 @@ describe('card utils', () => {
         });
 
     });
+
+  describe("parsedCardType", () => {
+    it("returns only the type, niceType, and code objecs returned from the card validator module", () => {
+      const cardType = [
+        {
+          niceType: "Visa",
+          type: "visa",
+          patterns: [4],
+          matchStrength: 1,
+          gaps: [4, 8, 12],
+          lengths: [16, 18, 19],
+          code: {
+            name: "CVV",
+            size: 3,
+          },
+        },
+      ];
+
+      expect(parsedCardType(cardType)).toStrictEqual([
+        {
+          niceType: "Visa",
+          type: "visa",
+          code: {
+            name: "CVV",
+            size: 3,
+          },
+        },
+      ])
+    });
+  });
 });

--- a/src/card/lib/exports.js
+++ b/src/card/lib/exports.js
@@ -1,13 +1,13 @@
 /* @flow */
 
 import { FRAME_NAME } from '../../constants';
-import { CardType } from '../types';
+import { type CardType } from '../types';
 
 export type ExportsOptions = {|
     name : $Values<typeof FRAME_NAME>,
     isFieldValid : () => boolean,
     isFieldPotentiallyValid : () => boolean,
-    getPotentialCardTypes : () => CardType,
+    getPotentialCardTypes : () => $ReadOnlyArray<CardType>,
     isFieldFocused : () => boolean,
     // eslint-disable-next-line no-undef
     getFieldValue : <T>() => T,
@@ -19,7 +19,7 @@ export type CardExports<V> = {|
     name : $Values<typeof FRAME_NAME>,
     isFieldValid : () => boolean,
     isFieldPotentiallyValid : () => boolean,
-    getPotentialCardTypes : () => CardType,
+    getPotentialCardTypes : () => $ReadOnlyArray<CardType>,
     isFieldFocused: () => boolean,
     getFieldValue : () => V,
     setGqlErrors : ({| field : string, errors : [] |}) => void,

--- a/src/card/lib/exports.js
+++ b/src/card/lib/exports.js
@@ -5,6 +5,7 @@ import { FRAME_NAME } from '../../constants';
 export type ExportsOptions = {|
     name : $Values<typeof FRAME_NAME>,
     isFieldValid : () => boolean,
+    isFieldPotentiallyValid : () => boolean,
     // eslint-disable-next-line no-undef
     getFieldValue : <T>() => T,
     setGqlErrors : ({| field : string, errors : [] |}) => void,
@@ -14,15 +15,17 @@ export type ExportsOptions = {|
 export type CardExports<V> = {|
     name : $Values<typeof FRAME_NAME>,
     isFieldValid : () => boolean,
+    isFieldPotentiallyValid : () => boolean,
     getFieldValue : () => V,
     setGqlErrors : ({| field : string, errors : [] |}) => void,
     resetGQLErrors : () => void
 |};
 
-export function setupExports<T>({ name, isFieldValid, getFieldValue, setGqlErrors, resetGQLErrors } : ExportsOptions) {
+export function setupExports<T>({ name, isFieldValid, isFieldPotentiallyValid, getFieldValue, setGqlErrors, resetGQLErrors } : ExportsOptions) {
     const xports : CardExports<T> = {
         name,
         isFieldValid,
+        isFieldPotentiallyValid,
         getFieldValue,
         setGqlErrors,
         resetGQLErrors

--- a/src/card/lib/exports.js
+++ b/src/card/lib/exports.js
@@ -6,6 +6,7 @@ export type ExportsOptions = {|
     name : $Values<typeof FRAME_NAME>,
     isFieldValid : () => boolean,
     isFieldPotentiallyValid : () => boolean,
+    getPotentialCardTypes : () => Array<object>,
     isFieldFocused : () => boolean,
     // eslint-disable-next-line no-undef
     getFieldValue : <T>() => T,
@@ -17,17 +18,19 @@ export type CardExports<V> = {|
     name : $Values<typeof FRAME_NAME>,
     isFieldValid : () => boolean,
     isFieldPotentiallyValid : () => boolean,
+    getPotentialCardTypes : () => Array<object>,
     isFieldFocused: () => boolean,
     getFieldValue : () => V,
     setGqlErrors : ({| field : string, errors : [] |}) => void,
     resetGQLErrors : () => void
 |};
 
-export function setupExports<T>({ name, isFieldValid, isFieldFocused, isFieldPotentiallyValid, getFieldValue, setGqlErrors, resetGQLErrors } : ExportsOptions) {
+export function setupExports<T>({ name, isFieldValid, isFieldFocused, isFieldPotentiallyValid, getFieldValue, setGqlErrors, resetGQLErrors, getPotentialCardTypes } : ExportsOptions) {
     const xports : CardExports<T> = {
         name,
         isFieldValid,
         isFieldPotentiallyValid,
+        getPotentialCardTypes,
         isFieldFocused,
         getFieldValue,
         setGqlErrors,

--- a/src/card/lib/exports.js
+++ b/src/card/lib/exports.js
@@ -9,6 +9,7 @@ export type ExportsOptions = {|
     isFieldFocused : () => boolean,
     // eslint-disable-next-line no-undef
     getFieldValue : <T>() => T,
+    getContainer : () => any,
     setGqlErrors : ({| field : string, errors : [] |}) => void,
     resetGQLErrors : () => void
 |};
@@ -19,17 +20,19 @@ export type CardExports<V> = {|
     isFieldPotentiallyValid : () => boolean,
     isFieldFocused: () => boolean,
     getFieldValue : () => V,
+    getContainer : () => any,
     setGqlErrors : ({| field : string, errors : [] |}) => void,
     resetGQLErrors : () => void
 |};
 
-export function setupExports<T>({ name, isFieldValid, isFieldFocused, isFieldPotentiallyValid, getFieldValue, setGqlErrors, resetGQLErrors } : ExportsOptions) {
+export function setupExports<T>({ name, isFieldValid, isFieldFocused, isFieldPotentiallyValid, getFieldValue, setGqlErrors, getContainer, resetGQLErrors } : ExportsOptions) {
     const xports : CardExports<T> = {
         name,
         isFieldValid,
         isFieldPotentiallyValid,
         isFieldFocused,
         getFieldValue,
+        getContainer,
         setGqlErrors,
         resetGQLErrors
     };

--- a/src/card/lib/exports.js
+++ b/src/card/lib/exports.js
@@ -6,6 +6,7 @@ export type ExportsOptions = {|
     name : $Values<typeof FRAME_NAME>,
     isFieldValid : () => boolean,
     isFieldPotentiallyValid : () => boolean,
+    isFieldFocused : () => boolean,
     // eslint-disable-next-line no-undef
     getFieldValue : <T>() => T,
     setGqlErrors : ({| field : string, errors : [] |}) => void,
@@ -16,16 +17,18 @@ export type CardExports<V> = {|
     name : $Values<typeof FRAME_NAME>,
     isFieldValid : () => boolean,
     isFieldPotentiallyValid : () => boolean,
+    isFieldFocused: () => boolean,
     getFieldValue : () => V,
     setGqlErrors : ({| field : string, errors : [] |}) => void,
     resetGQLErrors : () => void
 |};
 
-export function setupExports<T>({ name, isFieldValid, isFieldPotentiallyValid, getFieldValue, setGqlErrors, resetGQLErrors } : ExportsOptions) {
+export function setupExports<T>({ name, isFieldValid, isFieldFocused, isFieldPotentiallyValid, getFieldValue, setGqlErrors, resetGQLErrors } : ExportsOptions) {
     const xports : CardExports<T> = {
         name,
         isFieldValid,
         isFieldPotentiallyValid,
+        isFieldFocused,
         getFieldValue,
         setGqlErrors,
         resetGQLErrors

--- a/src/card/lib/exports.js
+++ b/src/card/lib/exports.js
@@ -9,7 +9,6 @@ export type ExportsOptions = {|
     isFieldFocused : () => boolean,
     // eslint-disable-next-line no-undef
     getFieldValue : <T>() => T,
-    getContainer : () => any,
     setGqlErrors : ({| field : string, errors : [] |}) => void,
     resetGQLErrors : () => void
 |};
@@ -20,19 +19,17 @@ export type CardExports<V> = {|
     isFieldPotentiallyValid : () => boolean,
     isFieldFocused: () => boolean,
     getFieldValue : () => V,
-    getContainer : () => any,
     setGqlErrors : ({| field : string, errors : [] |}) => void,
     resetGQLErrors : () => void
 |};
 
-export function setupExports<T>({ name, isFieldValid, isFieldFocused, isFieldPotentiallyValid, getFieldValue, setGqlErrors, getContainer, resetGQLErrors } : ExportsOptions) {
+export function setupExports<T>({ name, isFieldValid, isFieldFocused, isFieldPotentiallyValid, getFieldValue, setGqlErrors, resetGQLErrors } : ExportsOptions) {
     const xports : CardExports<T> = {
         name,
         isFieldValid,
         isFieldPotentiallyValid,
         isFieldFocused,
         getFieldValue,
-        getContainer,
         setGqlErrors,
         resetGQLErrors
     };

--- a/src/card/lib/exports.js
+++ b/src/card/lib/exports.js
@@ -1,12 +1,13 @@
 /* @flow */
 
 import { FRAME_NAME } from '../../constants';
+import { CardType } from '../types';
 
 export type ExportsOptions = {|
     name : $Values<typeof FRAME_NAME>,
     isFieldValid : () => boolean,
     isFieldPotentiallyValid : () => boolean,
-    getPotentialCardTypes : () => Array<object>,
+    getPotentialCardTypes : () => CardType,
     isFieldFocused : () => boolean,
     // eslint-disable-next-line no-undef
     getFieldValue : <T>() => T,
@@ -18,7 +19,7 @@ export type CardExports<V> = {|
     name : $Values<typeof FRAME_NAME>,
     isFieldValid : () => boolean,
     isFieldPotentiallyValid : () => boolean,
-    getPotentialCardTypes : () => Array<object>,
+    getPotentialCardTypes : () => CardType,
     isFieldFocused: () => boolean,
     getFieldValue : () => V,
     setGqlErrors : ({| field : string, errors : [] |}) => void,

--- a/src/card/props.js
+++ b/src/card/props.js
@@ -4,10 +4,10 @@ import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 import { FUNDING, CARD, type FundingEligibilityType } from '@paypal/sdk-constants/src';
 import { EXPERIENCE } from '@paypal/checkout-components/src/constants/button';
 
-import type { ProxyWindow, FeatureFlags, CardFieldsState } from '../types';
+import type { ProxyWindow, FeatureFlags } from '../types';
 import { getProps, type XProps, type Props } from '../props/props';
 
-import type { CardStyle, CardPlaceholder } from './types';
+import type { CardStyle, CardPlaceholder, CardFieldsState } from './types';
 import { CARD_FIELD_TYPE, CARD_ERRORS } from './constants';
 
 // export something to force webpack to see this as an ES module
@@ -21,7 +21,7 @@ export type PrerenderDetailsType = {|
 
 export type CardExport = ({|
     submit : () => ZalgoPromise<void>,
-    getState : () => ZalgoPromise<CardFieldsState>
+    getState : () => CardFieldsState
 |}) => ZalgoPromise<void>;
 
 export type OnChange = ({|

--- a/src/card/props.js
+++ b/src/card/props.js
@@ -1,10 +1,10 @@
 /* @flow */
 
-import type { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
+import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 import { FUNDING, CARD, type FundingEligibilityType } from '@paypal/sdk-constants/src';
 import { EXPERIENCE } from '@paypal/checkout-components/src/constants/button';
 
-import type { ProxyWindow, FeatureFlags } from '../types';
+import type { ProxyWindow, FeatureFlags, CardFieldsState } from '../types';
 import { getProps, type XProps, type Props } from '../props/props';
 
 import type { CardStyle, CardPlaceholder } from './types';
@@ -21,7 +21,7 @@ export type PrerenderDetailsType = {|
 
 export type CardExport = ({|
     submit : () => ZalgoPromise<void>,
-    getState : () => String
+    getState : () => ZalgoPromise<CardFieldsState>
 |}) => ZalgoPromise<void>;
 
 export type OnChange = ({|

--- a/src/card/props.js
+++ b/src/card/props.js
@@ -21,8 +21,8 @@ export type PrerenderDetailsType = {|
 
 export type CardExport = ({|
     submit : () => ZalgoPromise<void>,
-    getState : () => any
-|}) => any;
+    getState : () => String
+|}) => ZalgoPromise<void>;
 
 export type OnChange = ({|
     isValid : boolean,

--- a/src/card/props.js
+++ b/src/card/props.js
@@ -21,8 +21,8 @@ export type PrerenderDetailsType = {|
 
 export type CardExport = ({|
     submit : () => ZalgoPromise<void>,
-    getState : () => String
-|}) => ZalgoPromise<void>;
+    getState : () => any
+|}) => any;
 
 export type OnChange = ({|
     isValid : boolean,

--- a/src/card/props.js
+++ b/src/card/props.js
@@ -20,7 +20,8 @@ export type PrerenderDetailsType = {|
 |};
 
 export type CardExport = ({|
-    submit : () => ZalgoPromise<void>
+    submit : () => ZalgoPromise<void>,
+    getState : () => String
 |}) => ZalgoPromise<void>;
 
 export type OnChange = ({|

--- a/src/card/types.js
+++ b/src/card/types.js
@@ -63,16 +63,42 @@ export type CardPlaceholder = {|
     postal?: string
 |};
 
+export type CardTypeCode = {|
+    name : string,
+    size : number
+ |}
+
 export type CardType = {|
     gaps : $ReadOnlyArray<number>,
     lengths : $ReadOnlyArray<number>,
     patterns : $ReadOnlyArray<number>,
     type : string,
     niceType : string,
-    code : {|
-        name : string,
-        size : number
-     |}
+    code : CardTypeCode
+|};
+
+export type ParsedCardType = {|
+    type: string,
+    niceType: string,
+    code : CardTypeCode
+|};
+
+export type CardFieldState = {|
+    isEmpty: boolean,
+    isValid: boolean,
+    isPotentiallyValid: boolean,
+    isFocused: boolean
+|}
+
+export type CardFieldsState = {|
+    cards : ParsedCardType,
+    fields: {|
+        cardName? : CardFieldState,
+        cardNumber : CardFieldState,
+        cardExpiry : CardFieldState,
+        cardCvv : CardFieldState,
+        cardPostalCode? : CardFieldState
+    |}
 |};
 
 export type InputEvent = {|

--- a/src/card/types.js
+++ b/src/card/types.js
@@ -1,3 +1,4 @@
+/* eslint-disable flowtype/require-exact-type */
 /* @flow */
 
 import type { FeatureFlags } from "../types"
@@ -72,6 +73,7 @@ export type CardType = {|
     gaps : $ReadOnlyArray<number>,
     lengths : $ReadOnlyArray<number>,
     patterns : $ReadOnlyArray<number>,
+    matchStrength? : number,
     type : string,
     niceType : string,
     code : CardTypeCode
@@ -90,16 +92,16 @@ export type CardFieldState = {|
     isFocused: boolean
 |}
 
-export type CardFieldsState = {|
-    cards : ParsedCardType,
-    fields: {|
+export type CardFieldsState = {
+    cards : $ReadOnlyArray<ParsedCardType>,
+    fields: {
         cardName? : CardFieldState,
         cardNumber : CardFieldState,
         cardExpiry : CardFieldState,
         cardCvv : CardFieldState,
         cardPostalCode? : CardFieldState
-    |}
-|};
+    }
+};
 
 export type InputEvent = {|
     key : string,
@@ -165,3 +167,4 @@ export type InputOptions = {|
 export type ExtraFields = {|
     billingAddress? : string
 |};
+/* eslint-enable flowtype/require-exact-type */

--- a/src/card/types.js
+++ b/src/card/types.js
@@ -13,7 +13,8 @@ export type Card = {|
     number : string,
     cvv? : string,
     expiry? : string,
-    name? : string
+    name? : string,
+    postalCode: string
 |};
 
 export type FieldStyle = {|

--- a/src/card/types.js
+++ b/src/card/types.js
@@ -9,13 +9,13 @@ export type SetupCardOptions = {|
     featureFlags: FeatureFlags
 |};
 
-export type Card = {|
+export type Card = {
     number : string,
     cvv? : string,
     expiry? : string,
     name? : string,
-    postalCode: string
-|};
+    postalCode? : string
+};
 
 export type FieldStyle = {|
     appearance? : string,

--- a/src/card/types.js
+++ b/src/card/types.js
@@ -125,6 +125,7 @@ export type InputState = {|
     cursorEnd : number,
     keyStrokeCount : number,
     isPotentiallyValid : boolean,
+    isFocused : boolean,
     isValid : boolean,
     contentPasted? : boolean,
     displayCardIcon?: boolean

--- a/src/card/types.js
+++ b/src/card/types.js
@@ -10,11 +10,11 @@ export type SetupCardOptions = {|
 |};
 
 export type Card = {
-    number : string,
-    cvv? : string,
-    expiry? : string,
-    name? : string,
-    postalCode? : string
+    number : ?string,
+    cvv? : ?string,
+    expiry? : ?string,
+    name? : ?string,
+    postalCode? : ?string
 };
 
 export type FieldStyle = {|


### PR DESCRIPTION
### Description
This adds the getState method to the unbranded multi-card fields. This method returns a state object to the merchant with the following information:

#### List of potential card types (Eg: Visa, Mastercard, AmEx) with the following properties
- code
- type
- niceType
#### A Field object for each rendered field with the following properties:
- isFocused
- isEmpty
- isPotentiallyValid
- isValid


### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
[DTNOR-487](https://engineering.paypalcorp.com/jira/browse/DTNOR-487)


### Dependent Changes (if applicable)
https://github.com/paypal/paypal-checkout-components/pull/2033

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->
### Groups who should review (if applicable)
https://github.com/orgs/paypal/teams/checkout-sdk

❤️  Thank you!

#### Authors
@jplukarski 
@nidhinarendra
@siddy2181

