### PR TITLE
Fix custom padding overflow issue with payment card icon

### DIFF
--- a/src/card/constants.js
+++ b/src/card/constants.js
@@ -186,11 +186,12 @@ export const DEFAULT_STYLE = {
         'height':         '24px',
         'pointer-events': 'none',
         'position':       'absolute',
-        'top':            '1.6875rem', // calc(0.375rem + 0.0625rem + 1.25rem)
+        'top':            '50%',
+        'transform':      'translateY(-50%)',
         'left':           '1.1875rem' // calc(0.375rem + 0.0625rem + 0.75rem)
     },
     'input.card-field-number.display-icon': {
-        'padding-left': 'calc(1.2rem + 40px)' // calc(0.75rem + 40px + 0.375rem)' 
+        'padding-left': 'calc(1.2rem + 40px) !important' // calc(0.75rem + 40px + 0.375rem)' 
     },
     'input.card-field-number.display-icon + .card-icon': {
         'display': 'block'


### PR DESCRIPTION
### Description

.card-icon class was modified to support custom padding in style prop for paypal.CardFields. Previously we had a hard-coded amount of space from the top, so when users passed custom padding that amount would still be fixed and would cause an overflow of the icon. The proposed solution is to make the icon be centered regardless of padding or line-height etc.. An _!important_ was also added to the .card-field-number.display-icon class in order for it to take precedence over custom padding so that the card number always remains to the right of the card icon.

<!-- Ensure you have a PR description that answers: What? Why? How? -->
<!-- Example PR Description: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/ -->

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

Issue was brought up by a merchant that observed that the payment card icon would overflow whenever a custom padding was passed into paypal.CardFields({style:{}}).

### Reproduction Steps (if applicable)

### Screenshots (if applicable)

### Dependent Changes (if applicable)

<!-- If this PR depends on changes to other applications, document those dependencies (ex: paypal-checkout-components). -->
<!-- Are there any additional considerations when deploying this change to production? -->
### Groups who should review (if applicable)
<!-- For cross-team internal contributors, please tag a group or individual from your team who should review this PR -->

❤️  Thank you!
