### PR TITLE
remove unneeded get setup token call

### DIFF
--- a/src/api/vault.js
+++ b/src/api/vault.js
@@ -103,10 +103,12 @@ export const updateVaultSetupToken = ({
   clientID,
   vaultSetupToken,
   paymentSource,
+  idToken,
 }: {|
   clientID: string,
   vaultSetupToken: string,
   paymentSource: PaymentSourceInput,
+  idToken: string,
 |}): ZalgoPromise<{| id: string, status: VaultTokenStatus |}> =>
   callGraphQL<{| id: string, status: VaultTokenStatus |}>({
     name: "UpdateVaultSetupToken",
@@ -115,11 +117,13 @@ export const updateVaultSetupToken = ({
         $clientID: String!
         $vaultSetupToken: String!
         $paymentSource: PaymentSource
+        $idToken: String!
       ) {
         updateVaultSetupToken(
           clientId: $clientID
           vaultSetupToken: $vaultSetupToken
           paymentSource: $paymentSource
+          idToken: $idToken
         ) {
           id,
           status
@@ -129,5 +133,6 @@ export const updateVaultSetupToken = ({
       clientID,
       vaultSetupToken,
       paymentSource,
+      idToken,
     },
   });

--- a/src/card/interface/submitCardFields.js
+++ b/src/card/interface/submitCardFields.js
@@ -48,6 +48,7 @@ export function submitCardFields({
         onError: cardProps.onError,
         clientID: cardProps.clientID,
         paymentSource: convertCardToPaymentSource(card, extraFields),
+        idToken: cardProps.userIDToken || "",
       });
     }
     let orderID;

--- a/src/card/interface/submitCardFields.js
+++ b/src/card/interface/submitCardFields.js
@@ -46,7 +46,6 @@ export function submitCardFields({
         onApprove: cardProps.onApprove,
         createVaultSetupToken: cardProps.createVaultSetupToken,
         onError: cardProps.onError,
-        facilitatorAccessToken,
         clientID: cardProps.clientID,
         paymentSource: convertCardToPaymentSource(card, extraFields),
       });

--- a/src/card/interface/submitCardFields.test.js
+++ b/src/card/interface/submitCardFields.test.js
@@ -74,7 +74,7 @@ describe("submitCardFields", () => {
     );
   });
 
-  test("should use the provided save action", async () => {
+  test("should do a vault without purchase", async () => {
     const createVaultSetupToken = vi.fn().mockResolvedValue("setup-token");
     const onApprove = vi.fn();
 
@@ -92,6 +92,7 @@ describe("submitCardFields", () => {
     expect(resetGQLErrors).toHaveBeenCalledOnce();
     expect(savePaymentSource).toHaveBeenCalledWith({
       ...mockGetCardPropsReturn,
+      idToken: "",
       paymentSource: {
         card: {
           billingAddress: {

--- a/src/card/interface/submitCardFields.test.js
+++ b/src/card/interface/submitCardFields.test.js
@@ -92,7 +92,6 @@ describe("submitCardFields", () => {
     expect(resetGQLErrors).toHaveBeenCalledOnce();
     expect(savePaymentSource).toHaveBeenCalledWith({
       ...mockGetCardPropsReturn,
-      facilitatorAccessToken: defaultOptions.facilitatorAccessToken,
       paymentSource: {
         card: {
           billingAddress: {

--- a/src/card/interface/vault-without-purchase.js
+++ b/src/card/interface/vault-without-purchase.js
@@ -33,6 +33,7 @@ type VaultPaymenSourceOptions = {|
   onError: XOnError,
   clientID: string,
   paymentSource: PaymentSourceInput,
+  idToken: string,
 |};
 
 export const savePaymentSource = ({
@@ -41,6 +42,7 @@ export const savePaymentSource = ({
   onError,
   clientID,
   paymentSource,
+  idToken,
 }: VaultPaymenSourceOptions): ZalgoPromise<void> => {
   return createVaultSetupToken()
     .then((vaultSetupToken) =>
@@ -48,6 +50,9 @@ export const savePaymentSource = ({
         vaultSetupToken,
         clientID,
         paymentSource,
+        // passing the id token here is a temporary fix until we can deploy xobuyernodeserv
+        // to treak idToken as an optional field.
+        idToken,
       })
         .then(() => onApprove({ vaultSetupToken }))
         .then(() =>

--- a/src/card/interface/vault-without-purchase.js
+++ b/src/card/interface/vault-without-purchase.js
@@ -3,7 +3,6 @@
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/src";
 
 import {
-  getVaultSetupToken,
   updateVaultSetupToken,
   type PaymentSourceInput,
 } from "../../api/vault";
@@ -11,22 +10,28 @@ import {
   vaultWithoutPurchaseSuccess,
   vaultWithoutPurchaseFailure,
 } from "../logger";
-import type { XOnError, XCreateVaultSetupToken, SaveActionOnApprove } from "../../props";
+import type {
+  XOnError,
+  XCreateVaultSetupToken,
+  SaveActionOnApprove,
+} from "../../props";
 
-const onVaultWithoutPurchaseError = ({vaultToken, onError}: {|vaultToken?: string, onError: XOnError|}) => (error: mixed) => {
-  vaultWithoutPurchaseFailure({
-    vaultToken, error
-  })
+const onVaultWithoutPurchaseError =
+  ({ vaultToken, onError }: {| vaultToken?: string, onError: XOnError |}) =>
+  (error: mixed) => {
+    vaultWithoutPurchaseFailure({
+      vaultToken,
+      error,
+    });
 
-  onError(error)
-}
+    onError(error);
+  };
 
 type VaultPaymenSourceOptions = {|
   createVaultSetupToken: XCreateVaultSetupToken,
   onApprove: SaveActionOnApprove,
   onError: XOnError,
   clientID: string,
-  facilitatorAccessToken: string,
   paymentSource: PaymentSourceInput,
 |};
 
@@ -34,29 +39,23 @@ export const savePaymentSource = ({
   createVaultSetupToken,
   onApprove,
   onError,
-  facilitatorAccessToken,
   clientID,
   paymentSource,
 }: VaultPaymenSourceOptions): ZalgoPromise<void> => {
-
   return createVaultSetupToken()
     .then((vaultSetupToken) =>
-      getVaultSetupToken({
+      updateVaultSetupToken({
         vaultSetupToken,
-        facilitatorAccessToken,
+        clientID,
+        paymentSource,
       })
-        .then(() =>
-          updateVaultSetupToken({
-            vaultSetupToken,
-            clientID,
-            paymentSource,
-          })
-        )
         .then(() => onApprove({ vaultSetupToken }))
         .then(() =>
           vaultWithoutPurchaseSuccess({ vaultToken: vaultSetupToken })
         )
-        .catch(onVaultWithoutPurchaseError({onError, vaultToken: vaultSetupToken}))
+        .catch(
+          onVaultWithoutPurchaseError({ onError, vaultToken: vaultSetupToken })
+        )
     )
-    .catch(onVaultWithoutPurchaseError({onError}));
+    .catch(onVaultWithoutPurchaseError({ onError }));
 };

--- a/src/card/interface/vault-without-purchase.test.js
+++ b/src/card/interface/vault-without-purchase.test.js
@@ -1,7 +1,7 @@
 /* @flow */
 import { describe, afterEach, vi, test, expect, beforeEach } from "vitest";
 
-import { getVaultSetupToken, updateVaultSetupToken } from "../../api/vault";
+import { updateVaultSetupToken } from "../../api/vault";
 import {
   vaultWithoutPurchaseSuccess,
   vaultWithoutPurchaseFailure,
@@ -15,8 +15,6 @@ vi.mock("../../../src/api/vault");
 
 describe("savePaymentSource", () => {
   beforeEach(() => {
-    // $FlowIssue
-    getVaultSetupToken.mockResolvedValue();
     // $FlowIssue
     updateVaultSetupToken.mockResolvedValue();
   });
@@ -37,7 +35,6 @@ describe("savePaymentSource", () => {
   const defaultOptions = {
     ...defaultSave(),
     clientID: "client-id",
-    facilitatorAccessToken: "low-scoped-access-token",
     paymentSource: {
       card: {
         expiry: "01/24",
@@ -68,25 +65,6 @@ describe("savePaymentSource", () => {
       error: createVaultSetupTokenError,
     });
     expect(defaultOptions.onError).toBeCalledWith(createVaultSetupTokenError);
-  });
-
-  test("should handle failure from performing GET on a setup vault token", async () => {
-    const getVaultSetupTokenError = new Error(
-      "error with get vault setup token"
-    );
-
-    // $FlowIssue
-    getVaultSetupToken.mockRejectedValue(getVaultSetupTokenError);
-
-    await savePaymentSource(defaultOptions);
-
-    expect.assertions(3);
-    expect(vaultWithoutPurchaseSuccess).not.toHaveBeenCalled();
-    expect(vaultWithoutPurchaseFailure).toHaveBeenCalledWith({
-      error: getVaultSetupTokenError,
-      vaultToken: defaultVaultSetupToken,
-    });
-    expect(defaultOptions.onError).toBeCalledWith(getVaultSetupTokenError);
   });
 
   test("should handle failure from performing POST on a setup vault token", async () => {


### PR DESCRIPTION
`GET /v3/vault/setup-tokens/:id` needs special permission to call, and we don't need to use it on the sdk anyway. We can just use `update` and check contingencies that happen from the update call

EDIT:
We are also adding back the passing of the id token to the graphql update token endpoint.

We don't think its required for the vault without purchase flow but we still need to pass it until we can deploy xobuyernodeserv with a fix to make it optional.