### PR TITLE
Conditionally use UpdateShipping mutation in onShippingChange

### DIFF
--- a/src/api/order.js
+++ b/src/api/order.js
@@ -33,7 +33,7 @@ export type OrderConfirmResponse = {||};
 export type OrderGetResponse = {||};
 export type OrderAuthorizeResponse = {||};
 
-type OrderAPIOptions = {|
+export type OrderAPIOptions = {|
     facilitatorAccessToken : string,
     buyerAccessToken? : ?string,
     partnerAttributionID : ?string,
@@ -265,7 +265,7 @@ export function authorizeOrder(orderID : string, { facilitatorAccessToken, buyer
     });
 }
 
-type PatchData = mixed;
+export type PatchData = mixed;
 
 export function patchOrder(orderID : string, data : PatchData, { facilitatorAccessToken, buyerAccessToken, partnerAttributionID, forceRestAPI = false } : OrderAPIOptions) : ZalgoPromise<OrderResponse> {
     getLogger().info(`patch_order_lsat_upgrade_${ getLsatUpgradeCalled() ? 'called' : 'not_called' }`);
@@ -325,8 +325,13 @@ export function patchOrder(orderID : string, data : PatchData, { facilitatorAcce
         return patchData;
     });
 }
+export type PatchShippingArgs = {|
+    clientID: string;
+    orderID: string;
+    data: PatchData,
+|}
 
-export function patchShipping({ clientID, orderID, data } : {|clientID : string, orderID : string, data : PatchData |}) : ZalgoPromise<OrderResponse> {
+export function patchShipping({ clientID, orderID, data } : PatchShippingArgs) : ZalgoPromise<OrderResponse> {
     return callGraphQL({
         name:  'UpdateShipping',
         query: `

--- a/src/button/button.js
+++ b/src/button/button.js
@@ -4,7 +4,7 @@ import { onClick as onElementClick, querySelectorAll, noop, stringifyErrorMessag
 import { FUNDING, COUNTRY, FPTI_KEY, type FundingEligibilityType } from '@paypal/sdk-constants/src';
 import { ZalgoPromise } from '@krakenjs/zalgo-promise/src';
 
-import type { ContentType, Wallet, PersonalizationType, FeatureFlags, InlinePaymentFieldsEligibility } from '../types';
+import type { ContentType, Wallet, PersonalizationType, Experiments, FeatureFlags, InlinePaymentFieldsEligibility } from '../types';
 import { getLogger, getSmartFieldsByFundingSource, setBuyerAccessToken, registerServiceWorker, unregisterServiceWorker } from '../lib';
 import { type FirebaseConfig } from '../api';
 import { DATA_ATTRIBUTES, BUYER_INTENT, FPTI_STATE } from '../constants';
@@ -39,6 +39,7 @@ export type SetupButtonOptions = {|
     cookies : string,
     personalization : PersonalizationType,
     brandedDefault? : boolean | null,
+    experiments?: Experiments;
     featureFlags: FeatureFlags,
     smartWalletOrderID? : string,
     enableOrdersApprovalSmartWallet? : boolean,
@@ -75,6 +76,7 @@ export function setupButton({
     personalization,
     correlationID: buttonCorrelationID = '',
     brandedDefault = null,
+    experiments = {},
     featureFlags,
     smartWalletOrderID,
     enableOrdersApprovalSmartWallet,
@@ -111,7 +113,7 @@ export function setupButton({
 
     const paymentSource = enableOrdersApprovalSmartWallet ? FUNDING.PAYPAL : null;
 
-    const props = getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource, featureFlags, enableOrdersApprovalSmartWallet, smartWalletOrderID });
+    const props = getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource, featureFlags, enableOrdersApprovalSmartWallet, smartWalletOrderID, experiments});
     const { env, sessionID, partnerAttributionID, commit, sdkCorrelationID, locale, onShippingChange,
         buttonSessionID, merchantDomain, onInit,
         getPrerenderDetails, rememberFunding, getQueriedEligibleFunding, experience,
@@ -210,7 +212,7 @@ export function setupButton({
             event.preventDefault();
             event.stopPropagation();
 
-            const paymentProps = getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource: paymentFundingSource, featureFlags, enableOrdersApprovalSmartWallet, smartWalletOrderID });
+            const paymentProps = getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource: paymentFundingSource, featureFlags, enableOrdersApprovalSmartWallet, smartWalletOrderID, experiments });
 
             const payPromise = initiatePayment({ payment, props: paymentProps });
             const { onError } = paymentProps;
@@ -252,7 +254,7 @@ export function setupButton({
                 throw new Error(`Can not find button element`);
             }
 
-            const paymentProps = getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource: paymentFundingSource, featureFlags, enableOrdersApprovalSmartWallet, smartWalletOrderID });
+            const paymentProps = getButtonProps({ facilitatorAccessToken, brandedDefault, paymentSource: paymentFundingSource, featureFlags, enableOrdersApprovalSmartWallet, smartWalletOrderID, experiments });
             const payment = { win, button, fundingSource: paymentFundingSource, card, buyerIntent: BUYER_INTENT.PAY };
             const payPromise = initiatePayment({ payment, props: paymentProps });
             const { onError } = paymentProps;

--- a/src/button/props.js
+++ b/src/button/props.js
@@ -6,7 +6,7 @@ import type { CustomStyle } from '@paypal/checkout-components/src/types';
 import { EXPERIENCE } from '@paypal/checkout-components/src/constants/button';
 
 import type { ContentType, ProxyWindow, Wallet, CheckoutFlowType, CardFormFlowType,
-    ThreeDomainSecureFlowType, MenuFlowType, PersonalizationType, QRCodeType, PaymentFieldsFlowType, InlinePaymentFieldsEligibility, FeatureFlags } from '../types';
+    ThreeDomainSecureFlowType, MenuFlowType, PersonalizationType, QRCodeType, PaymentFieldsFlowType, InlinePaymentFieldsEligibility, Experiments, FeatureFlags } from '../types';
 import { type FirebaseConfig } from '../api';
 import { getNonce } from '../lib';
 import { getProps, type XProps, type Props } from '../props/props';
@@ -50,6 +50,7 @@ export function getButtonProps({
     facilitatorAccessToken,
     brandedDefault,
     paymentSource,
+    experiments,
     featureFlags,
     enableOrdersApprovalSmartWallet,
     smartWalletOrderID
@@ -57,6 +58,7 @@ export function getButtonProps({
     facilitatorAccessToken : string,
     brandedDefault : boolean | null,
     paymentSource : $Values<typeof FUNDING> | null,
+    experiments: Experiments;
     featureFlags: FeatureFlags,
     enableOrdersApprovalSmartWallet? : boolean,
     smartWalletOrderID? : string
@@ -140,6 +142,7 @@ export function getButtonProps({
       branded,
       clientAccessToken,
       vault,
+      experiments,
       featureFlags,
       createBillingAgreement: xprops.createBillingAgreement,
       createSubscription: xprops.createSubscription,

--- a/src/button/props.test.js
+++ b/src/button/props.test.js
@@ -20,6 +20,7 @@ describe('getButtonProps', () => {
     shouldThrowIntegrationError: true,
   };
   const defaultArgs = {
+    experiments: {},
     facilitatorAccessToken,
     brandedDefault,
     paymentSource,

--- a/src/props/legacyProps.js
+++ b/src/props/legacyProps.js
@@ -2,7 +2,7 @@
 
 import { INTENT, FUNDING, CURRENCY } from '@paypal/sdk-constants/src';
 
-import type { FeatureFlags } from '../types';
+import type { Experiments, FeatureFlags } from '../types';
 
 import { getCreateBillingAgreement } from "./createBillingAgreement"
 import { getCreateSubscription } from "./createSubscription"
@@ -33,6 +33,7 @@ export type LegacyPropOptions = {|
   branded : boolean | null,
   clientAccessToken : ?string,
   vault : boolean,
+  experiments?: Experiments;
   featureFlags: FeatureFlags,
   onApprove : ?XOnApprove,
   onComplete? : ?XOnComplete,
@@ -80,6 +81,7 @@ export function getLegacyProps({
   branded,
   clientAccessToken,
   vault = false,
+  experiments = {},
   featureFlags,
   createBillingAgreement: inputCreateBillingAgreement,
   createSubscription: inputCreateSubscription,
@@ -100,7 +102,7 @@ export function getLegacyProps({
    const onApprove = getOnApprove({ onApprove: inputOnApprove, createBillingAgreement, createSubscription, intent, onError, partnerAttributionID, clientAccessToken, vault, clientID, facilitatorAccessToken, branded, createOrder, paymentSource, featureFlags });
    const onComplete = getOnComplete({ intent, onComplete: inputOnComplete, partnerAttributionID, onError, clientID, facilitatorAccessToken, createOrder, featureFlags });
    const onCancel = getOnCancel({ onCancel: inputOnCancel, onError }, { createOrder });
-   const onShippingChange = getOnShippingChange({ onShippingChange: inputOnShippingChange, partnerAttributionID, featureFlags  }, { facilitatorAccessToken, createOrder });
+   const onShippingChange = getOnShippingChange({ onShippingChange: inputOnShippingChange, partnerAttributionID, experiments, featureFlags, clientID }, { facilitatorAccessToken, createOrder });
    const onShippingAddressChange = getOnShippingAddressChange({ onShippingAddressChange: inputOnShippingAddressChange, clientID }, { createOrder });
    const onShippingOptionsChange = getOnShippingOptionsChange({ onShippingOptionsChange: inputOnShippingOptionsChange, clientID }, { createOrder });
    const onAuth = getOnAuth({ facilitatorAccessToken, createOrder, createSubscription, featureFlags });

--- a/src/props/legacyProps.test.js
+++ b/src/props/legacyProps.test.js
@@ -35,6 +35,7 @@ describe("legacyProps", () => {
       vault: false,
       clientAccessToken: "some access token",
       featureFlags: {},
+      experiments: {},
       createBillingAgreement: vi.fn(),
       createSubscription: vi.fn(),
       createOrder: vi.fn(),

--- a/src/props/onShippingChange.test.js
+++ b/src/props/onShippingChange.test.js
@@ -1,0 +1,129 @@
+/** @flow */
+
+import { uniqueID } from "@krakenjs/belter/src";
+import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
+import { type LoggerType } from '@krakenjs/beaver-logger/src';
+
+import { getLogger } from "../lib";
+import { patchShipping, patchOrder, type PatchData, type OrderAPIOptions, type OrderResponse, type PatchShippingArgs } from "../api";
+
+
+import { getOnShippingChange } from "./onShippingChange";
+
+jest.mock("../api");
+jest.mock("./createOrder");
+jest.mock("../lib");
+
+const mockPatchOrder: JestMockFn<[string, PatchData, OrderAPIOptions], ZalgoPromise<OrderResponse>> = patchOrder;
+
+const mockPatchShipping: JestMockFn<[PatchShippingArgs], ZalgoPromise<OrderResponse>> = patchShipping;
+
+const mockGetLogger: JestMockFn<[], LoggerType> = getLogger;
+
+describe("onShippingChange", () => {
+    describe("getOnShippingChange", () => {
+        let clientID;
+        let facilitatorAccessToken;
+        let partnerAttributionID;
+        let orderID;
+        const createOrder = jest.fn();
+        const invocationActions = {
+            reject: () => ZalgoPromise.reject(),
+            resolve: () => ZalgoPromise.resolve(),
+        };
+        const featureFlags = { isLsatUpgradable: false };
+
+        beforeEach(() => {
+            clientID = uniqueID();
+            facilitatorAccessToken = uniqueID();
+            partnerAttributionID = uniqueID();
+            orderID = uniqueID();
+            createOrder.mockImplementation(() => ZalgoPromise.resolve(orderID));
+            
+            // $FlowFixMe
+            mockGetLogger.mockReturnValue({
+                // $FlowFixMe
+                info: () => ({
+                    // $FlowFixMe
+                    track: () => ({ flush: () => undefined }),
+                }),
+            });
+        });
+
+        it("should call patchOrder", async () => {
+            // $FlowFixMe
+            mockPatchOrder.mockImplementation(() => ZalgoPromise.resolve({}));
+
+            const patchData = [];
+            const onShippingChange = jest.fn((data, actions) => {
+                actions.order.patch(patchData);
+                return ZalgoPromise.resolve();
+            });
+
+            const experiments = { useShippingChangeCallbackMutation: false };
+
+            const buyerAccessToken = uniqueID();
+
+            const fn = getOnShippingChange(
+                {
+                    onShippingChange,
+                    partnerAttributionID,
+                    featureFlags,
+                    experiments,
+                    clientID,
+                },
+                { facilitatorAccessToken, createOrder }
+            );
+
+            const data = { buyerAccessToken };
+
+            if (fn) {
+                await fn(data, invocationActions);
+                expect(patchOrder).toBeCalledWith(orderID, patchData, {
+                    facilitatorAccessToken,
+                    buyerAccessToken,
+                    partnerAttributionID,
+                    forceRestAPI: featureFlags.isLsatUpgradable,
+                });
+            }
+
+            expect.assertions(1);
+        });
+
+        it("should call patchShipping when experiment is active", async () => {
+            // $FlowFixMe
+            mockPatchShipping.mockImplementation(() => ZalgoPromise.resolve({}));
+
+            const patchData = [];
+            const onShippingChange = jest.fn((data, actions) => {
+                actions.order.patch(patchData);
+                return ZalgoPromise.resolve();
+            });
+
+            const experiments = { useShippingChangeCallbackMutation: true };
+
+            const fn = getOnShippingChange(
+                {
+                    onShippingChange,
+                    partnerAttributionID,
+                    featureFlags,
+                    experiments,
+                    clientID,
+                },
+                { facilitatorAccessToken, createOrder }
+            );
+
+            if (fn) {
+                await fn({}, invocationActions);
+            }
+
+            expect(patchShipping).toBeCalledWith({
+                clientID,
+                data: patchData,
+                orderID,
+            });
+
+            expect.assertions(1);
+        });
+    });
+});

--- a/src/props/onShippingChange.test.js
+++ b/src/props/onShippingChange.test.js
@@ -2,128 +2,141 @@
 
 import { uniqueID } from "@krakenjs/belter/src";
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
-import { type LoggerType } from '@krakenjs/beaver-logger/src';
+import { type LoggerType } from "@krakenjs/beaver-logger/src";
+import { describe, beforeEach, test, expect, vi } from "vitest";
 
+import {
+  patchShipping,
+  patchOrder,
+  type PatchData,
+  type OrderAPIOptions,
+  type OrderResponse,
+  type PatchShippingArgs,
+} from "../api";
 import { getLogger } from "../lib";
-import { patchShipping, patchOrder, type PatchData, type OrderAPIOptions, type OrderResponse, type PatchShippingArgs } from "../api";
-
 
 import { getOnShippingChange } from "./onShippingChange";
 
-jest.mock("../api");
-jest.mock("./createOrder");
-jest.mock("../lib");
+vi.mock("../api");
+vi.mock("./createOrder");
+vi.mock("../lib");
 
-const mockPatchOrder: JestMockFn<[string, PatchData, OrderAPIOptions], ZalgoPromise<OrderResponse>> = patchOrder;
+const mockPatchOrder: JestMockFn<
+  [string, PatchData, OrderAPIOptions],
+  ZalgoPromise<OrderResponse>
+> = patchOrder;
 
-const mockPatchShipping: JestMockFn<[PatchShippingArgs], ZalgoPromise<OrderResponse>> = patchShipping;
+const mockPatchShipping: JestMockFn<
+  [PatchShippingArgs],
+  ZalgoPromise<OrderResponse>
+> = patchShipping;
 
 const mockGetLogger: JestMockFn<[], LoggerType> = getLogger;
 
 describe("onShippingChange", () => {
-    describe("getOnShippingChange", () => {
-        let clientID;
-        let facilitatorAccessToken;
-        let partnerAttributionID;
-        let orderID;
-        const createOrder = jest.fn();
-        const invocationActions = {
-            reject: () => ZalgoPromise.reject(),
-            resolve: () => ZalgoPromise.resolve(),
-        };
-        const featureFlags = { isLsatUpgradable: false };
+  describe("getOnShippingChange", () => {
+    let clientID;
+    let facilitatorAccessToken;
+    let partnerAttributionID;
+    let orderID;
+    const createOrder = vi.fn();
+    const invocationActions = {
+      reject: () => ZalgoPromise.reject(),
+      resolve: () => ZalgoPromise.resolve(),
+    };
+    const featureFlags = { isLsatUpgradable: false };
 
-        beforeEach(() => {
-            clientID = uniqueID();
-            facilitatorAccessToken = uniqueID();
-            partnerAttributionID = uniqueID();
-            orderID = uniqueID();
-            createOrder.mockImplementation(() => ZalgoPromise.resolve(orderID));
-            
-            // $FlowFixMe
-            mockGetLogger.mockReturnValue({
-                // $FlowFixMe
-                info: () => ({
-                    // $FlowFixMe
-                    track: () => ({ flush: () => undefined }),
-                }),
-            });
-        });
+    beforeEach(() => {
+      clientID = uniqueID();
+      facilitatorAccessToken = uniqueID();
+      partnerAttributionID = uniqueID();
+      orderID = uniqueID();
+      createOrder.mockImplementation(() => ZalgoPromise.resolve(orderID));
 
-        it("should call patchOrder", async () => {
-            // $FlowFixMe
-            mockPatchOrder.mockImplementation(() => ZalgoPromise.resolve({}));
-
-            const patchData = [];
-            const onShippingChange = jest.fn((data, actions) => {
-                actions.order.patch(patchData);
-                return ZalgoPromise.resolve();
-            });
-
-            const experiments = { useShippingChangeCallbackMutation: false };
-
-            const buyerAccessToken = uniqueID();
-
-            const fn = getOnShippingChange(
-                {
-                    onShippingChange,
-                    partnerAttributionID,
-                    featureFlags,
-                    experiments,
-                    clientID,
-                },
-                { facilitatorAccessToken, createOrder }
-            );
-
-            const data = { buyerAccessToken };
-
-            if (fn) {
-                await fn(data, invocationActions);
-                expect(patchOrder).toBeCalledWith(orderID, patchData, {
-                    facilitatorAccessToken,
-                    buyerAccessToken,
-                    partnerAttributionID,
-                    forceRestAPI: featureFlags.isLsatUpgradable,
-                });
-            }
-
-            expect.assertions(1);
-        });
-
-        it("should call patchShipping when experiment is active", async () => {
-            // $FlowFixMe
-            mockPatchShipping.mockImplementation(() => ZalgoPromise.resolve({}));
-
-            const patchData = [];
-            const onShippingChange = jest.fn((data, actions) => {
-                actions.order.patch(patchData);
-                return ZalgoPromise.resolve();
-            });
-
-            const experiments = { useShippingChangeCallbackMutation: true };
-
-            const fn = getOnShippingChange(
-                {
-                    onShippingChange,
-                    partnerAttributionID,
-                    featureFlags,
-                    experiments,
-                    clientID,
-                },
-                { facilitatorAccessToken, createOrder }
-            );
-
-            if (fn) {
-                await fn({}, invocationActions);
-            }
-
-            expect(patchShipping).toBeCalledWith({
-                clientID,
-                data: patchData,
-                orderID,
-            });
-
-            expect.assertions(1);
-        });
+      // $FlowFixMe
+      mockGetLogger.mockReturnValue({
+        // $FlowFixMe
+        info: () => ({
+          // $FlowFixMe
+          track: () => ({ flush: () => undefined }),
+        }),
+      });
     });
+
+    test("should call patchOrder", async () => {
+      // $FlowFixMe
+      mockPatchOrder.mockImplementation(() => ZalgoPromise.resolve({}));
+
+      const patchData = [];
+      const onShippingChange = vi.fn((data, actions) => {
+        actions.order.patch(patchData);
+        return ZalgoPromise.resolve();
+      });
+
+      const experiments = { useShippingChangeCallbackMutation: false };
+
+      const buyerAccessToken = uniqueID();
+
+      const fn = getOnShippingChange(
+        {
+          onShippingChange,
+          partnerAttributionID,
+          featureFlags,
+          experiments,
+          clientID,
+        },
+        { facilitatorAccessToken, createOrder }
+      );
+
+      const data = { buyerAccessToken };
+
+      if (fn) {
+        await fn(data, invocationActions);
+        expect(patchOrder).toBeCalledWith(orderID, patchData, {
+          facilitatorAccessToken,
+          buyerAccessToken,
+          partnerAttributionID,
+          forceRestAPI: featureFlags.isLsatUpgradable,
+        });
+      }
+
+      expect.assertions(1);
+    });
+
+    test("should call patchShipping when experiment is active", async () => {
+      // $FlowFixMe
+      mockPatchShipping.mockImplementation(() => ZalgoPromise.resolve({}));
+
+      const patchData = [];
+      const onShippingChange = vi.fn((data, actions) => {
+        actions.order.patch(patchData);
+        return ZalgoPromise.resolve();
+      });
+
+      const experiments = { useShippingChangeCallbackMutation: true };
+
+      const fn = getOnShippingChange(
+        {
+          onShippingChange,
+          partnerAttributionID,
+          featureFlags,
+          experiments,
+          clientID,
+        },
+        { facilitatorAccessToken, createOrder }
+      );
+
+      if (fn) {
+        await fn({}, invocationActions);
+      }
+
+      expect(patchShipping).toBeCalledWith({
+        clientID,
+        data: patchData,
+        orderID,
+      });
+
+      expect.assertions(1);
+    });
+  });
 });

--- a/src/types.js
+++ b/src/types.js
@@ -21,7 +21,14 @@ export const TYPES = true;
 // how to share this type between the two code bases
 export type FeatureFlags = $Shape<{|
     isLsatUpgradable: boolean;
-    shouldThrowIntegrationError: boolean
+    shouldThrowIntegrationError: boolean;
+|}>
+
+// This type is shared with smartcomponentnodeweb
+// When we move to typescript we should figure out
+// how to share this type between the two code bases
+export type Experiments = $Shape<{|
+    useShippingChangeCallbackMutation?: boolean;
 |}>
 
 export type ProxyWindow = _ProxyWindow;


### PR DESCRIPTION
### Description
See #525 for history. 

Use a newly passed Elmo experiment to conditionally use the UpdateShipping mutation in the onShippingChange callback function. 

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
https://paypal.atlassian.net/browse/DTOPPOR-1189
Uses a new Elmo experiment to conditionally use the UpdateShipping mutation, rather than Patch Order REST call, when the onShippingChange callback is called.

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)
Elmo: https://internal.msmaster.qa.paypal.com/elmo/experiment/125252
smartcomponents PR: https://paypal.atlassian.net/browse/DTOPPOR-1189

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->
### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
