### PR TITLE
add browser eligiblity check for app shell service worker registration

### DIFF
--- a/src/lib/register-service-worker.js
+++ b/src/lib/register-service-worker.js
@@ -38,7 +38,6 @@ const requestSwLogs = () => {
 };
 
 const startBroadCastChannel = () => {
-    // eslint-disable-next-line compat/compat
     broadcastChannel = new BroadcastChannel(LOGS_CHANNEL_NAME);
 };
 

--- a/src/lib/register-service-worker.js
+++ b/src/lib/register-service-worker.js
@@ -72,7 +72,7 @@ const unRegisterButtonHandlers = () => {
 const startRegistration = (swUrl) => {
     // eslint-disable-next-line compat/compat
     navigator.serviceWorker
-        ?.register('https://localhost.paypal.com:8443/dumbledore-service-worker.js?releaseHash=43968c7e8195936f0b5e4467e9cc71cea8df9152', { scope: SW_SCOPE })
+        ?.register(swUrl, { scope: SW_SCOPE })
         .then((registration) => {
 
             getLogger().info(`${ LOG_PREFIX }REGISTERED`);
@@ -120,6 +120,7 @@ const executeServiceWorker = (releaseHash: string, serviceWorker: string) => {
 }
 
 export function registerServiceWorker({ dumbledoreCurrentReleaseHash, dumbledoreServiceWorker }: RegisterServiceWorkerParams) {
+    // Browser eligibility criteria for SW registration
     if ('serviceWorker' in navigator === false || 'BroadcastChannel' in window === false) {
         getLogger().info(`${ LOG_PREFIX }NOT_SUPPORTED`);
         return;

--- a/src/lib/register-service-worker.js
+++ b/src/lib/register-service-worker.js
@@ -120,7 +120,7 @@ const executeServiceWorker = (releaseHash: string, serviceWorker: string) => {
 }
 
 export function registerServiceWorker({ dumbledoreCurrentReleaseHash, dumbledoreServiceWorker }: RegisterServiceWorkerParams) {
-    if ('serviceWorker' in navigator === false) {
+    if ('serviceWorker' in navigator === false || 'BroadcastChannel' in window === false) {
         getLogger().info(`${ LOG_PREFIX }NOT_SUPPORTED`);
         return;
     }

--- a/src/lib/register-service-worker.js
+++ b/src/lib/register-service-worker.js
@@ -72,7 +72,7 @@ const unRegisterButtonHandlers = () => {
 const startRegistration = (swUrl) => {
     // eslint-disable-next-line compat/compat
     navigator.serviceWorker
-        ?.register(swUrl, { scope: SW_SCOPE })
+        ?.register('https://localhost.paypal.com:8443/dumbledore-service-worker.js?releaseHash=43968c7e8195936f0b5e4467e9cc71cea8df9152', { scope: SW_SCOPE })
         .then((registration) => {
 
             getLogger().info(`${ LOG_PREFIX }REGISTERED`);

--- a/src/lib/register-service-worker.js
+++ b/src/lib/register-service-worker.js
@@ -122,7 +122,10 @@ const executeServiceWorker = (releaseHash: string, serviceWorker: string) => {
 export function registerServiceWorker({ dumbledoreCurrentReleaseHash, dumbledoreServiceWorker }: RegisterServiceWorkerParams) {
     // Browser eligibility criteria for SW registration
     if ('serviceWorker' in navigator === false || 'BroadcastChannel' in window === false) {
-        getLogger().info(`${ LOG_PREFIX }NOT_SUPPORTED`);
+        getLogger().info(`${ LOG_PREFIX }NOT_SUPPORTED`, {
+          serviceWorker: Boolean('serviceWorker' in navigator),
+          BroadcastChannel: Boolean('BroadcastChannel' in window),
+        });
         return;
     }
     if (!dumbledoreCurrentReleaseHash) {


### PR DESCRIPTION
### Description

<!-- Ensure you have a PR description that answers: What? Why? How? -->
We currently use the BroadcastChannel browser API in the App Shell service worker. However, we do not currently have checks for browser support of this API, so we add that check prior to service worker registration.
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
DTLITEPLAT-1147


### Reproduction Steps (if applicable)
Run the App Shell flow locally (internal documentation). Test on browser versions that support and don't support BroadcastChannel. Ensure that the service worker only gets registered when the browser version supports service workers and BroadcastChannel.

[https://caniuse.com/broadcastchannel](https://caniuse.com/broadcastchannel)
[https://caniuse.com/serviceworkers](https://caniuse.com/serviceworkers)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->

❤️  Thank you!
