### PR TITLE
chore: no longer marking ineligible cards as invalid

### DIFF
--- a/src/card/components/fields.jsx
+++ b/src/card/components/fields.jsx
@@ -113,15 +113,7 @@ export function CardField({ cspNonce, onChange, styleObject = {}, placeholder = 
 
         const errors = setErrors({ isCardEligible, isNumberValid: numberValidity.isValid, isCvvValid: cvvValidity.isValid, isExpiryValid: expiryValidity.isValid, gqlErrorsObject });
 
-        if (!isCardEligible) {
-            const element = numberRef?.current?.base;
-            if (element) {
-                element.classList.add('invalid');
-                element.classList.remove('valid');
-            }
-        } else {
-            markValidity(numberRef, numberValidity, hasFocus, touched);
-        }
+        markValidity(numberRef, numberValidity, hasFocus, touched);
         markValidity(expiryRef, expiryValidity, hasFocus, touched);
         markValidity(cvvRef, cvvValidity, hasFocus, touched);
 
@@ -264,15 +256,7 @@ export function CardNumberField({ cspNonce, onChange, onFocus, styleObject = {},
     }, [ gqlErrors ]);
 
     useEffect(() => {
-        if (!isCardEligible) {
-            const element = numberRef?.current?.base;
-            if (element) {
-                element.classList.add('invalid');
-                element.classList.remove('valid');
-            }
-        } else {
-            markValidity(numberRef, numberValidity, hasFocus, touched);
-        }
+        markValidity(numberRef, numberValidity, hasFocus, touched);
         onChange({ value: number, valid: numberValidity.isValid, isFocused: hasFocus, potentiallyValid: numberValidity.isPotentiallyValid, potentialCardTypes: cards });
     }, [ number, isCardEligible, isValid, hasFocus, isPotentiallyValid, cards ]);
 

--- a/src/card/interface/getCardFields.js
+++ b/src/card/interface/getCardFields.js
@@ -2,12 +2,13 @@
 
 import { FRAME_NAME } from '../../constants';
 import { CARD_ERRORS } from '../constants';
-import type { Card } from '../types';
+import type { Card, CardType } from '../types';
+import { checkCardEligibility } from '../lib';
 
 import { getExportsByFrameName } from './getExportsByFrameName';
 import { getCardFrames } from './getCardFrames';
 
-export function getCardFields(): Card {
+export function getCardFields(isVaultFlow?: boolean = false): Card {
   const card = {};
   const cardFrame = getExportsByFrameName(FRAME_NAME.CARD_FIELD);
 
@@ -25,7 +26,14 @@ export function getCardFields(): Card {
 
   // 3 Required fields for HCFs purchase
   if (cardNumberFrame && cardNumberFrame.isFieldValid()) {
-    card.number = cardNumberFrame.getFieldValue();
+    const cardNumber: string = cardNumberFrame.getFieldValue();
+    const cardType: CardType = cardNumberFrame.getPotentialCardTypes()[0];
+
+    if (checkCardEligibility(cardNumber, cardType, isVaultFlow)) {
+      card.number = cardNumber;
+    } else {
+      throw new Error(CARD_ERRORS.INELIGIBLE_CARD_VENDOR);
+    }
   } else {
     throw new Error(CARD_ERRORS.INVALID_NUMBER);
   }

--- a/src/card/interface/submitCardFields.js
+++ b/src/card/interface/submitCardFields.js
@@ -38,12 +38,15 @@ export function submitCardFields({
     if (!hasCardFields()) {
       throw new Error(`Card fields not available to submit`);
     }
+    // $FlowIssue
+    const isVaultFlow = Boolean(cardProps.createVaultSetupToken);
+    const card = getCardFields(isVaultFlow);
 
-    const card = getCardFields();
-
-    if (cardProps.createVaultSetupToken) {
+    if (isVaultFlow) {
       return savePaymentSource({
+        // $FlowFixMe
         onApprove: cardProps.onApprove,
+        // $FlowFixMe
         createVaultSetupToken: cardProps.createVaultSetupToken,
         onError: cardProps.onError,
         clientID: cardProps.clientID,
@@ -53,8 +56,9 @@ export function submitCardFields({
     }
     let orderID;
 
+    if (cardProps.createOrder) {
       // $FlowFixMe
-    return cardProps
+      return cardProps
       .createOrder()
       .then((id) => {
         if (typeof id?.valueOf() !== "string") {
@@ -92,5 +96,6 @@ export function submitCardFields({
 
         throw error;
       });
+    }
   });
 }

--- a/src/card/lib/card-checks.js
+++ b/src/card/lib/card-checks.js
@@ -92,20 +92,21 @@ export function addGapsToCardNumber(cardNumber : string, cardType? : CardType) :
     return cardNumber;
 }
 
-export function checkCardEligibility(value : string, cardType : CardType) : boolean  {
+export function checkCardEligibility(cardNumber : string, cardType : CardType, isVaultFlow? : boolean) : boolean  {
     // check if the card type is eligible
     const fundingEligibility = window.xprops.fundingEligibility;
     const type = VALIDATOR_TO_TYPE_MAP[cardType.type];
-    if (value.length === 0) {
+    if (cardNumber.length === 0) {
         return true;
     }
-    if (fundingEligibility && fundingEligibility.card && fundingEligibility.card.eligible) {
+    if (fundingEligibility?.card?.eligible && type && fundingEligibility.card.vendors && !fundingEligibility.card.branded) {
         // mark as eligible if the card vendor is explicitly set to be eligible
-        if (type && fundingEligibility.card.vendors) {
-            const vendor = fundingEligibility.card.vendors[type];
-            if (vendor && vendor.eligible && !vendor.branded) {
-                return true;
-            }
+        const vendor = fundingEligibility.card.vendors[type];
+        if (isVaultFlow && vendor?.vaultable) {
+            return true;
+        }
+        else if (!isVaultFlow && vendor?.eligible) {
+            return true;
         }
     }
     // otherwise default to be not eligible

--- a/src/card/lib/card-checks.test.js
+++ b/src/card/lib/card-checks.test.js
@@ -138,7 +138,7 @@ describe("card-checks", () => {
       window.xprops = {};
     });
 
-    it("should find the card eligible when the vendor is eligible", () => {
+    it("should find the card eligible when the vendor is eligible for purchaese flow", () => {
       window.xprops.fundingEligibility = {
         card: {
           eligible: true,
@@ -151,10 +151,13 @@ describe("card-checks", () => {
       };
       const cardNumber = "4111111111111111";
       const cardType = detectCardType(cardNumber)[0];
-      expect(checkCardEligibility(cardNumber, cardType)).toBe(true);
+      const isVaultFlow = false;
+      expect(checkCardEligibility(cardNumber, cardType, isVaultFlow)).toBe(
+        true
+      );
     });
 
-    it("should find the card not eligible when the vendor in not eligible", () => {
+    it("should find the card ineligible when the card type is ineligible for purchaese flow", () => {
       window.xprops.fundingEligibility = {
         card: {
           eligible: true,
@@ -167,7 +170,48 @@ describe("card-checks", () => {
       };
       const cardNumber = "4111111111111111";
       const cardType = detectCardType(cardNumber)[0];
-      expect(checkCardEligibility(cardNumber, cardType)).toBe(false);
+      const isVaultFlow = false;
+      expect(checkCardEligibility(cardNumber, cardType, isVaultFlow)).toBe(
+        false
+      );
+    });
+
+    it("should find the card eligible when the card type is eligible for vaulting", () => {
+      window.xprops.fundingEligibility = {
+        card: {
+          eligible: true,
+          vendors: {
+            discover: {
+              vaultable: true,
+            },
+          },
+        },
+      };
+      const cardNumber = "6011000990139424";
+      const cardType = detectCardType(cardNumber)[0];
+      const isVaultFlow = true;
+      expect(checkCardEligibility(cardNumber, cardType, isVaultFlow)).toBe(
+        true
+      );
+    });
+
+    it("should find the card ineligible when the card type is ineligible for vaulting", () => {
+      window.xprops.fundingEligibility = {
+        card: {
+          eligible: true,
+          vendors: {
+            discover: {
+              vaultable: false,
+            },
+          },
+        },
+      };
+      const cardNumber = "6011000990139424";
+      const cardType = detectCardType(cardNumber)[0];
+      const isVaultFlow = true;
+      expect(checkCardEligibility(cardNumber, cardType, isVaultFlow)).toBe(
+        false
+      );
     });
 
     it("should find card payments not eligible when the merchant is not onboarded for card payments", () => {
@@ -178,7 +222,9 @@ describe("card-checks", () => {
       };
       const cardNumber = "4111111111111111";
       const cardType = detectCardType(cardNumber)[0];
-      expect(checkCardEligibility(cardNumber, cardType)).toBe(false);
+      expect.assertions(2);
+      expect(checkCardEligibility(cardNumber, cardType, true)).toBe(false);
+      expect(checkCardEligibility(cardNumber, cardType, false)).toBe(false);
     });
 
     it("should find unbranded card payments not eligible if the merchant is only eligible for branded payments", () => {
@@ -187,22 +233,27 @@ describe("card-checks", () => {
           branded: true,
         },
       };
-
       const cardNumber = "4111111111111111";
       const cardType = detectCardType(cardNumber)[0];
-      expect(checkCardEligibility(cardNumber, cardType)).toBe(false);
+      expect.assertions(2);
+      expect(checkCardEligibility(cardNumber, cardType, true)).toBe(false);
+      expect(checkCardEligibility(cardNumber, cardType, false)).toBe(false);
     });
 
     it("should default to ineligible if there is no funding eligibility specified", () => {
       const cardNumber = "4111111111111111";
       const cardType = detectCardType(cardNumber)[0];
-      expect(checkCardEligibility(cardNumber, cardType)).toBe(false);
+      expect.assertions(2);
+      expect(checkCardEligibility(cardNumber, cardType, true)).toBe(false);
+      expect(checkCardEligibility(cardNumber, cardType, false)).toBe(false);
     });
 
     it("should default to eligible if there is no card number entered", () => {
       const cardNumber = "";
       const cardType = detectCardType(cardNumber)[0];
-      expect(checkCardEligibility(cardNumber, cardType)).toBe(true);
+      expect.assertions(2);
+      expect(checkCardEligibility(cardNumber, cardType, true)).toBe(true);
+      expect(checkCardEligibility(cardNumber, cardType, false)).toBe(true);
     });
   });
 });

--- a/src/card/lib/card-checks.test.js
+++ b/src/card/lib/card-checks.test.js
@@ -222,7 +222,6 @@ describe("card-checks", () => {
       };
       const cardNumber = "4111111111111111";
       const cardType = detectCardType(cardNumber)[0];
-      expect.assertions(2);
       expect(checkCardEligibility(cardNumber, cardType, true)).toBe(false);
       expect(checkCardEligibility(cardNumber, cardType, false)).toBe(false);
     });
@@ -235,7 +234,6 @@ describe("card-checks", () => {
       };
       const cardNumber = "4111111111111111";
       const cardType = detectCardType(cardNumber)[0];
-      expect.assertions(2);
       expect(checkCardEligibility(cardNumber, cardType, true)).toBe(false);
       expect(checkCardEligibility(cardNumber, cardType, false)).toBe(false);
     });
@@ -243,7 +241,6 @@ describe("card-checks", () => {
     it("should default to ineligible if there is no funding eligibility specified", () => {
       const cardNumber = "4111111111111111";
       const cardType = detectCardType(cardNumber)[0];
-      expect.assertions(2);
       expect(checkCardEligibility(cardNumber, cardType, true)).toBe(false);
       expect(checkCardEligibility(cardNumber, cardType, false)).toBe(false);
     });
@@ -251,7 +248,6 @@ describe("card-checks", () => {
     it("should default to eligible if there is no card number entered", () => {
       const cardNumber = "";
       const cardType = detectCardType(cardNumber)[0];
-      expect.assertions(2);
       expect(checkCardEligibility(cardNumber, cardType, true)).toBe(true);
       expect(checkCardEligibility(cardNumber, cardType, false)).toBe(true);
     });


### PR DESCRIPTION
### Description

When the merchant account is ineligible for certain card types(Discover,Amex),the form is able to submit successfully even though the field is marked as invalid.
The orders API team confirmed that the payment would decline on their end after the call is made.

We'll no longer mark ineligible cards as invalid and will allow the call to orders API to go through. The response will be an error and we can surface this to the merchant so they can decide and handle what to do on their site when a buyer attempts to make a purchase with an ineligible card type.

Additionally, when we detect that a card is ineligible for either the purchase or vaulting flow, we'll throw an error for the merchant to know and handle any UI changes on their end.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

https://paypal.atlassian.net/browse/DTCURIOSTY-8609

### Reproduction Steps (if applicable)

Type in a Discover card number in the card number field. If the merchant does not have Discover enabled as a part of their funding eligibility then it will be marked as invalid, but still allow the form to submit.

### Screenshots (if applicable)

<img width="1786" alt="Screenshot 2023-03-17 at 15 20 20" src="https://user-images.githubusercontent.com/63573634/226471556-72cdfd8d-116f-4d56-998a-cd14d4571c5b.png">

❤️  Thank you!
