### PR TITLE
feat: send product flow to approve payment mutation

### DIFF
--- a/src/api/payment.js
+++ b/src/api/payment.js
@@ -5,7 +5,7 @@ import { FPTI_KEY } from '@paypal/sdk-constants/src';
 
 import { PAYMENTS_API_URL } from '../config';
 import { getLogger } from '../lib';
-import { FPTI_TRANSITION, FPTI_CONTEXT_TYPE, HEADERS } from '../constants';
+import { FPTI_TRANSITION, FPTI_CONTEXT_TYPE, HEADERS, PRODUCT_FLOW } from '../constants';
 import type { ApplePayPayment } from '../payment-flows/types';
 
 import { callGraphQL, callRestAPI } from './api';
@@ -140,6 +140,7 @@ export function approveApplePayPayment(orderID : string, clientID : string, appl
                 $clientID : String!
                 $billingContact: ApplePayPaymentContact!
                 $shippingContact: ApplePayPaymentContact
+                $productFlow: String
             ) {
                 approveApplePayPayment(
                     token: $token
@@ -147,10 +148,11 @@ export function approveApplePayPayment(orderID : string, clientID : string, appl
                     clientID: $clientID
                     billingContact: $billingContact
                     shippingContact: $shippingContact
+                    productFlow: $productFlow
                 )
             }
         `,
-        variables: { token, orderID, clientID, billingContact, shippingContact }
+        variables: { token, orderID, clientID, billingContact, shippingContact, productFlow: PRODUCT_FLOW.SMART_PAYMENT_BUTTONS, }
     }).then((gqlResult) => {
         if (!gqlResult || !gqlResult.approveApplePayPayment) {
             throw new Error(`GraphQL GetApplePayPayment returned no applePayment object`);


### PR DESCRIPTION
### Description

NOTE: Previously merged in https://github.com/paypal/paypal-smart-payment-buttons/pull/688, but reverted due to xobuyer dependency.

This adds a new optional param in the Approve Applepay graphql mutation in order to specify that the applepay flow is coming from Smart Payment Buttons rather than the applepay custom component.

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues
ApplePay flow can come from more than one integration. On the SDK we have SPB and Custom Components.
https://paypal.atlassian.net/browse/DTALTPAY-1623

### Reproduction Steps (if applicable)
Integration with applepay enabled will include applepay SPB. Selecting the applepay payment method will start the flow. Buyer approval leads to the approve applepay payment mutation call.
Alternately, specifying components=applepay uses the paypal-applepay-components custom component.

### Screenshots (if applicable)
Screenshot 2023-09-22 at 12 55 44 PM ![image](https://github.com/paypal/paypal-smart-payment-buttons/assets/29203245/9ace67c9-ae0d-4e50-9e78-a4476dd7c584)

### Dependent Changes (if applicable)
Changes to xobuyer mutation are for the optional variable are live as of 10/20!

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->
### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
