### PR TITLE
preventing onSubmit if cardholder name is invalid

### DIFF
--- a/src/button/logger.js
+++ b/src/button/logger.js
@@ -190,7 +190,7 @@ export function setupButtonLogger({ env, sessionID, buttonSessionID, clientID, p
             [FPTI_KEY.SELECTED_FI]:                     fundingSource,
             [FPTI_KEY.FUNDING_COUNT]:                   fundingSources.length.toString(),
             [FPTI_KEY.PAGE_LOAD_TIME]:                  pageRenderTime ? pageRenderTime.toString() : '',
-            [FPTI_KEY.POTENTIAL_PAYMENT_METHODS]:       queriedEligibleFunding.join(':'),
+            [FPTI_KEY.POTENTIAL_PAYMENT_METHODS]:       Array.isArray(queriedEligibleFunding) ? queriedEligibleFunding.join(':') : '',
             [FPTI_KEY.PAY_NOW]:                         payNow.toString(),
             [FPTI_BUTTON_KEY.BUTTON_LAYOUT]:            layout,
             [FPTI_BUTTON_KEY.BUTTON_COLOR]:             color,

--- a/src/card/constants.js
+++ b/src/card/constants.js
@@ -53,6 +53,8 @@ export const CARD_FIELD_TYPE_TO_FRAME_NAME : {| [$Values<typeof CARD_FIELD_TYPE>
     [ CARD_FIELD_TYPE.POSTAL ]: FRAME_NAME.CARD_POSTAL_FIELD
 };
 
+export const OPTIONAL_CARD_FIELDS: $ReadOnlyArray<string> = ['name'];
+
 export const FIELD_STYLE : FieldStyle = {
     appearance:              'appearance',
     color:                   'color',

--- a/src/card/interface/getCardFields.js
+++ b/src/card/interface/getCardFields.js
@@ -1,13 +1,14 @@
 /* @flow */
 
 import { FRAME_NAME } from '../../constants';
+import { CARD_ERRORS } from '../constants';
 import type { Card } from '../types';
 
 import { getExportsByFrameName } from './getExportsByFrameName';
 import { getCardFrames } from './getCardFrames';
 
 export function getCardFields(): Card {
-  const card = {}
+  const card = {};
   const cardFrame = getExportsByFrameName(FRAME_NAME.CARD_FIELD);
 
   if (cardFrame && cardFrame.isFieldValid()) {
@@ -22,30 +23,44 @@ export function getCardFields(): Card {
     cardPostalFrame
   } = getCardFrames();
 
-  if (
-    cardNumberFrame &&
-    cardNumberFrame.isFieldValid() &&
-    cardCVVFrame &&
-    cardCVVFrame.isFieldValid() &&
-    cardExpiryFrame &&
-    cardExpiryFrame.isFieldValid()
-    ) {
-      card.number = cardNumberFrame.getFieldValue()
-      card.cvv = cardCVVFrame.getFieldValue()
-      card.expiry = cardExpiryFrame.getFieldValue()
-    } else {
-      throw new Error(`Card fields not available to submit`);
+  // 3 Required fields for HCFs purchase
+  if (cardNumberFrame && cardNumberFrame.isFieldValid()) {
+    card.number = cardNumberFrame.getFieldValue();
+  } else {
+    throw new Error(CARD_ERRORS.INVALID_NUMBER);
+  }
+
+  if (cardCVVFrame && cardCVVFrame.isFieldValid()) {
+    card.cvv = cardCVVFrame.getFieldValue();
+  } else {
+    throw new Error(CARD_ERRORS.INVALID_CVV);
+  }
+
+  if (cardExpiryFrame && cardExpiryFrame.isFieldValid()) {
+    card.expiry = cardExpiryFrame.getFieldValue();
+  } else {
+    throw new Error(CARD_ERRORS.INVALID_EXPIRY);
+  }
+
+  // cardNameFrame and cardPostalFrame are optional fields so we only want to check the validity if they are rendered and non-blank.
+  // Postal code is not available for now, it will be added when billing address fields are complete.
+  if (cardNameFrame) {
+    const cardNameValue = cardNameFrame.getFieldValue();
+    if (cardNameFrame.isFieldValid()) {
+      card.name = cardNameValue;
+    } else if (cardNameValue.length !== 0) {
+      throw new Error(CARD_ERRORS.INVALID_NAME);
     }
-
-  // cardNameFrame and cardPostalFrame are optional fields so we only want to check the validity if they are rendered.
-  if ( cardNameFrame && cardNameFrame.isFieldValid() ) {
-    card.name = cardNameFrame.getFieldValue()
   }
 
-  if (cardPostalFrame && cardPostalFrame.isFieldValid()) {
-    card.postalCode = cardPostalFrame.getFieldValue()
+  if (cardPostalFrame) {
+    const postalCodeValue = cardPostalFrame.getFieldValue();
+    if (cardPostalFrame.isFieldValid()) {
+      card.name = postalCodeValue;
+    } else if (postalCodeValue.length !== 0) {
+      throw new Error(CARD_ERRORS.INVALID_POSTAL);
+    }
   }
 
-  return card
-
+  return card;
 }

--- a/src/card/lib/card-utils.js
+++ b/src/card/lib/card-utils.js
@@ -13,7 +13,8 @@ import {
     FILTER_CSS_VALUES,
     GQL_ERRORS,
     VALID_EXTRA_FIELDS,
-    ALLOWED_ATTRIBUTES
+    ALLOWED_ATTRIBUTES,
+    OPTIONAL_CARD_FIELDS
 } from '../constants';
 import { getLogger } from '../../lib';
 
@@ -154,11 +155,18 @@ export function getCSSText(cardFieldStyle : Object, customStyle : Object) : stri
     return s.join('\n');
 }
 
+export function isFieldOptional(element: HTMLInputElement): boolean {
+    return OPTIONAL_CARD_FIELDS.includes(element.name);
+}
+
 // mark the ref's HTMLElement as valid or invalid
-export function markValidity(ref : Object, validity : FieldValidity, hasFocus?: boolean, touched?: boolean ) {
-    const element = ref?.current?.base;
+export function markValidity(ref : Object, validity : FieldValidity, hasFocus?: boolean, touched?: boolean) {
+    const element: HTMLInputElement = ref?.current?.base;
     if (element) {
-        if (validity.isValid || (validity.isPotentiallyValid && hasFocus)) {
+        if (isFieldOptional(element) && element.value.length === 0) {
+            element.classList.remove('valid');
+            element.classList.remove('invalid');
+        } else if (validity.isValid || (validity.isPotentiallyValid && hasFocus)) {
             element.classList.add('valid');
             element.classList.remove('invalid');
         } else if(touched){

--- a/src/card/lib/card-utils.test.js
+++ b/src/card/lib/card-utils.test.js
@@ -891,6 +891,54 @@ describe("filterExtraFields", () => {
       expect(element.classList.contains("invalid")).toBe(false);
       expect(element.classList.contains("valid")).toBe(true);
     });
+
+    it("removes valid and invalid class from element when field is optional and blank", () => {
+      const element = document.createElement("input");
+      element.name = "name";
+      element.value = "";
+
+      const ref = {
+        current: {
+          base: element,
+        },
+      };
+
+      const validity = {
+        isValid: false,
+        isPotentiallyValid: true,
+      };
+
+      const hasFocus = false;
+      const touched = true;
+      markValidity(ref, validity, hasFocus, touched);
+
+      expect(element.classList.contains("invalid")).toBe(false);
+      expect(element.classList.contains("valid")).toBe(false);
+    });
+
+    it("marks HTMLElement as invalid when field is required and blank", () => {
+      const element = document.createElement("input");
+      element.name = "requiredField";
+      element.value = "";
+
+      const ref = {
+        current: {
+          base: element,
+        },
+      };
+
+      const validity = {
+        isValid: false,
+        isPotentiallyValid: true,
+      };
+
+      const hasFocus = false;
+      const touched = true;
+      markValidity(ref, validity, hasFocus, touched);
+
+      expect(element.classList.contains("invalid")).toBe(true);
+      expect(element.classList.contains("valid")).toBe(false);
+    });
   });
 
   describe("shouldUseZeroPaddedExpiryPattern", () => {


### PR DESCRIPTION
### Description

Preventing `submitCardFields()` to complete if the cardholder name is invalid. This change is for all optional fields. The expected behaviour is to prevent any API calls to happen if we know there's a mistake on the forms, and log them for the merchant.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
https://paypal.atlassian.net/browse/DTCURIOSTY-8477
https://paypal.atlassian.net/browse/DTNOR-863

### Reproduction Steps (if applicable)

Render the cardholderName field, and fill it out using only digits. The payment should not be going through, but it's currently ignoring this field as it's an optional field. This fix will prevent the flow from continuing.

❤️  Thank you!
