### PR TITLE
fix: update fieldName to isPotentiallyValid

### DIFF
--- a/src/card/components/page.jsx
+++ b/src/card/components/page.jsx
@@ -102,7 +102,7 @@ function Page({ cspNonce, props, featureFlags } : PageProps) : mixed {
         fields[currentField] = {
             isEmpty: isEmpty(fieldValue),
             isFocused: fieldFocus,
-            isFieldPotentiallyValid: fieldPotentiallyValid,
+            isPotentiallyValid: fieldPotentiallyValid,
             isValid: fieldValid
         }
         if (currentField === 'cardNumberField') {


### PR DESCRIPTION
### Description
Currently, the stateObject returned during the `onChange` inputEvent has one of the fields as `isFieldPotentiallyValid` as opposed to `isPotentiallyValid`. This PR is to fix that bug.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

### Reproduction Steps (if applicable)

### Screenshots (if applicable)
<img width="906" alt="Screenshot 2023-03-23 at 4 15 51 PM" src="https://user-images.githubusercontent.com/24843989/227387074-52212a4f-2c39-4e91-80c2-cf414123cce9.png">
### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->
### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
