### PR TITLE
Add vitest coverage to codecov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,4 +41,4 @@ jobs:
       - name: ⬆️ Upload coverage report
         uses: codecov/codecov-action@v3
         with:
-          files: coverage/clover.xml, coverage-vitest/clover.xml
+          files: coverage/lcov.info, coverage-vitest/clover.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,3 +40,5 @@ jobs:
 
       - name: ⬆️ Upload coverage report
         uses: codecov/codecov-action@v3
+        with:
+          files: coverage/clover.xml, coverage-vitest/clover.xml

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ log
 *.log
 .DS_Store
 coverage
+coverage-vitest
 cdbs
 protected
 tmp

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "release:dry-run": "DRY_RUN=true grabthar-release",
     "setup": "npm install && npm run flow-typed",
     "start": "npm run webpack -- --progress --watch",
-    "test": "npm run coverage -- run && npm run karma",
+    "test": "npm run coverage && npm run karma",
     "typecheck": "npm run flow-typed && npm run flow -- check",
     "vitest": "vitest",
     "webpack": "babel-node --plugins=transform-es2015-modules-commonjs $(npm bin)/webpack",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "release:dry-run": "DRY_RUN=true grabthar-release",
     "setup": "npm install && npm run flow-typed",
     "start": "npm run webpack -- --progress --watch",
-    "test": "npm run vitest -- run && npm run karma",
+    "test": "npm run coverage -- run && npm run karma",
     "typecheck": "npm run flow-typed && npm run flow -- check",
     "vitest": "vitest",
     "webpack": "babel-node --plugins=transform-es2015-modules-commonjs $(npm bin)/webpack",

--- a/vite.config.js
+++ b/vite.config.js
@@ -42,6 +42,7 @@ export default defineConfig({
     },
     coverage: {
       provider: "v8",
+      reportsDirectory: "./coverage-vitest",
     },
   },
   optimizeDeps: {


### PR DESCRIPTION
### Description

This PR adds `vitest --coverage` output to `codecov`'s coverage stats.

### Why are we making these changes?

There have been a few recent PRs where codecov will comment on the PR saying the added line is missing coverage. This is true insofar as the lines were not tested with `karma`, but _were_ tested with `vitest`. This change will include the code coverage report generated by running `npm run coverage`.

### Reproduction Steps (if applicable)

1. Add some code to a PR
2. Add test coverage using `vitest` (not `karma`)
3. Observe that codecov leaves a comment about missing test coverage.

### Screenshots (if applicable)

<img width="385" alt="Screenshot 2023-09-05 at 09 51 40" src="https://github.com/paypal/paypal-smart-payment-buttons/assets/3824954/ae370b1a-30bf-40b4-b957-ab520044cbb2">


❤️  Thank you!
