### PR TITLE
(feat): Update sanitization rules for patchShipping

### DIFF
--- a/src/props/onShippingChange.js
+++ b/src/props/onShippingChange.js
@@ -103,11 +103,12 @@ export type LogInvalidShippingChangePatchesPayload = {|
  * Full matches the following;
  *  /purchase_units/@reference_id=='default'/amount
  *  /purchase_units/@reference_id=='default'/shipping/address
+ *  /purchase_units/@reference_id=='default'/shipping/name
  *  /purchase_units/@reference_id=='default'/shipping/options
  *  /purchase_units/@reference_id=='d9f80740-38f0-11e8-b467-0ed5f89f718b'/amount
  */
 const pathPattern = new RegExp(
-    /^\/purchase_units\/@reference_id=='(?:\w|-)*'\/(?:amount|shipping\/(?:options|address))$/
+    /^\/purchase_units\/@reference_id=='(?:\w|-)*'\/(?:amount|shipping\/(?:options|address|name))$/
 );
 
 export const sanitizePatch = (rejected: $ReadOnlyArray<string>, patch: Query): $ReadOnlyArray<string> => {

--- a/src/props/onShippingChange.test.js
+++ b/src/props/onShippingChange.test.js
@@ -287,6 +287,14 @@ describe("onShippingChange", () => {
       [
         {
           op: "replace",
+          path: "/purchase_units/@reference_id=='default'/shipping/name",
+          value: {},
+        },
+        [],
+      ],
+      [
+        {
+          op: "replace",
           path: "/purchase_units/@reference_id=='d9f80740-38f0-11e8-b467-0ed5f89f718b'/amount",
           value: {},
         },


### PR DESCRIPTION
### Description

- Update regex sanitization pattern for `patchShipping` mutation to allow changing the shipping name.
- We discovered that `checkoutsellerplatserv` allows patching the shipping name with a low access token; hence, we're modifying the sanitization rules to allow it. 

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
- Update regex sanitization pattern for `patchShipping` mutation to allow changing the shipping name.
- We discovered that `checkoutsellerplatserv` allows patching the shipping name with a low access token; hence, we're modifying the sanitization rules to allow it.

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->
### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
