### PR TITLE
bug: cvv being marked as invalid when cardType defaults

### DIFF
--- a/src/card/constants.js
+++ b/src/card/constants.js
@@ -137,7 +137,7 @@ export const DEFAULT_CARD_TYPE : CardType = {
     niceType: 'Unknown',
     code:     {
         name: 'CVV',
-        size: 4
+        size: 3
     }
 };
 


### PR DESCRIPTION
### Description

Occasionally, when the `cardType` returns to its default state, the card CVV is being marked as invalid because it's length isn't matching the one on the input.

### Reproduction Steps (if applicable)

Intermittent, not always reproducible but happens frequently when the buyer modifies a valid card number after the CVV is filled out.

### Screenshots (if applicable)

<img width="1000" alt="Screenshot 2023-03-17 at 15 26 37" src="https://user-images.githubusercontent.com/63573634/226031827-b455d61e-eced-4978-aeeb-6e0129ecaf8b.png">


❤️  Thank you!
