### PR TITLE
separated submitCardFields into 2 flows

### DIFF
--- a/src/card/constants.js
+++ b/src/card/constants.js
@@ -44,6 +44,14 @@ export const CARD_ERRORS = {
     INVALID_POSTAL:         ('INVALID_POSTAL' : 'INVALID_POSTAL')
 };
 
+export const SUBMIT_ERRORS = {
+    UNABLE_TO_SUBMIT:           ('Card fields not available to submit' : 'Card fields not available to submit'),
+    ORDER_ID_TYPE_ERROR:        ('Expected createOrder to return a promise that resolves with the order ID as a string' : 'Expected createOrder to return a promise that resolves with the order ID as a string'),
+    VAULT_TOKEN_TYPE_ERROR:     ('Expected createVaultSetupToken to return a promise that resolves with vaultSetupToken as a string' : 'Expected createVaultSetupToken to return a promise that resolves with vaultSetupToken as a string'),
+    MISSING_BOTH_FUNCTIONS:     ('Must pass either createVaultSetupToken or createOrder' : 'Must pass either createVaultSetupToken or createOrder'),
+    PASSING_BOTH_FUNCTIONS:     ('Cannot pass both createVaultSetupToken and createOrder' : 'Cannot pass both createVaultSetupToken and createOrder')
+}
+
 export const CARD_FIELD_TYPE_TO_FRAME_NAME : {| [$Values<typeof CARD_FIELD_TYPE>] : $Values<typeof FRAME_NAME> |} = {
     [ CARD_FIELD_TYPE.SINGLE ]: FRAME_NAME.CARD_FIELD,
     [ CARD_FIELD_TYPE.NUMBER ]: FRAME_NAME.CARD_NUMBER_FIELD,

--- a/src/card/interface/submitCardFields.js
+++ b/src/card/interface/submitCardFields.js
@@ -2,12 +2,13 @@
 
 import { ZalgoPromise } from "@krakenjs/zalgo-promise/src"
 
-import { getCardProps } from "../props"
+import { getCardProps, type SaveCardFieldsProps, type LegacyCardProps } from "../props"
 import { confirmOrderAPI } from "../../api"
 import { hcfTransactionError, hcfTransactionSuccess } from "../logger"
 import type { FeatureFlags } from "../../types"
-import type { BillingAddress } from '../types'
+import type { BillingAddress, Card, ExtraFields } from '../types'
 import {convertCardToPaymentSource, reformatPaymentSource} from '../lib'
+import { SUBMIT_ERRORS } from "../constants"
 
 import { resetGQLErrors } from "./gql"
 import { hasCardFields } from "./hasCardFields"
@@ -22,6 +23,60 @@ type SubmitCardFieldsOptions = {|
   |},
 |};
 
+function handleVaultFlow(cardProps: SaveCardFieldsProps, card: Card, extraFields?: ExtraFields): ZalgoPromise<void> {
+  return savePaymentSource({
+    onApprove: cardProps.onApprove,
+    createVaultSetupToken: cardProps.createVaultSetupToken,
+    onError: cardProps.onError,
+    clientID: cardProps.clientID,
+    paymentSource: convertCardToPaymentSource(card, extraFields),
+    idToken: cardProps.userIDToken || "",
+  });
+}
+
+function handlePurchaseFlow(cardProps: LegacyCardProps, card: Card, extraFields: ExtraFields, facilitatorAccessToken: string): ZalgoPromise<void> {
+  let orderID;
+
+  return cardProps
+    .createOrder()
+    .then((id) => {
+      if (typeof id?.valueOf() !== "string") {
+        throw new TypeError(SUBMIT_ERRORS.ORDER_ID_TYPE_ERROR);
+      }
+      const payment_source = convertCardToPaymentSource(card, extraFields);
+      // eslint-disable-next-line flowtype/no-weak-types
+      const data: any = {
+        payment_source: {
+          // $FlowIssue
+          card: reformatPaymentSource(payment_source.card),
+        },
+      };
+      orderID = id;
+      return confirmOrderAPI(orderID, data, {
+        facilitatorAccessToken,
+        partnerAttributionID: "",
+      });
+    })
+    .then(() => {
+      // $FlowFixMe
+      return cardProps.onApprove({ orderID }, {});
+    })
+    .then(() => {
+      hcfTransactionSuccess({ orderID });
+    })
+    .catch((error) => {
+      if (typeof error === "string") {
+        error = new Error(error);
+      }
+      hcfTransactionError({ error, orderID });
+      if (cardProps.onError) {
+        cardProps.onError(error);
+      }
+
+      throw error;
+    });
+}
+
 export function submitCardFields({
   facilitatorAccessToken,
   extraFields,
@@ -32,70 +87,23 @@ export function submitCardFields({
     featureFlags,
   });
 
+  // $FlowIssue
+  const [isPurchaseFlow, isVaultFlow] = [Boolean(cardProps.createOrder), Boolean(cardProps.createVaultSetupToken)];
+
   resetGQLErrors();
 
   return ZalgoPromise.try(() => {
     if (!hasCardFields()) {
-      throw new Error(`Card fields not available to submit`);
+      throw new Error(SUBMIT_ERRORS.UNABLE_TO_SUBMIT);
     }
-    // $FlowIssue
-    const isVaultFlow = Boolean(cardProps.createVaultSetupToken);
     const card = getCardFields(isVaultFlow);
 
-    if (isVaultFlow) {
-      return savePaymentSource({
-        // $FlowFixMe
-        onApprove: cardProps.onApprove,
-        // $FlowFixMe
-        createVaultSetupToken: cardProps.createVaultSetupToken,
-        onError: cardProps.onError,
-        clientID: cardProps.clientID,
-        paymentSource: convertCardToPaymentSource(card, extraFields),
-        idToken: cardProps.userIDToken || "",
-      });
-    }
-    let orderID;
-
-    if (cardProps.createOrder) {
+    if (isPurchaseFlow) {
       // $FlowFixMe
-      return cardProps
-      .createOrder()
-      .then((id) => {
-        if (typeof id?.valueOf() !== "string") {
-          throw new TypeError("Expected createOrder to return a promise that resolves with the order ID as a string.");
-        }
-        const payment_source = convertCardToPaymentSource(card, extraFields)
-        // eslint-disable-next-line flowtype/no-weak-types
-        const data: any = {
-          payment_source: {
-            // $FlowIssue
-            card: reformatPaymentSource(payment_source.card)
-          }
-        }
-        orderID = id;
-        return confirmOrderAPI(orderID, data, {
-          facilitatorAccessToken,
-          partnerAttributionID: ""
-        })
-      })
-      .then(() => {
-        // $FlowFixMe
-        return cardProps.onApprove({ orderID }, {})
-      })
-      .then(() => {
-        hcfTransactionSuccess({ orderID });
-      })
-      .catch((error) => {
-        if (typeof error === "string") {  
-          error = new Error(error);
-        }
-        hcfTransactionError({error, orderID});
-        if (cardProps.onError) {
-          cardProps.onError(error);
-        }
-
-        throw error;
-      });
+      return handlePurchaseFlow(cardProps, card, extraFields, facilitatorAccessToken);
+    } else if (isVaultFlow) {
+      // $FlowFixMe
+      return handleVaultFlow(cardProps, card, extraFields)
     }
   });
 }

--- a/src/card/interface/vault-without-purchase.js
+++ b/src/card/interface/vault-without-purchase.js
@@ -15,6 +15,7 @@ import type {
   XCreateVaultSetupToken,
   SaveActionOnApprove,
 } from "../../props";
+import { SUBMIT_ERRORS } from "../constants";
 
 type VaultPaymenSourceOptions = {|
   createVaultSetupToken: XCreateVaultSetupToken,
@@ -36,6 +37,9 @@ export const savePaymentSource = ({
   let vaultToken;
   return createVaultSetupToken()
     .then((vaultSetupToken) => {
+      if (typeof vaultSetupToken !== "string") {
+        throw new TypeError(SUBMIT_ERRORS.VAULT_TOKEN_TYPE_ERROR);
+      }
       vaultToken = vaultSetupToken;
       return updateVaultSetupToken({
         vaultSetupToken,

--- a/src/card/props.js
+++ b/src/card/props.js
@@ -35,7 +35,7 @@ import type {
   ParsedCardType,
   FieldsState,
 } from "./types";
-import { CARD_FIELD_TYPE, CARD_ERRORS } from "./constants";
+import { CARD_FIELD_TYPE, CARD_ERRORS, SUBMIT_ERRORS } from "./constants";
 
 // export something to force webpack to see this as an ES module
 export const TYPES = true;
@@ -223,7 +223,9 @@ export function getCardProps({
 
   const baseProps = getProps({ branded });
 
-  if (createVaultSetupToken) {
+  if (createVaultSetupToken && createOrder) {
+    throw new Error(SUBMIT_ERRORS.PASSING_BOTH_FUNCTIONS);
+  } else if (createVaultSetupToken) {
     return {
       ...baseProps,
       ...validateVaultWithoutPurchaseSetup(xprops, baseProps),
@@ -279,7 +281,7 @@ export function getCardProps({
       hcfSessionID
     }
   } else {
-    throw new Error('Must pass either createVaultSetupToken or createOrder');
+    throw new Error(SUBMIT_ERRORS.MISSING_BOTH_FUNCTIONS);
   }
 }
 

--- a/src/card/props.test.js
+++ b/src/card/props.test.js
@@ -8,6 +8,7 @@ import * as getPropsStuff from "../props/props";
 import * as getLegacyPropsStuff from "../props/legacyProps";
 
 import { getCardProps } from "./props";
+import { SUBMIT_ERRORS } from "./constants";
 
 const vaultMock = {
   createVaultSetupToken: vi.fn(),
@@ -71,7 +72,7 @@ describe("getCardProps", () => {
       };
 
       expect(() => getCardProps(inputs)).toThrow(
-        `Do not pass ${prop} with an action.`
+        SUBMIT_ERRORS.PASSING_BOTH_FUNCTIONS
       );
     });
 


### PR DESCRIPTION
### Description

Splitting up the purchase and vault-without-purchase flow in the `submitCardFields()` function. The `getCardProps()` method will validate that only 1 of either `createVaultSetupToken` or `createOrder` methods is being passed in.

❤️  Thank you!
