### PR TITLE
Fixed bug where cardExpiryToPaymentSourceExpiry returns the wrong date

### DIFF
--- a/src/card/lib/index.js
+++ b/src/card/lib/index.js
@@ -8,7 +8,7 @@ export * from "./card-utils";
 export * from "./exports";
 export * from "./methods";
 
-const cardExpiryToPaymentSourceExpiry = (dateString: string): string => {
+export const cardExpiryToPaymentSourceExpiry = (dateString: string): string => {
   if (!dateString || typeof dateString !== "string") {
     throw new Error(`can not convert invalid expiry date: ${dateString}`);
   }
@@ -24,15 +24,11 @@ const cardExpiryToPaymentSourceExpiry = (dateString: string): string => {
 
   if (dateString.match(mmYYYYRegex)) {
     const [monthString, yearString] = dateString.split("/");
+    
+    const formattedYearString = yearString.length === 2 ? `20${yearString}` : yearString;
+    const formattedMonthString = monthString.length === 1 ? `0${monthString}` : monthString;
 
-    // if using 23 instead of 2023, the Date class will interpret the year as 1923
-    const formattedYearString = yearString.length === 2 ? `20${yearString}` : yearString
-    const date = new Date(parseInt(formattedYearString, 10), parseInt(monthString, 10))
-    const rawMonth = date.getMonth();
-    // the Date class returns month as 1-12, we'd like to append a 0 to numbers less than 10
-    const formattedMonth = rawMonth < 10 ? `0${rawMonth}` : rawMonth.toString()
-
-    return `${date.getFullYear()}-${formattedMonth}`
+    return `${formattedYearString}-${formattedMonthString}`;
   }
 
   throw new Error(`can not convert invalid expiry date: ${dateString}`);

--- a/src/card/lib/index.test.js
+++ b/src/card/lib/index.test.js
@@ -1,5 +1,5 @@
 /* @flow */
-import { convertCardToPaymentSource } from "./index";
+import { convertCardToPaymentSource, cardExpiryToPaymentSourceExpiry } from "./index";
 
 const testCard = "4111111111111111";
 const testSecurityCode = "100";
@@ -60,5 +60,57 @@ describe("convertCardToPaymentSource", () => {
         cvv: testSecurityCode,
       })
     ).toThrowError(`can not convert invalid expiry date: ${badDate}`);
+  });
+});
+
+describe("cardExpiryToPaymentSourceExpiry", () => {
+  it("returns the same input string when the input string is already in YYYY-mm format", () => {
+    const input = "2023-02";
+    expect(cardExpiryToPaymentSourceExpiry(input)).toEqual(input);
+  });
+
+  it("converts mm/YYYY input to YYYY-mm format for first month", () => {
+    const input1 = "01/2024";
+    const input2 = "1/24";
+    const expectedOutput = "2024-01";
+    expect(cardExpiryToPaymentSourceExpiry(input1)).toEqual(expectedOutput);
+    expect(cardExpiryToPaymentSourceExpiry(input2)).toEqual(expectedOutput);
+  });
+
+  it("converts mm/YYYY input to YYYY-mm format for a middle month", () => {
+    const input1 = "04/2024";
+    const input2 = "4/24";
+    const expectedOutput = "2024-04";
+    expect(cardExpiryToPaymentSourceExpiry(input1)).toEqual(expectedOutput);
+    expect(cardExpiryToPaymentSourceExpiry(input2)).toEqual(expectedOutput);
+  });
+
+  it("converts mm/YYYY input to YYYY-mm format for last month", () => {
+    const input1 = "12/2024";
+    const input2 = "12/24";
+    const expectedOutput = "2024-12";
+    expect(cardExpiryToPaymentSourceExpiry(input1)).toEqual(expectedOutput);
+    expect(cardExpiryToPaymentSourceExpiry(input2)).toEqual(expectedOutput);
+  });
+
+  it("throws an error when the input string is not in the expected format", () => {
+    const input = "2023/02";
+    expect(() => {
+      cardExpiryToPaymentSourceExpiry(input);
+    }).toThrowError(`can not convert invalid expiry date: ${input}`);
+  });
+
+  it("throws an error when the input is not a string", () => {
+    const input = 123;
+    expect(() => {
+      cardExpiryToPaymentSourceExpiry(input);
+    }).toThrowError(`can not convert invalid expiry date: ${input}`);
+  });
+
+  it("throws an error when the input is empty", () => {
+    const input = "";
+    expect(() => {
+      cardExpiryToPaymentSourceExpiry(input);
+    }).toThrowError(`can not convert invalid expiry date: ${input}`);
   });
 });


### PR DESCRIPTION
### Description

Refactored `cardExpiryToPaymentSourceExpiry(dateString)` function to return the expected month when the card expiry date is in December. Added unit tests for this function.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)
Submit HCFs with a December card expiry date (12/2023, 12/23, etc.)
The order will be submitted with the wrong date.

### Screenshots (if applicable)
![Screenshot 2023-02-28 at 13 22 47](https://user-images.githubusercontent.com/63573634/221994727-c69f861f-5903-407d-9e61-3fd41c4bda13.png)

❤️  Thank you!
