### PR TITLE
chore: add log for render version mismatch

### DIFF
--- a/src/button/logger.js
+++ b/src/button/logger.js
@@ -131,15 +131,15 @@ export function setupButtonLogger({ env, sessionID, buttonSessionID, clientID, p
             native_device = 'android_chrome';
         }
 
-        const renderVersion = getTemplateVersion();
-        const dotSeparatedRenderVersion = renderVersion.split('_').join('.');
+        const serverRenderVersion = getTemplateVersion();
+        const dotSeparatedRenderVersion = serverRenderVersion.split('_').join('.');
 
         if (dotSeparatedRenderVersion !== sdkVersion) {
-          logger.warn('server_render_version_mismatch', {sdkVersion, renderVersion})
+          logger.warn('server_render_version_mismatch', {sdkVersion, serverRenderVersion})
         }
 
         logger.info(`button_render`);
-        logger.info(`button_render_template_version_${ renderVersion }`);
+        logger.info(`button_render_template_version_${ serverRenderVersion }`);
         logger.info(`button_render_client_version_${ getClientVersion() }`);
         logger.info(`button_render_color_${ color }`);
         logger.info(`button_render_shape_${ shape }`);

--- a/src/button/logger.js
+++ b/src/button/logger.js
@@ -139,7 +139,7 @@ export function setupButtonLogger({ env, sessionID, buttonSessionID, clientID, p
           logger.warn('server_render_version_mismatch', {sdkVersion, serverRenderVersion})
           sendMetric({
             name: 'pp.app.paypal_sdk.buttons.server_render_version_mismatch',
-            dimensions: {sdkVersion, serverRenderVersion}
+            dimensions: {}
           });
         }
 

--- a/src/button/logger.js
+++ b/src/button/logger.js
@@ -131,8 +131,15 @@ export function setupButtonLogger({ env, sessionID, buttonSessionID, clientID, p
             native_device = 'android_chrome';
         }
 
+        const renderVersion = getTemplateVersion();
+        const dotSeparatedRenderVersion = renderVersion.split('_').join('.');
+
+        if (dotSeparatedRenderVersion !== sdkVersion) {
+          logger.warn('server_render_version_mismatch', {sdkVersion, renderVersion})
+        }
+
         logger.info(`button_render`);
-        logger.info(`button_render_template_version_${ getTemplateVersion() }`);
+        logger.info(`button_render_template_version_${ renderVersion }`);
         logger.info(`button_render_client_version_${ getClientVersion() }`);
         logger.info(`button_render_color_${ color }`);
         logger.info(`button_render_shape_${ shape }`);

--- a/src/button/logger.js
+++ b/src/button/logger.js
@@ -12,7 +12,8 @@ import {
     isIOSSafari,
     isAndroidChrome,
     prepareLatencyInstrumentationPayload,
-    getNavigationTimeOrigin
+    getNavigationTimeOrigin,
+    sendMetric
 } from '../lib';
 import {
     DATA_ATTRIBUTES, FPTI_TRANSITION, FPTI_BUTTON_TYPE, FPTI_BUTTON_KEY,
@@ -136,6 +137,10 @@ export function setupButtonLogger({ env, sessionID, buttonSessionID, clientID, p
 
         if (dotSeparatedRenderVersion !== sdkVersion) {
           logger.warn('server_render_version_mismatch', {sdkVersion, serverRenderVersion})
+          sendMetric({
+            name: 'pp.app.paypal_sdk.buttons.server_render_version_mismatch',
+            dimensions: {sdkVersion, serverRenderVersion}
+          });
         }
 
         logger.info(`button_render`);

--- a/src/button/logger.test.js
+++ b/src/button/logger.test.js
@@ -11,6 +11,7 @@ import { setupButtonLogger } from "./logger";
 vi.mock("../lib/logger", () => ({
   getLogger: vi.fn(),
   setupLogger: vi.fn(),
+  sendMetric: vi.fn(),
 }));
 
 const buttonLoggerProps = {


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->
* Added warning log when SDK version used for first render doesn't match SDK version used for server-side render.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
To increase visibility of fallback rendering behaviors in SCNW

### Screenshots (if applicable)
<img width="1724" alt="Screenshot 2023-06-21 at 8 28 55 PM" src="https://github.com/paypal/paypal-smart-payment-buttons/assets/69579929/778b2931-ce4e-4c5f-9cdc-68cd956a6eb4">

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->
### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
