### PR TITLE
Remove btSdkOrdersV2Migration experiment

### DIFF
--- a/src/props/onApprove.js
+++ b/src/props/onApprove.js
@@ -691,10 +691,7 @@ export function getOnApproveOrder({
               supplementalData.checkoutSession &&
               supplementalData.checkoutSession.cart &&
               supplementalData.checkoutSession.cart.paymentId);
-          if (
-            !paymentID &&
-            !billingToken
-          ) {
+          if (!paymentID && !billingToken) {
             // The Braintree SDK prefixes the orderID with "EC-" to support
             // backwards compatibility. Before invoking onApprove, we need
             // to remove that prefix.

--- a/src/props/onApprove.js
+++ b/src/props/onApprove.js
@@ -692,7 +692,6 @@ export function getOnApproveOrder({
               supplementalData.checkoutSession.cart &&
               supplementalData.checkoutSession.cart.paymentId);
           if (
-            experiments.btSdkOrdersV2Migration &&
             !paymentID &&
             !billingToken
           ) {

--- a/src/props/onApprove.test.js
+++ b/src/props/onApprove.test.js
@@ -96,26 +96,10 @@ describe("onApprove", () => {
       ...commonOptions,
       beforeOnApprove: vi.fn(),
     };
-    test("invokes the merchant's onApprove call with an undefined paymentID", async () => {
-      const getOnApproveOrderResult = getOnApproveOrder(
-        getOnApproveOrderOptions,
-      );
-      await getOnApproveOrderResult({}, { restart });
-      expect(merchantOnApprove).toHaveBeenCalledWith(
-        expect.objectContaining({
-          orderID,
-          paymentID: undefined,
-        }),
-        expect.anything(),
-      );
-    });
 
     test("invokes the merchant's onApprove call with an undefined paymentID when billingToken is present", async () => {
       const getOnApproveOrderResult = getOnApproveOrder({
         ...getOnApproveOrderOptions,
-        experiments: {
-          btSdkOrdersV2Migration: true,
-        },
       });
       await getOnApproveOrderResult(
         {
@@ -135,9 +119,6 @@ describe("onApprove", () => {
     test("invokes the merchant's onApprove call with a paymentID aliased to orderID", async () => {
       const getOnApproveOrderResult = getOnApproveOrder({
         ...getOnApproveOrderOptions,
-        experiments: {
-          btSdkOrdersV2Migration: true,
-        },
       });
       await getOnApproveOrderResult({}, { restart });
       expect(merchantOnApprove).toHaveBeenCalledWith(

--- a/src/props/onShippingChange.js
+++ b/src/props/onShippingChange.js
@@ -340,7 +340,7 @@ export function getOnShippingChange(
           })
           .flush();
 
-        if (experiments.btSdkOrdersV2Migration && !data.paymentID) {
+        if (!data.paymentID) {
           // The Braintree SDK prefixes the orderID with "EC-" to support
           // backwards compatibility. Before invoking onShippingChange,
           // we need to remove that prefix.

--- a/src/props/onShippingChange.test.js
+++ b/src/props/onShippingChange.test.js
@@ -57,9 +57,7 @@ describe("onShippingChange", () => {
         // $FlowFixMe
         {
           clientID,
-          experiments: {
-            btSdkOrdersV2Migration: true,
-          },
+          experiments: {},
           featureFlags,
           onShippingChange: merchantOnShippingChange,
           partnerAttributionID,

--- a/src/types.js
+++ b/src/types.js
@@ -37,7 +37,6 @@ export type Experiments = $Shape<{|
   useShippingChangeCallbackMutation?: boolean,
   payPalWalletVaultWithoutPurchase?: boolean,
   popupIncreaseDimensions?: boolean,
-  btSdkOrdersV2Migration?: boolean,
   disableSmartAPI?: boolean,
   deprecateVaultValidatePaymentMethod?: boolean,
   upgradeLSATWithIgnoreCache?: boolean,


### PR DESCRIPTION
### Description

Remove unused elmo experiment btSdkOrdersV2Migration

### Why are we making these changes? Include references to any related Jira tasks or GitHub Issues

[DTPPCPSDK-1271](https://paypal.atlassian.net/browse/DTPPCPSDK-1271)

### Dependent Changes (if applicable)

Experiment will also need to be removed from [smartcomponentnodeweb](https://github.paypal.com/Checkout-R/smartcomponentnodeweb)

❤️ Thank you!
