### PR TITLE
Remove env logic from isNativeEligible()

### DIFF
--- a/src/payment-flows/native/eligibility.js
+++ b/src/payment-flows/native/eligibility.js
@@ -176,10 +176,6 @@ export function isNativeEligible({ props, config, serviceData } : IsEligibleOpti
         return false;
     }
 
-    if (env === ENV.LOCAL || env === ENV.STAGE) {
-        return false;
-    }
-
     if (merchantID.length > 1) {
         return false;
     }


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
**Jira**:  [LI-4619](https://paypal.atlassian.net/browse/LI-4619)

On stage right now, if you use the Venmo button when trying to create a billing agreement, it defaults to the fallback.  We don't need this logic anymore. 😄

### Reproduction Steps (if applicable)
1. On stage, try to create a billing agreement with Venmo.
2. Before this change: You will see the fallback modal saying "We weren't able to open Venmo".
3. After this change: You should see the normal popup

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->
### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->
@elizabethmv 

❤️  Thank you!
