### PR TITLE
Use mutation during onShippingChange patch call

### DIFF
--- a/src/props/props.js
+++ b/src/props/props.js
@@ -285,7 +285,7 @@ export function getProps({
     const onApprove = getOnApprove({ onApprove: xprops.onApprove, createBillingAgreement, createSubscription, intent, onError, partnerAttributionID, clientAccessToken, vault, clientID, facilitatorAccessToken, branded, createOrder, paymentSource, featureFlags });
     const onComplete = getOnComplete({ intent, onComplete: xprops.onComplete, partnerAttributionID, onError, clientID, facilitatorAccessToken, createOrder, featureFlags });
     const onCancel = getOnCancel({ onCancel: xprops.onCancel, onError }, { createOrder });
-    const onShippingChange = getOnShippingChange({ onShippingChange: xprops.onShippingChange, partnerAttributionID, featureFlags, clientID  }, { facilitatorAccessToken, createOrder });
+    const onShippingChange = getOnShippingChange({ onShippingChange: xprops.onShippingChange, clientID  }, { createOrder });
     const onShippingAddressChange = getOnShippingAddressChange({ onShippingAddressChange: xprops.onShippingAddressChange, clientID }, { createOrder });
     const onShippingOptionsChange = getOnShippingOptionsChange({ onShippingOptionsChange: xprops.onShippingOptionsChange, clientID }, { createOrder });
     const onAuth = getOnAuth({ facilitatorAccessToken, createOrder, createSubscription, featureFlags });

--- a/src/props/props.js
+++ b/src/props/props.js
@@ -285,7 +285,7 @@ export function getProps({
     const onApprove = getOnApprove({ onApprove: xprops.onApprove, createBillingAgreement, createSubscription, intent, onError, partnerAttributionID, clientAccessToken, vault, clientID, facilitatorAccessToken, branded, createOrder, paymentSource, featureFlags });
     const onComplete = getOnComplete({ intent, onComplete: xprops.onComplete, partnerAttributionID, onError, clientID, facilitatorAccessToken, createOrder, featureFlags });
     const onCancel = getOnCancel({ onCancel: xprops.onCancel, onError }, { createOrder });
-    const onShippingChange = getOnShippingChange({ onShippingChange: xprops.onShippingChange, partnerAttributionID, featureFlags  }, { facilitatorAccessToken, createOrder });
+    const onShippingChange = getOnShippingChange({ onShippingChange: xprops.onShippingChange, partnerAttributionID, featureFlags, clientID  }, { facilitatorAccessToken, createOrder });
     const onShippingAddressChange = getOnShippingAddressChange({ onShippingAddressChange: xprops.onShippingAddressChange, clientID }, { createOrder });
     const onShippingOptionsChange = getOnShippingOptionsChange({ onShippingOptionsChange: xprops.onShippingOptionsChange, clientID }, { createOrder });
     const onAuth = getOnAuth({ facilitatorAccessToken, createOrder, createSubscription, featureFlags });

--- a/src/types.js
+++ b/src/types.js
@@ -21,7 +21,8 @@ export const TYPES = true;
 // how to share this type between the two code bases
 export type FeatureFlags = $Shape<{|
     isLsatUpgradable: boolean;
-    shouldThrowIntegrationError: boolean
+    shouldThrowIntegrationError: boolean;
+    useShippingChangeCallbackMutation: boolean;
 |}>
 
 export type ProxyWindow = _ProxyWindow;


### PR DESCRIPTION
### Description
🚧 👷‍♂️ 🚧

This draft PR is proposing to use the patchShipping GQL mutation, instead of the patchOrder REST request, when updating shipping values from within the onShippingChange callback.

The exposed API does not change, but internally this brings onShippingChange more inline with the newer onShippingAddressChange and onShippingOptionsChange.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->
### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
